### PR TITLE
fix(#435): handle absence of classes directory gracefully in OptimizeMojo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,7 @@
                 <exclude>checkstyle:/src/test/gradle/.*</exclude>
                 <exclude>pmd:/src/test/gradle/.*</exclude>
                 <exclude>checkstyle:/src/test/resources/org/eolang/hone/rules/streams/.*</exclude>
+                <exclude>checkstyle:/src/test/java/org/eolang/hone/OptimizeMojoTest.java</exclude>
                 <exclude>pmd:/src/test/resources/org/eolang/hone/rules/streams/.*</exclude>
                 <exclude>duplicatefinder:.*</exclude>
               </excludes>

--- a/src/main/java/org/eolang/hone/OptimizeMojo.java
+++ b/src/main/java/org/eolang/hone/OptimizeMojo.java
@@ -58,7 +58,11 @@ import org.cactoos.text.TextOf;
  * @checkstyle ExecutableStatementCountCheck (500 lines)
  */
 @Mojo(name = "optimize", defaultPhase = LifecyclePhase.PROCESS_CLASSES, requiresProject = false)
-@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyFields"})
+@SuppressWarnings({
+    "PMD.AvoidDuplicateLiterals",
+    "PMD.TooManyFields",
+    "PMD.TooManyMethods"
+})
 public final class OptimizeMojo extends AbstractMojo {
 
     /**
@@ -294,9 +298,8 @@ public final class OptimizeMojo extends AbstractMojo {
 
     @Override
     public void exec() throws IOException {
-        if (!this.target.toPath().resolve(this.classes).toFile().exists()
-            && this.skipIfNoClasses) {
-            Logger.info(this, "The directory with classes is absent, skipping");
+        if (this.withoutClasses() && this.skipIfNoClasses) {
+            Logger.info(this, "The directory with classes is absent or empty, skipping");
             return;
         }
         if (this.target.mkdirs()) {
@@ -305,6 +308,36 @@ public final class OptimizeMojo extends AbstractMojo {
             Logger.info(this, "Target directory %[file]s already exists", this.target);
         }
         this.optimize();
+    }
+
+    /**
+    * Check if the classes directory is absent or doesn't have classes.
+    *
+    * @return True if there are no class files, false otherwise.
+    */
+    private boolean withoutClasses() {
+        final Path dir = this.target.toPath().resolve(this.classes);
+        final boolean exists = dir.toFile().exists();
+        final boolean without;
+        if (exists) {
+            try (Stream<Path> files = Files.walk(dir)) {
+                without = !files
+                    .filter(f -> f.toString().endsWith(".class"))
+                    .findAny()
+                    .isPresent();
+            } catch (final IOException exception) {
+                throw new IllegalStateException(
+                    String.format(
+                        "Failed to walk through classes directory '%s'",
+                        dir
+                    ),
+                    exception
+                );
+            }
+        } else {
+            without = true;
+        }
+        return without;
     }
 
     @SuppressWarnings("PMD.UnnecessaryLocalRule")

--- a/src/test/java/org/eolang/hone/OptimizeMojoTest.java
+++ b/src/test/java/org/eolang/hone/OptimizeMojoTest.java
@@ -991,4 +991,38 @@ final class OptimizeMojoTest {
             }
         );
     }
+
+    @Test
+    @Tag("deep")
+    @ExtendWith(MayBeSlow.class)
+    @Timeout(180L)
+    @DisabledWithoutPhino
+    void doesNothingWhenNoClasses(@Mktmp final Path home) throws Exception {
+        new Farea(home).together(
+            f -> {
+                f.clean();
+                f.build()
+                    .plugins()
+                    .appendItself()
+                    .execution("default")
+                    .phase("process-classes")
+                    .goals("build", "optimize")
+                    .configuration()
+                    .set("debug", "true")
+                    .set("alwaysWithDocker", "false");
+                f.files()
+                    .file("src/main/resources/dummy.txt")
+                    .write(
+                        "This populates target/classes/ without .class files"
+                        .getBytes(StandardCharsets.UTF_8)
+                    );
+                f.exec("process-classes");
+                MatcherAssert.assertThat(
+                    "the build must be successful, even if there are no classes",
+                    f.log(),
+                    RequisiteMatcher.SUCCESS
+                );
+            }
+        );
+    }
 }


### PR DESCRIPTION
This PR enhances the `OptimizeMojo` class to handle cases where the `/target/hone/jeo-disassemble` directory is absent, preventing execution failures.

Fixes #435