### PR TITLE
unicode fails the build

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -32,7 +32,7 @@ jobs:
   mvn:
     strategy:
       matrix:
-        os: [ ubuntu-24.04 ]
+        os: [ ubuntu-24.04, macos-12 ]
         java: [ 17, 21 ]
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -35,6 +35,10 @@ jobs:
         os: [ ubuntu-24.04 ]
         java: [ 17, 21 ]
     runs-on: ${{ matrix.os }}
+    env:
+      LC_ALL: C
+      LANG: C
+      LANGUAGE: C
     steps:
       - uses: actions/checkout@v4
       - run: |

--- a/src/it/larger/src/main/java/org/eolang/larger/Book.java
+++ b/src/it/larger/src/main/java/org/eolang/larger/Book.java
@@ -24,17 +24,17 @@
 package org.eolang.larger;
 
 class Book implements Material {
-    private final String title;
-    private byte[] data;
+    private final String мойTitle;
+    private byte[] мойData;
     Book(String t, byte[] d) {
-        this.title = t;
-        this.data = d;
+        мойTitle = t;
+        мойData = d;
     }
     @Override
     public String итог() {
-        return String.format("%s %s", this.title, new String(this.data));
+        return String.format("%s %s", мойTitle, new String(мойData));
     }
     void setData(byte[] d) {
-        this.data = d;
+        мойData = d;
     }
 }

--- a/src/it/larger/src/main/java/org/eolang/larger/Dictionary.java
+++ b/src/it/larger/src/main/java/org/eolang/larger/Dictionary.java
@@ -1,0 +1,37 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.larger;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class Dictionary<K, V> {
+    private final Map<K, V> map = new HashMap<K, V>(0);
+    void put(K k, V v) {
+        map.put(k, v);
+    }
+    V get(K k) {
+        return map.get(k);
+    }
+}

--- a/src/it/larger/src/main/java/org/eolang/larger/𝜑.java
+++ b/src/it/larger/src/main/java/org/eolang/larger/𝜑.java
@@ -1,0 +1,34 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.larger;
+
+class 𝜑 {
+    private final String name;
+    𝜑(String n) {
+        name = n;
+    }
+    public String اسم() {
+        return this.name;
+    }
+}

--- a/src/it/larger/src/test/java/org/eolang/larger/BookTest.java
+++ b/src/it/larger/src/test/java/org/eolang/larger/BookTest.java
@@ -46,7 +46,6 @@ final class BookTest {
         for (Field f : m.getClass().getDeclaredFields()) {
             String n = f.getName();
             Assertions.assertTrue(n.startsWith("мой"), n);
-
         }
     }
 }

--- a/src/it/larger/src/test/java/org/eolang/larger/BookTest.java
+++ b/src/it/larger/src/test/java/org/eolang/larger/BookTest.java
@@ -41,7 +41,7 @@ final class BookTest {
     }
 
     @Test
-    void keepsAttributeNames() throws Exception {
+    void keepsUnicodeAttributeNames() throws Exception {
         Material m = new Book("x", new byte[] {});
         for (Field f : m.getClass().getDeclaredFields()) {
             String n = f.getName();

--- a/src/it/larger/src/test/java/org/eolang/larger/BookTest.java
+++ b/src/it/larger/src/test/java/org/eolang/larger/BookTest.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.larger;
 
+import java.lang.reflect.Field;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -37,5 +38,15 @@ final class BookTest {
         ((Book) m).setData(new byte[]{ (byte) 0x41, (byte) 0x42, (byte) 0x43 });
         String s = m.итог();
         Assertions.assertTrue(s.contains("ABC"), s);
+    }
+
+    @Test
+    void keepsAttributeNames() throws Exception {
+        Material m = new Book("x", new byte[] {});
+        for (Field f : m.getClass().getDeclaredFields()) {
+            String n = f.getName();
+            Assertions.assertTrue(n.startsWith("мой"), n);
+
+        }
     }
 }

--- a/src/it/larger/src/test/java/org/eolang/larger/DictionaryTest.java
+++ b/src/it/larger/src/test/java/org/eolang/larger/DictionaryTest.java
@@ -1,0 +1,37 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.larger;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class DictionaryTest {
+
+    @Test
+    void savesAndRetrieves() throws Exception {
+        Dictionary<String, Long> d = new Dictionary<>();
+        d.put("привет", 42L);
+        Assertions.assertEquals(42L, d.get("привет"));
+    }
+}

--- a/src/it/larger/src/test/java/org/eolang/larger/𝜑Test.java
+++ b/src/it/larger/src/test/java/org/eolang/larger/𝜑Test.java
@@ -1,0 +1,35 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.larger;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class 𝜑Test {
+
+    @Test
+    void printsName() throws Exception {
+        Assertions.assertEquals("Иван", new 𝜑("Иван").اسم());
+    }
+}

--- a/src/main/java/org/eolang/hone/Docker.java
+++ b/src/main/java/org/eolang/hone/Docker.java
@@ -97,7 +97,7 @@ final class Docker {
         try (VerboseProcess proc = new VerboseProcess(bldr, Level.INFO, Level.INFO)) {
             final VerboseProcess.Result ret = proc.waitFor();
             Logger.info(
-                this, "+ %s -> %d in %[ms]s",
+                this, "+ %s -> 0x%04x in %[ms]s",
                 String.join(" ", command), ret.code(),
                 System.currentTimeMillis() - start
             );

--- a/src/main/resources/org/eolang/hone/docker/in-docker-pom.xml
+++ b/src/main/resources/org/eolang/hone/docker/in-docker-pom.xml
@@ -31,7 +31,7 @@ SOFTWARE.
   <name>hone</name>
   <properties>
     <eo.version>0.39.2</eo.version>
-    <jeo.version>0.6.11</jeo.version>
+    <jeo.version>0.6.12</jeo.version>
   </properties>
   <build>
     <pluginManagement>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating versions, enhancing the test suite, and introducing new classes with Unicode attributes in the `org.eolang.larger` package.

### Detailed summary
- Updated `<jeo.version>` from `0.6.11` to `0.6.12` in `in-docker-pom.xml`.
- Modified GitHub Actions workflow to support `macos-12`.
- Changed variable names in `Book.java` to use Unicode.
- Added tests for Unicode attribute names in `BookTest.java`.
- Introduced new classes `𝜑` and `Dictionary` with methods and tests.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->