### PR TITLE
ci(#477): support Java 17 in Maven workflow and downgrade cactoos version

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-24.04 ]
-        java: [ 22 ]
+        java: [ 17, 22 ]
     runs-on: ${{ matrix.os }}
     env:
       LC_ALL: C


### PR DESCRIPTION
This PR updates the Java version matrix in the `mvn.yml` workflow to include `17` and downgrades the `cactoos` dependency version in `pom.xml` to `0.58.0`.

Fixes #477