### PR TITLE
Fix default grep-in matching class path hex

### DIFF
--- a/src/main/java/org/eolang/hone/OptimizeMojo.java
+++ b/src/main/java/org/eolang/hone/OptimizeMojo.java
@@ -133,7 +133,10 @@ public final class OptimizeMojo extends AbstractMojo {
      * @since 0.10.0
      * @checkstyle MemberNameCheck (6 lines)
      */
-    @Parameter(property = "hone.grep-in", defaultValue = "(66-69-6C-74-65-72|6D-61-70)")
+    @Parameter(
+        property = "hone.grep-in",
+        defaultValue = "<o>(66-69-6C-74-65-72|6D-61-70)</o>"
+    )
     private String grepIn;
 
     /**

--- a/src/test/java/org/eolang/hone/OptimizeMojoTest.java
+++ b/src/test/java/org/eolang/hone/OptimizeMojoTest.java
@@ -143,10 +143,51 @@ final class OptimizeMojoTest {
                     .goals("optimize")
                     .configuration()
                     .set("rules", "streams/*");
-                    // .set("grepIn","(66-69-6C-74-65-72|6D-61-70)");
                 f.exec("test");
                 MatcherAssert.assertThat(
                     "phino should skip optimization if the default grep-in does not match any of the instructions",
+                    f.log().content(),
+                    Matchers.allOf(
+                        Matchers.containsString("No grep-in match for 1/1 X.xmir"),
+                        Matchers.containsString("Finished rewriting 1 file"),
+                        Matchers.containsString("BUILD SUCCESS")
+                    )
+                );
+            }
+        );
+    }
+
+    @Test
+    void skipsOptimizationWhenDefaultGrepInMatchesOnlyClassNamePath(@Mktmp final Path dir)
+    throws Exception {
+        new Farea(dir).together(
+            f -> {
+                f.clean();
+                f.files()
+                    .file("src/main/java/mapped/X.java")
+                    .write(
+                        """
+                        package mapped;
+
+                        class X {
+                            public static void main(String[] a) {
+                              byte[] r = new byte[] {(byte) 0x01, (byte) 0x02};
+                              System.out.println(r);
+                            }
+                        }
+                        """.getBytes(StandardCharsets.UTF_8)
+                    );
+                f.build()
+                    .plugins()
+                    .appendItself()
+                    .execution("default")
+                    .phase("process-classes")
+                    .goals("optimize")
+                    .configuration()
+                    .set("rules", "streams/*");
+                f.exec("test");
+                MatcherAssert.assertThat(
+                    "default grep-in should not match method names inside class/package path hex",
                     f.log().content(),
                     Matchers.allOf(
                         Matchers.containsString("No grep-in match for 1/1 X.xmir"),


### PR DESCRIPTION
## Summary
- narrow the default `grepIn` pattern so it only matches XMIR object payloads
- prevent false positives when class/package path hex contains `map` or `filter`
- add a regression test for the `mapped/X` case from the issue

## What changed
The previous default pattern:

```text
(66-69-6C-74-65-72|6D-61-70)
```

could match unrelated hex fragments in XMIR, including class/package path names such as mapped/X.

This patch changes the default to:

```text
<o>(66-69-6C-74-65-72|6D-61-70)</o>
```

so the default grep-in targets actual XMIR object payloads instead of arbitrary hex anywhere in the file.

## Verification
added a regression test for a class under the mapped package with no map/filter usage
attempted to run the related OptimizeMojoTest cases locally
local execution is blocked on Windows by java.lang.UnsatisfiedLinkError: Unable to load library 'c' from OptimizeMojo.whoami(), so I could not complete end-to-end verification in this environment