### PR TITLE
ci(#461): add GitHub Actions workflow for Maven without Phino

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -23,7 +23,7 @@ jobs:
           set -e
           sudo apt-get update
           sudo apt-get -y install libxml2-utils
-          sudo wget -q -O /usr/bin/phino http://phino.objectionary.com/releases/ubuntu-24.04/phino-latest
+          sudo wget -q -O /usr/bin/phino http://phino.objectionary.com/releases/ubuntu-24.04/phino-0.0.0.43
           sudo chmod +x /usr/bin/phino
           phino --version
       - run: make -C src/test/resources/org/eolang/hone/rules/streams

--- a/.github/workflows/mvn-rultor-image.yml
+++ b/.github/workflows/mvn-rultor-image.yml
@@ -18,7 +18,8 @@ jobs:
       matrix:
         os: [ ubuntu-24.04 ]
     runs-on: ${{ matrix.os }}
-    container: yegor256/java
+    container:
+      image: yegor256/java
     steps:
       - uses: actions/checkout@v6
       - name: Fix Git safe directory
@@ -29,5 +30,4 @@ jobs:
           key: ${{ runner.os }}-yegor-java-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-yegor-java-maven-
-      - run: mvn clean install --errors -Dinvoker.skip --batch-mode
-      - run: mvn clean test -Pgradle
+      - run: mvn clean install -Dinvoker.skip -Pqulice -e -B -Dstyle.color=never

--- a/.github/workflows/mvn-rultor-image.yml
+++ b/.github/workflows/mvn-rultor-image.yml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+name: mvn-on-rultor-image
+'on':
+  push:
+    branches:
+      - master
+    paths-ignore: [ 'README.md' ]
+  pull_request:
+    branches:
+      - master
+    paths-ignore: [ 'README.md' ]
+jobs:
+  mvn:
+    strategy:
+      matrix:
+        os: [ ubuntu-24.04 ]
+    runs-on: ${{ matrix.os }}
+    container: yegor256/java
+    steps:
+      - uses: actions/checkout@v6
+      - name: Fix Git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - uses: actions/cache@v5
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-yegor-java-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-yegor-java-maven-
+      - run: mvn clean install --errors -Dinvoker.skip --batch-mode
+      - run: mvn clean test -Pgradle

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,3 @@ debug/
 .classpath
 .project
 .settings/
-run-docker.sh

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ debug/
 .classpath
 .project
 .settings/
+run-docker.sh

--- a/README.md
+++ b/README.md
@@ -90,6 +90,18 @@ classes.dependsOn hone
 
 See how it works in [this example](src/test/gradle).
 
+## How to Use in Docker
+
+If you ran `hone-maven-plugin` in a Docker container, you might face issues if
+your Docker image doesn't have [phino](https://github.com/objectionary/phino)
+installed. In this case, `hone-maven-plugin`
+will try to run a Docker container inside your Docker container (DinD).
+This might lead to problems with
+[volume mounting](https://github.com/objectionary/hone-maven-plugin/pull/458).
+
+While it's technically possible to implement this (by specifying correct
+volumes on your host machine), we highly recommend **avoiding** such a setup.
+
 ## Benchmark
 
 Here is the result of the latest processing of a large Java class

--- a/src/main/java/org/eolang/hone/OptimizeMojo.java
+++ b/src/main/java/org/eolang/hone/OptimizeMojo.java
@@ -470,6 +470,9 @@ public final class OptimizeMojo extends AbstractMojo {
         command.addAll(Arrays.asList("--env", "HONE_STATISTICS=true"));
         command.add("--user");
         command.add(OptimizeMojo.whoami());
+        command.add("--privileged");
+        command.add("-v");
+        command.add("/var/run/docker.sock:/var/run/docker.sock");
         command.addAll(
             Arrays.asList(
                 "--env",

--- a/src/test/java/org/eolang/hone/OptimizeMojoTest.java
+++ b/src/test/java/org/eolang/hone/OptimizeMojoTest.java
@@ -66,6 +66,8 @@ final class OptimizeMojoTest {
     }
 
     @Test
+    @Tag("deep")
+    @DisabledWithoutDocker
     void doesNotSkipOptimizationDueGrepInOption(@Mktmp final Path dir)
     throws Exception {
         new Farea(dir).together(
@@ -115,6 +117,8 @@ final class OptimizeMojoTest {
     }
 
     @Test
+    @Tag("deep")
+    @DisabledWithoutDocker
     void skipsOptimizationDueGrepInOption(@Mktmp final Path dir)
     throws Exception {
         new Farea(dir).together(
@@ -143,7 +147,6 @@ final class OptimizeMojoTest {
                     .goals("optimize")
                     .configuration()
                     .set("rules", "streams/*");
-                    // .set("grepIn","(66-69-6C-74-65-72|6D-61-70)");
                 f.exec("test");
                 MatcherAssert.assertThat(
                     "phino should skip optimization if the default grep-in does not match any of the instructions",


### PR DESCRIPTION
This PR adds a GitHub Actions workflow `mvn-without-phino` to ensure that `hone-maven-plugin` has a pipeline withotu phino pre-installed.

Related to #461