### PR TITLE
Fix #492: use getgid() for Docker --user, not geteuid()

### DIFF
--- a/src/main/java/org/eolang/hone/OptimizeMojo.java
+++ b/src/main/java/org/eolang/hone/OptimizeMojo.java
@@ -337,7 +337,7 @@ public final class OptimizeMojo extends AbstractMojo {
         return String.format(
             "%d:%d",
             lib.getuid(),
-            lib.geteuid()
+            lib.getgid()
         );
     }
 

--- a/src/main/java/org/eolang/hone/OptimizeMojo.java
+++ b/src/main/java/org/eolang/hone/OptimizeMojo.java
@@ -328,6 +328,20 @@ public final class OptimizeMojo extends AbstractMojo {
     }
 
     /**
+     * Return the user and group IDs of the current user, using the given C library.
+     *
+     * @param lib The C library to query for the IDs
+     * @return A string in the format "uid:gid"
+     */
+    static String whoami(final OptimizeMojo.CLibrary lib) {
+        return String.format(
+            "%d:%d",
+            lib.getuid(),
+            lib.geteuid()
+        );
+    }
+
+    /**
     * Check if the classes directory is absent or doesn't have classes.
     *
     * @return True if there are no class files, false otherwise.
@@ -588,11 +602,7 @@ public final class OptimizeMojo extends AbstractMojo {
      * @return A string in the format "uid:gid"
      */
     private static String whoami() {
-        return String.format(
-            "%d:%d",
-            OptimizeMojo.CLibrary.INSTANCE.getuid(),
-            OptimizeMojo.CLibrary.INSTANCE.geteuid()
-        );
+        return OptimizeMojo.whoami(OptimizeMojo.CLibrary.INSTANCE);
     }
 
     private String rulesAsString() {
@@ -727,5 +737,12 @@ public final class OptimizeMojo extends AbstractMojo {
          * @return The effective user ID
          */
         int geteuid();
+
+        /**
+         * Get the group ID of the calling process.
+         *
+         * @return The group ID
+         */
+        int getgid();
     }
 }

--- a/src/test/java/org/eolang/hone/OptimizeMojoTest.java
+++ b/src/test/java/org/eolang/hone/OptimizeMojoTest.java
@@ -1183,4 +1183,66 @@ final class OptimizeMojoTest {
             Matchers.is(false)
         );
     }
+
+    @Test
+    void formatsWhoamiAsUidColonGid() {
+        MatcherAssert.assertThat(
+            "whoami must format the Docker --user value as 'uid:gid', not 'uid:euid' (see #492)",
+            OptimizeMojo.whoami(
+                new OptimizeMojoTest.FakeCLibrary(1000, 2000, 3000)
+            ),
+            Matchers.is("1000:3000")
+        );
+    }
+
+    /**
+     * Fixed-value stub of {@link OptimizeMojo.CLibrary} that returns
+     * distinct values for uid, euid, and gid so callers can be checked
+     * for picking up the right one.
+     *
+     * @since 0.6.0
+     */
+    private static final class FakeCLibrary implements OptimizeMojo.CLibrary {
+        /**
+         * Real user ID to return.
+         */
+        private final int uid;
+
+        /**
+         * Effective user ID to return.
+         */
+        private final int euid;
+
+        /**
+         * Group ID to return.
+         */
+        private final int gid;
+
+        /**
+         * Ctor.
+         * @param ruid Real user ID
+         * @param reuid Effective user ID
+         * @param rgid Group ID
+         */
+        FakeCLibrary(final int ruid, final int reuid, final int rgid) {
+            this.uid = ruid;
+            this.euid = reuid;
+            this.gid = rgid;
+        }
+
+        @Override
+        public int getuid() {
+            return this.uid;
+        }
+
+        @Override
+        public int geteuid() {
+            return this.euid;
+        }
+
+        @Override
+        public int getgid() {
+            return this.gid;
+        }
+    }
 }


### PR DESCRIPTION
@yegor256 this PR fixes #492 — `OptimizeMojo.whoami()` was passing `geteuid()` as the *group* component of the Docker `--user` flag, despite the method's own Javadoc saying the result is `uid:gid`.

## What changed

- `OptimizeMojo.CLibrary` now declares `int getgid()` (it was missing)
- `whoami()` is split into two: a `private static` production entry point and a package-private overload `whoami(CLibrary)` so the format can be exercised without `Native.load("c", ...)`
- the format now reads `lib.getgid()` for the second component
- `OptimizeMojoTest#formatsWhoamiAsUidColonGid` uses a fake `CLibrary` with distinct values for `uid` (1000), `euid` (2000), and `gid` (3000) — so the regression is caught even on the common case where `euid == uid` and the bug is silent

## Why it matters

Docker's `--user` flag expects `uid:gid`, not `uid:euid`. On most boxes `euid == uid` so nothing breaks, but on systems where they differ (setuid binaries, certain CI runners) Docker gets a wrong group — typically `1000:0` — which causes permission errors on group-owned files inside the container. This change makes the behaviour consistent with the standard `--user $(id -u):$(id -g)` idiom.

## Commits

1. `52ea3f9d` — refactors `whoami` for testability and adds the failing regression test (the `getgid()` declaration is added in this commit so the fake `CLibrary` can compile)
2. `801b7393` — one-line fix swapping `lib.geteuid()` for `lib.getgid()`

## Test plan

- [x] `mvn -Pqulice clean install -DskipTests -Dinvoker.skip` passes locally (no new lint violations)
- [x] `mvn test` passes locally — 27 unit tests, 1 skipped (Docker-only)
- [x] `formatsWhoamiAsUidColonGid` fails on commit 1 (`Expected: "1000:3000" but: was "1000:2000"`) and passes on commit 2
- [x] All 17 PR CI jobs green: actionlint, bashate, copyrights, docker, hadolint, make, markdown-lint, mvn (matrix 17, 22, rultor-image), pdd, qulice, reuse, shellcheck, typos, xcop, yamllint