### PR TITLE
#449: anchor default grep-in at XML tag boundaries

### DIFF
--- a/src/main/java/org/eolang/hone/OptimizeMojo.java
+++ b/src/main/java/org/eolang/hone/OptimizeMojo.java
@@ -68,12 +68,17 @@ public final class OptimizeMojo extends AbstractMojo {
     /**
      * Default value for {@link #grepIn}.
      *
-     * <p>Exposed as a constant so that tests can reference the exact regex
-     * that is applied when the user does not override <tt>hone.grep-in</tt>.</p>
+     * <p>Anchors the hex-byte alternatives between <tt>&gt;</tt> and
+     * <tt>&lt;</tt> (the XML tag boundaries that delimit a single PHI bytes
+     * literal inside a {@code .xmir} file) so that the bytes of
+     * <tt>"map"</tt> or <tt>"filter"</tt> only match when they are the
+     * <em>entire</em> content of an {@code <o>} element — not when they
+     * happen to appear as a prefix or suffix of a longer byte sequence
+     * (e.g. <tt>"mapped/X"</tt> or <tt>"filtered"</tt>). See issue #449.</p>
      *
      * @since 0.19.0
      */
-    static final String DEFAULT_GREP_IN = "(66-69-6C-74-65-72|6D-61-70)";
+    static final String DEFAULT_GREP_IN = ">(66-69-6C-74-65-72|6D-61-70)<";
 
     /**
      * Location of <tt>.class</tt> files to optimize inside

--- a/src/main/java/org/eolang/hone/OptimizeMojo.java
+++ b/src/main/java/org/eolang/hone/OptimizeMojo.java
@@ -66,6 +66,16 @@ import org.cactoos.text.TextOf;
 public final class OptimizeMojo extends AbstractMojo {
 
     /**
+     * Default value for {@link #grepIn}.
+     *
+     * <p>Exposed as a constant so that tests can reference the exact regex
+     * that is applied when the user does not override <tt>hone.grep-in</tt>.</p>
+     *
+     * @since 0.19.0
+     */
+    static final String DEFAULT_GREP_IN = "(66-69-6C-74-65-72|6D-61-70)";
+
+    /**
      * Location of <tt>.class</tt> files to optimize inside
      * the {@code target} directory.
      *
@@ -133,7 +143,7 @@ public final class OptimizeMojo extends AbstractMojo {
      * @since 0.10.0
      * @checkstyle MemberNameCheck (6 lines)
      */
-    @Parameter(property = "hone.grep-in", defaultValue = "(66-69-6C-74-65-72|6D-61-70)")
+    @Parameter(property = "hone.grep-in", defaultValue = OptimizeMojo.DEFAULT_GREP_IN)
     private String grepIn;
 
     /**

--- a/src/test/java/org/eolang/hone/OptimizeMojoTest.java
+++ b/src/test/java/org/eolang/hone/OptimizeMojoTest.java
@@ -1139,4 +1139,48 @@ final class OptimizeMojoTest {
             }
         );
     }
+
+    @Test
+    void matchesStandaloneMapByteSequenceInDefaultGrepIn() {
+        MatcherAssert.assertThat(
+            "default grep-in must match a standalone 'map' byte sequence",
+            Pattern.compile(OptimizeMojo.DEFAULT_GREP_IN).matcher(
+                "<o as=\"α0\">6D-61-70</o>"
+            ).find(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void matchesStandaloneFilterByteSequenceInDefaultGrepIn() {
+        MatcherAssert.assertThat(
+            "default grep-in must match a standalone 'filter' byte sequence",
+            Pattern.compile(OptimizeMojo.DEFAULT_GREP_IN).matcher(
+                "<o as=\"α0\">66-69-6C-74-65-72</o>"
+            ).find(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void ignoresMapBytesEmbeddedInLongerStringInDefaultGrepIn() {
+        MatcherAssert.assertThat(
+            "default grep-in must not match 'map' bytes embedded in 'mapped/X' (see #449)",
+            Pattern.compile(OptimizeMojo.DEFAULT_GREP_IN).matcher(
+                "<o as=\"α0\">6D-61-70-70-65-64-2F-58</o>"
+            ).find(),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void ignoresFilterBytesEmbeddedInLongerStringInDefaultGrepIn() {
+        MatcherAssert.assertThat(
+            "default grep-in must not match 'filter' bytes embedded in 'filtered'",
+            Pattern.compile(OptimizeMojo.DEFAULT_GREP_IN).matcher(
+                "<o as=\"α0\">66-69-6C-74-65-72-65-64</o>"
+            ).find(),
+            Matchers.is(false)
+        );
+    }
 }


### PR DESCRIPTION
Addresses #449.

## Root cause

The default `grep-in` regex was `(66-69-6C-74-65-72|6D-61-70)` — the hex bytes of `"filter"` and `"map"` with no boundary anchors. In XMIR, strings are emitted as byte sequences inside `<o>` elements, e.g.
```xml
<o as="α0">6D-61-70-70-65-64-2F-58</o>  <!-- "mapped/X" -->
```
The unanchored alternation matches `6D-61-70` as a prefix of `"mapped/X"`, so phino happily rewrites classes that never call `Stream.map()` / `Stream.filter()` — which is exactly the scenario @volodya-lombrozo reported.

## Fix

Anchor each alternative between `>` and `<` so a match only fires when the hex bytes are the entire content of an `<o>` element — i.e. a standalone UTF-8 method name in XMIR. A byte block that merely starts or ends with the target bytes now has a trailing/leading `-` that breaks the match.

`DEFAULT_GREP_IN` is now `>(66-69-6C-74-65-72|6D-61-70)<`. The new Javadoc on the constant spells out the reasoning for the next reader.

## Tests

The default is exposed as the package-private constant `OptimizeMojo.DEFAULT_GREP_IN` so that unit tests can assert on it directly (the `@Parameter` annotation is `RetentionPolicy.CLASS` and not visible via reflection at runtime).

Four new unit tests in `OptimizeMojoTest`:
- `matchesStandaloneMapByteSequenceInDefaultGrepIn` — a standalone `<o>6D-61-70</o>` still matches (happy path).
- `matchesStandaloneFilterByteSequenceInDefaultGrepIn` — same for `"filter"` bytes.
- `ignoresMapBytesEmbeddedInLongerStringInDefaultGrepIn` — `<o>6D-61-70-70-65-64-2F-58</o>` (the `"mapped/X"` case from #449) does **not** match. Fails on `master`, passes with the fix.
- `ignoresFilterBytesEmbeddedInLongerStringInDefaultGrepIn` — the symmetric `"filtered"` case.

The first commit adds the tests (with the old regex still in place) so the bug is reproducible on the tip; the second commit flips the constant to the anchored regex and the tests go green.

## Verification

- `mvn test` — 26 tests, all green locally (1 skipped because Docker isn't available in this environment).
- `mvn -Pqulice verify -DskipTests -DskipITs` — clean.