### PR TITLE
Bump qulice-maven-plugin to 0.27.6 and fix new lint violations

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ name: docker
     paths-ignore: [ 'README.md' ]
 jobs:
   docker:
-    timeout-minutes: 15
+    timeout-minutes: 30
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6

--- a/pom.xml
+++ b/pom.xml
@@ -325,7 +325,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.25.1</version>
+            <version>0.27.6</version>
             <configuration>
               <excludes>
                 <exclude>pmd:/src/it/.*</exclude>
@@ -335,6 +335,7 @@
                 <exclude>checkstyle:/src/test/resources/org/eolang/hone/rules/streams/.*</exclude>
                 <exclude>checkstyle:/src/test/java/org/eolang/hone/OptimizeMojoTest.java</exclude>
                 <exclude>pmd:/src/test/resources/org/eolang/hone/rules/streams/.*</exclude>
+                <exclude>errorprone:/src/test/resources/org/eolang/hone/rules/streams/.*</exclude>
                 <exclude>duplicatefinder:.*</exclude>
               </excludes>
             </configuration>

--- a/src/main/java/org/eolang/hone/AbstractMojo.java
+++ b/src/main/java/org/eolang/hone/AbstractMojo.java
@@ -30,7 +30,6 @@ abstract class AbstractMojo extends org.apache.maven.plugin.AbstractMojo {
 
     /**
      * The "target/" directory of Maven project.
-     *
      * @since 0.1.0
      */
     @Parameter(
@@ -52,14 +51,12 @@ abstract class AbstractMojo extends org.apache.maven.plugin.AbstractMojo {
 
     /**
      * Timings tracker for performance measurements.
-     *
      * @since 0.1.0
      */
     protected Timings timings;
 
     /**
      * Docker image to use.
-     *
      * @since 0.1.0
      */
     @Parameter(property = "hone.image", defaultValue = "yegor256/hone:latest")
@@ -67,7 +64,6 @@ abstract class AbstractMojo extends org.apache.maven.plugin.AbstractMojo {
 
     /**
      * Whether to use "sudo" when executing Docker commands.
-     *
      * @since 0.1.0
      */
     @Parameter(property = "hone.sudo", defaultValue = "false")
@@ -88,7 +84,6 @@ abstract class AbstractMojo extends org.apache.maven.plugin.AbstractMojo {
 
     /**
      * Phino version to use.
-     *
      * @since 0.21.0
      * @checkstyle MemberNameCheck (6 lines)
      */
@@ -97,7 +92,6 @@ abstract class AbstractMojo extends org.apache.maven.plugin.AbstractMojo {
 
     /**
      * Skip the execution, if set to TRUE.
-     *
      * @since 0.1.0
      */
     @Parameter(property = "hone.skip", defaultValue = "false")
@@ -105,7 +99,6 @@ abstract class AbstractMojo extends org.apache.maven.plugin.AbstractMojo {
 
     /**
      * Skip the execution, if Docker is not available.
-     *
      * @since 0.22.0
      * @checkstyle MemberNameCheck (6 lines)
      */
@@ -114,7 +107,6 @@ abstract class AbstractMojo extends org.apache.maven.plugin.AbstractMojo {
 
     /**
      * Skip the execution, if it's Windows.
-     *
      * @since 0.23.0
      * @checkstyle MemberNameCheck (6 lines)
      */

--- a/src/main/java/org/eolang/hone/BuildMojo.java
+++ b/src/main/java/org/eolang/hone/BuildMojo.java
@@ -6,7 +6,7 @@ package org.eolang.hone;
 
 import com.jcabi.log.Logger;
 import java.io.IOException;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -40,7 +40,6 @@ public final class BuildMojo extends AbstractMojo {
 
     /**
      * Shall we use buildx?
-     *
      * @since 0.8.0
      * @checkstyle MemberNameCheck (6 lines)
      */
@@ -49,7 +48,6 @@ public final class BuildMojo extends AbstractMojo {
 
     /**
      * JEO version to use.
-     *
      * @since 0.20.0
      * @checkstyle MemberNameCheck (6 lines)
      */
@@ -85,7 +83,7 @@ public final class BuildMojo extends AbstractMojo {
             for (final String file : new String[] {"entry.sh", "rewrite.sh"}) {
                 temp.path().resolve(file).toFile().setExecutable(true);
             }
-            final List<String> args = new LinkedList<>();
+            final List<String> args = new ArrayList<>(0);
             if (this.useBuildx) {
                 args.add("buildx");
             }

--- a/src/main/java/org/eolang/hone/CSV.java
+++ b/src/main/java/org/eolang/hone/CSV.java
@@ -4,8 +4,9 @@
  */
 package org.eolang.hone;
 
-import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -24,7 +25,6 @@ import org.cactoos.list.ListOf;
 
 /**
  * CSV summary .
- *
  * @since 0.1.0
  * @checkstyle AbbreviationAsWordInNameCheck (3 lines)
  */
@@ -42,8 +42,8 @@ public final class CSV {
 
     /**
      * Constructor.
-     *
      * @param root CSV file path
+     * @checkstyle ConstructorsCodeFreeCheck (3 lines)
      */
     CSV(final Path root) {
         this(CSV.from(root));
@@ -51,8 +51,8 @@ public final class CSV {
 
     /**
      * Constructor.
-     *
      * @param records CSV records
+     * @checkstyle ConstructorsCodeFreeCheck (5 lines)
      */
     private CSV(final List<CSVRecord> records) {
         this(
@@ -63,7 +63,6 @@ public final class CSV {
 
     /**
      * Constructor.
-     *
      * @param headers CSV headers
      * @param records CSV records
      */
@@ -77,9 +76,8 @@ public final class CSV {
 
     /**
      * Combines this CSV with another CSV, concatenating their records.
-     *
-     * @param other The other CSV to combine with this one.
-     * @return A new CSV instance containing the combined records of both CSVs.
+     * @param other The other CSV to combine with this one
+     * @return A new CSV instance containing the combined records of both CSVs
      */
     CSV add(final CSV other) {
         final List<Map<String, String>> combined = new ArrayList<>(this.records);
@@ -89,8 +87,7 @@ public final class CSV {
 
     /**
     * Number of records in the CSV.
-    *
-    * @return The number of records in the CSV.
+    * @return The number of records in the CSV
     */
     int size() {
         return this.records.size();
@@ -98,10 +95,9 @@ public final class CSV {
 
     /**
      * Counts rows where a column value matches the given condition.
-     *
-     * @param header The column name to check.
-     * @param condition Predicate applied to the column value.
-     * @return Number of matching rows.
+     * @param header The column name to check
+     * @param condition Predicate applied to the column value
+     * @return Number of matching rows
      */
     int count(final String header, final Predicate<String> condition) {
         return (int) this.records.stream()
@@ -111,10 +107,9 @@ public final class CSV {
 
     /**
      * Recomputes the values of a column using a transformation function.
-     *
-     * @param header The name of the column to recompute.
-     * @param modification Transformation function.
-     * @return A new CSV instance with the recomputed values.
+     * @param header The name of the column to recompute
+     * @param modification Transformation function
+     * @return A new CSV instance with the recomputed values
      */
     CSV recompute(
         final String header,
@@ -122,21 +117,19 @@ public final class CSV {
     ) {
         return new CSV(
             this.headers,
-            this.records.stream()
-                .map(
-                    row -> {
-                        final Map<String, String> data = new HashMap<>(row);
-                        data.put(header, modification.apply(row.get(header)));
-                        return data;
-                    }
-                ).collect(Collectors.toList())
+            this.records.stream().map(
+                row -> {
+                    final Map<String, String> data = new HashMap<>(row);
+                    data.put(header, modification.apply(row.get(header)));
+                    return data;
+                }
+            ).collect(Collectors.toList())
         );
     }
 
     /**
      * Flushes the CSV content to the specified file path.
-     *
-     * @param res The path to the file where the CSV content should be written.
+     * @param res The path to the file where the CSV content should be written
      */
     void flush(final Path res) {
         try (
@@ -164,15 +157,20 @@ public final class CSV {
             .collect(Collectors.toList());
     }
 
-    @SuppressWarnings({"PMD.AvoidFileStream", "PMD.RelianceOnDefaultCharset"})
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     private static List<CSVRecord> from(final Path csv) {
-        try {
+        try (
+            Reader reader = new InputStreamReader(
+                Files.newInputStream(csv),
+                StandardCharsets.UTF_8
+            )
+        ) {
             return new ListOf<>(
                 CSVFormat.DEFAULT.builder()
                     .setHeader()
                     .setSkipHeaderRecord(false)
                     .get()
-                    .parse(new FileReader(csv.toFile()))
+                    .parse(reader)
                     .iterator()
             );
         } catch (final IOException exception) {

--- a/src/main/java/org/eolang/hone/Docker.java
+++ b/src/main/java/org/eolang/hone/Docker.java
@@ -7,9 +7,9 @@ package org.eolang.hone;
 import com.jcabi.log.Logger;
 import com.jcabi.log.VerboseProcess;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.logging.Level;
 
@@ -50,7 +50,7 @@ final class Docker {
      * @return Exit code (always 0 on success)
      * @throws IOException If the command fails or returns non-zero exit code
      */
-    public int exec(final String... args) throws IOException {
+    int exec(final String... args) throws IOException {
         return this.exec(Arrays.asList(args));
     }
 
@@ -58,7 +58,7 @@ final class Docker {
      * Docker executable is available?
      * @return TRUE if Docker is here
      */
-    public boolean available() {
+    boolean available() {
         boolean yes = true;
         try {
             this.exec("--version");
@@ -75,8 +75,8 @@ final class Docker {
      * @return Exit code (always 0 on success)
      * @throws IOException If the command fails or returns non-zero exit code
      */
-    public int exec(final Collection<String> args) throws IOException {
-        final List<String> command = new LinkedList<>();
+    int exec(final Collection<String> args) throws IOException {
+        final List<String> command = new ArrayList<>(args.size() + 2);
         if (this.sudo) {
             command.add("sudo");
         }
@@ -95,9 +95,13 @@ final class Docker {
     private int fire(final List<String> command) throws IOException {
         final long start = System.currentTimeMillis();
         Logger.info(this, "+ %s ...", String.join(" ", command));
-        try (VerboseProcess proc = new VerboseProcess(
-            new ProcessBuilder(command), Level.INFO, Level.INFO
-        )) {
+        try (
+            VerboseProcess proc = new VerboseProcess(
+                new ProcessBuilder(command),
+                Level.INFO,
+                Level.INFO
+            )
+        ) {
             final VerboseProcess.Result ret = proc.waitFor();
             Logger.info(
                 this, "+ %s -> 0x%04x in %[ms]s",
@@ -115,5 +119,4 @@ final class Docker {
         }
         return 0;
     }
-
 }

--- a/src/main/java/org/eolang/hone/Mktemp.java
+++ b/src/main/java/org/eolang/hone/Mktemp.java
@@ -31,17 +31,10 @@ final class Mktemp implements Closeable {
     /**
      * Creates a new temporary directory.
      * @throws IOException If directory creation fails
+     * @checkstyle ConstructorsCodeFreeCheck (3 lines)
      */
     Mktemp() throws IOException {
         this.dir = Files.createTempDirectory("tmp");
-    }
-
-    /**
-     * Get the path to the temporary directory.
-     * @return Path of the temporary directory
-     */
-    public Path path() {
-        return this.dir;
     }
 
     @Override
@@ -52,5 +45,13 @@ final class Mktemp implements Closeable {
                 .sorted(Comparator.reverseOrder())
                 .forEach(File::delete);
         }
+    }
+
+    /**
+     * Get the path to the temporary directory.
+     * @return Path of the temporary directory
+     */
+    Path path() {
+        return this.dir;
     }
 }

--- a/src/main/java/org/eolang/hone/OptimizeMojo.java
+++ b/src/main/java/org/eolang/hone/OptimizeMojo.java
@@ -13,10 +13,11 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -81,9 +82,13 @@ public final class OptimizeMojo extends AbstractMojo {
     static final String DEFAULT_GREP_IN = ">(66-69-6C-74-65-72|6D-61-70)<";
 
     /**
+     * Splitter for comma-separated values (with optional whitespace).
+     */
+    private static final Pattern COMMA = Pattern.compile("\\s*,\\s*");
+
+    /**
      * Location of <tt>.class</tt> files to optimize inside
      * the {@code target} directory.
-     *
      * @since 0.8.0
      * @checkstyle MemberNameCheck (6 lines)
      */
@@ -114,7 +119,6 @@ public final class OptimizeMojo extends AbstractMojo {
     /**
      * List of extra rules to use for optimization, provided as
      * YAML files.
-     *
      * @since 0.1.0
      * @checkstyle MemberNameCheck (6 lines)
      */
@@ -123,7 +127,6 @@ public final class OptimizeMojo extends AbstractMojo {
 
     /**
      * EO version to use.
-     *
      * @since 0.1.0
      * @checkstyle MemberNameCheck (6 lines)
      */
@@ -165,7 +168,6 @@ public final class OptimizeMojo extends AbstractMojo {
 
     /**
      * Skip if no .class files found.
-     *
      * @since 0.16.0
      * @checkstyle MemberNameCheck (6 lines)
      */
@@ -256,7 +258,6 @@ public final class OptimizeMojo extends AbstractMojo {
 
     /**
      * The list of all file extensions for the extra rules.
-     *
      * @since 0.5.0
      * @checkstyle MemberNameCheck (6 lines)
      */
@@ -293,7 +294,6 @@ public final class OptimizeMojo extends AbstractMojo {
 
     /**
      * JEO version to use.
-     *
      * @since 0.1.0
      * @checkstyle MemberNameCheck (6 lines)
      */
@@ -302,7 +302,6 @@ public final class OptimizeMojo extends AbstractMojo {
 
     /**
      * EO cache directory.
-     *
      * @since 0.1.0
      * @checkstyle MemberNameCheck (7 lines)
      * @checkstyle VisibilityModifierCheck (10 lines)
@@ -329,7 +328,6 @@ public final class OptimizeMojo extends AbstractMojo {
 
     /**
      * Return the user and group IDs of the current user, using the given C library.
-     *
      * @param lib The C library to query for the IDs
      * @return A string in the format "uid:gid"
      */
@@ -343,8 +341,7 @@ public final class OptimizeMojo extends AbstractMojo {
 
     /**
     * Check if the classes directory is absent or doesn't have classes.
-    *
-    * @return True if there are no class files, false otherwise.
+    * @return True if there are no class files, false otherwise
     */
     private boolean withoutClasses() {
         final Path dir = this.target.toPath().resolve(this.classes);
@@ -400,7 +397,7 @@ public final class OptimizeMojo extends AbstractMojo {
     private void withDocker() throws IOException {
         final String tdir = "/target";
         final String cdir = "/eo-cache";
-        final Collection<String> command = new LinkedList<>(
+        final Collection<String> command = new ArrayList<>(
             Arrays.asList(
                 "run",
                 "--rm",
@@ -534,9 +531,13 @@ public final class OptimizeMojo extends AbstractMojo {
     }
 
     private void saveExtra(final Path src, final Path target) throws IOException {
+        final long count;
+        try (Stream<Path> stream = Files.list(target)) {
+            count = stream.count();
+        }
         final String name = String.format(
             "%04d-%s.yml",
-            Files.list(target).collect(Collectors.toList()).size(),
+            count,
             src.getFileName().toString().replaceAll("\\.[a-zA-Z0-9]+$", "")
         );
         final Path copy = target.resolve(name);
@@ -556,7 +557,6 @@ public final class OptimizeMojo extends AbstractMojo {
         );
     }
 
-    @SuppressWarnings("PMD.CognitiveComplexity")
     private void copyExtras(final Path extdir) throws IOException {
         if (this.extra != null) {
             if (extdir.toFile().mkdirs()) {
@@ -570,21 +570,15 @@ public final class OptimizeMojo extends AbstractMojo {
                         "Scanning %[file]s for extra rules (%s)...",
                         src, this.extraExtensions
                     );
+                    final String[] exts = OptimizeMojo.COMMA.split(this.extraExtensions);
                     try (Stream<Path> files = Files.list(src)) {
-                        final List<Path> yamls = files
-                            .filter(
-                                f -> {
-                                    boolean match = false;
-                                    for (final String extn : this.extraExtensions.split(",")) {
-                                        match = match || f.getFileName().toString().endsWith(
-                                            String.format(".%s", extn.trim())
-                                        );
-                                    }
-                                    return match;
-                                }
+                        final List<Path> yamls = files.filter(
+                            f -> Arrays.stream(exts).anyMatch(
+                                extn -> f.getFileName().toString().endsWith(
+                                    String.format(".%s", extn.trim())
+                                )
                             )
-                            .sorted()
-                            .collect(Collectors.toList());
+                        ).sorted().collect(Collectors.toList());
                         for (final Path yaml : yamls) {
                             this.saveExtra(yaml, extdir);
                         }
@@ -598,7 +592,6 @@ public final class OptimizeMojo extends AbstractMojo {
 
     /**
      * Return the user and group IDs of the current user.
-     *
      * @return A string in the format "uid:gid"
      */
     private static String whoami() {
@@ -717,6 +710,7 @@ public final class OptimizeMojo extends AbstractMojo {
      * @since 0.6.0
      */
     public interface CLibrary extends Library {
+
         /**
          * Instance of the C library.
          *
@@ -726,21 +720,18 @@ public final class OptimizeMojo extends AbstractMojo {
 
         /**
          * Get the user ID of the calling process.
-         *
          * @return The user ID
          */
         int getuid();
 
         /**
          * Get the effective user ID of the calling process.
-         *
          * @return The effective user ID
          */
         int geteuid();
 
         /**
          * Get the group ID of the calling process.
-         *
          * @return The group ID
          */
         int getgid();

--- a/src/main/java/org/eolang/hone/Phino.java
+++ b/src/main/java/org/eolang/hone/Phino.java
@@ -11,7 +11,6 @@ import java.io.IOException;
 
 /**
  * An abstraction of Phino in command line.
- *
  * @since 0.17.0
  */
 final class Phino {
@@ -21,7 +20,7 @@ final class Phino {
      * @param expected This is the expected version
      * @return TRUE if available
      */
-    public boolean available(final String expected) {
+    boolean available(final String expected) {
         boolean available = false;
         try {
             final Result result = new Jaxec("phino", "--version").withCheck(false).execUnsafe();
@@ -31,10 +30,8 @@ final class Phino {
                     available = true;
                     Logger.info(
                         this,
-                        String.format(
-                            "The 'phino' executable found (%s), no need to use Docker",
-                            version
-                        )
+                        "The 'phino' executable found (%s), no need to use Docker",
+                        version
                     );
                 } else {
                     Logger.info(
@@ -52,13 +49,10 @@ final class Phino {
         } catch (final IOException ex) {
             Logger.info(
                 this,
-                String.format(
-                    "The 'phino' executable not found, we must use Docker: %s",
-                    ex.getMessage()
-                )
+                "The 'phino' executable not found, we must use Docker: %s",
+                ex.getMessage()
             );
         }
         return available;
     }
-
 }

--- a/src/main/java/org/eolang/hone/Rules.java
+++ b/src/main/java/org/eolang/hone/Rules.java
@@ -10,10 +10,10 @@ import io.github.classgraph.Resource;
 import io.github.classgraph.ScanResult;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -41,6 +41,11 @@ final class Rules {
     private static final String RULES_PATH = "org/eolang/hone/rules";
 
     /**
+     * Splitter for pattern strings.
+     */
+    private static final Pattern SEPARATOR = Pattern.compile("\\s*,\\s*");
+
+    /**
      * Compiled regex patterns for rule matching with inclusion/exclusion flags.
      */
     private final Map<Pattern, Boolean> patterns;
@@ -55,6 +60,7 @@ final class Rules {
     /**
      * Creates a rule manager with specific patterns.
      * @param ptns Comma-separated patterns (e.g., "simple,b*,!abc")
+     * @checkstyle ConstructorsCodeFreeCheck (3 lines)
      */
     Rules(final String ptns) {
         this.patterns = Rules.regexs(ptns);
@@ -77,8 +83,8 @@ final class Rules {
      * this method will return "none.yml 33-to-42.yml".</p>
      * @return Iterable of YAML file names for matching rules
      */
-    public Iterable<String> yamls() {
-        final Collection<String> files = new LinkedList<>();
+    Iterable<String> yamls() {
+        final Collection<String> files = new ArrayList<>(0);
         for (final String name : Rules.discover()) {
             if (!this.matches(name)) {
                 Logger.debug(this, "Rule %s doesn't match", name);
@@ -96,7 +102,7 @@ final class Rules {
      * @param dir Destination directory where rule files will be copied
      * @throws IOException If copying files fails
      */
-    public void copyTo(final Path dir) throws IOException {
+    void copyTo(final Path dir) throws IOException {
         if (dir.toFile().mkdirs()) {
             Logger.info(this, "Directory created at %[file]s", dir);
         }
@@ -145,26 +151,26 @@ final class Rules {
      */
     private static Map<Pattern, Boolean> regexs(final String ptns) {
         final Map<Pattern, Boolean> list = new HashMap<>(0);
-        for (final String ptn : ptns.split("\\s*,\\s*")) {
-            if (ptn.isEmpty()) {
-                continue;
+        Rules.SEPARATOR.splitAsStream(ptns).filter(ptn -> !ptn.isEmpty()).forEach(
+            ptn -> {
+                final boolean negative = ptn.charAt(0) == '!';
+                final String body;
+                if (negative) {
+                    body = ptn.substring(1);
+                } else {
+                    body = ptn;
+                }
+                list.put(
+                    Pattern.compile(
+                        String.format(
+                            "^\\Q%s\\E\\.(yml|phr)$",
+                            body.replace("*", "\\E.*\\Q")
+                        ).replace("\\Q\\E", "")
+                    ),
+                    !negative
+                );
             }
-            boolean negative = false;
-            String body = ptn;
-            if (ptn.charAt(0) == '!') {
-                negative = true;
-                body = body.substring(1);
-            }
-            list.put(
-                Pattern.compile(
-                    String.format(
-                        "^\\Q%s\\E\\.(yml|phr)$",
-                        body.replace("*", "\\E.*\\Q")
-                    ).replace("\\Q\\E", "")
-                ),
-                !negative
-            );
-        }
+        );
         return list;
     }
 
@@ -173,10 +179,12 @@ final class Rules {
      * @return Array of rule names discovered from classpath resources
      */
     private static String[] discover() {
-        final List<String> names = new LinkedList<>();
-        try (ScanResult scan = new ClassGraph()
-            .acceptPaths(Rules.RULES_PATH)
-            .scan()) {
+        final List<String> names = new ArrayList<>(0);
+        try (
+            ScanResult scan = new ClassGraph()
+                .acceptPaths(Rules.RULES_PATH)
+                .scan()
+        ) {
             for (final Resource resource : scan.getAllResources()) {
                 final String path = resource.getPath();
                 if (!path.endsWith(".phr") && !path.endsWith(".yml")) {

--- a/src/main/java/org/eolang/hone/Summary.java
+++ b/src/main/java/org/eolang/hone/Summary.java
@@ -14,7 +14,6 @@ import java.util.stream.Stream;
 
 /**
  * Build summary statistics.
- *
  * @since 0.1.0
  */
 public final class Summary {
@@ -31,8 +30,7 @@ public final class Summary {
 
     /**
      * Constructor.
-     *
-     * @param root Root directory to search for statistics.
+     * @param root Root directory to search for statistics
      */
     Summary(final Path root) {
         this(root, root);
@@ -40,9 +38,8 @@ public final class Summary {
 
     /**
      * Constructor.
-     *
-     * @param root Root directory to search for statistics.
-     * @param target Directory to save the summary report.
+     * @param root Root directory to search for statistics
+     * @param target Directory to save the summary report
      */
     Summary(final Path root, final Path target) {
         this.root = root;
@@ -51,20 +48,14 @@ public final class Summary {
 
     /**
      * Collects summary statistics from all child modules.
-     *
-     * @return The path to the generated summary report.
+     * @return The path to the generated summary report
      */
-    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     Path collect() {
         final List<CSV> found = new ArrayList<>(0);
         final String stats = "hone-statistics.csv";
         try (Stream<Path> paths = Files.walk(this.root)) {
             paths.filter(Files::isRegularFile)
-                .filter(
-                    path -> path.getFileName()
-                        .toString()
-                        .equals(stats)
-                )
+                .filter(path -> stats.equals(path.getFileName().toString()))
                 .map(CSV::new)
                 .forEach(found::add);
         } catch (final IOException exception) {
@@ -80,17 +71,17 @@ public final class Summary {
         return destination;
     }
 
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     private static CSV reduce(final List<CSV> csvs) {
-        final AtomicInteger index = new AtomicInteger(1);
         final CSV res = csvs.stream().reduce(CSV::add).orElseThrow(
             () -> new IllegalStateException(
                 "Failed to reduce summary statistics: no CSV files found."
             )
         );
-        final int size = res.size();
+        final AtomicInteger index = new AtomicInteger(1);
         return res.recompute(
             "ID",
-            ignore -> String.format("%d/%d", index.getAndIncrement(), size)
+            ignore -> String.format("%d/%d", index.getAndIncrement(), res.size())
         );
     }
 }

--- a/src/main/java/org/eolang/hone/Timings.java
+++ b/src/main/java/org/eolang/hone/Timings.java
@@ -44,7 +44,7 @@ final class Timings {
      * @throws IOException If recording the timing fails
      */
     @SuppressWarnings("PMD.UnnecessaryLocalRule")
-    public void through(final String name, final Timings.Action action) throws IOException {
+    void through(final String name, final Timings.Action action) throws IOException {
         final long start = System.currentTimeMillis();
         try {
             action.exec();
@@ -56,7 +56,7 @@ final class Timings {
             Files.write(
                 this.path,
                 String.format(
-                    "%s,%d\n", name, System.currentTimeMillis() - start
+                    "%s,%d%n", name, System.currentTimeMillis() - start
                 ).getBytes(StandardCharsets.UTF_8),
                 StandardOpenOption.APPEND, StandardOpenOption.CREATE
             );
@@ -65,16 +65,15 @@ final class Timings {
 
     /**
      * Functional interface for actions that can be timed.
-     *
      * @since 0.1.0
      */
     @FunctionalInterface
-    public interface Action {
+    interface Action {
+
         /**
          * Execute the action.
          * @throws IOException If execution fails
          */
         void exec() throws IOException;
     }
-
 }

--- a/src/main/java/org/eolang/hone/package-info.java
+++ b/src/main/java/org/eolang/hone/package-info.java
@@ -4,7 +4,6 @@
  */
 /**
  * The main classes of the hone-maven-plugin.
- *
  * @since 0.1.0
  */
 package org.eolang.hone;

--- a/src/test/java/org/eolang/hone/AbstractMojoTest.java
+++ b/src/test/java/org/eolang/hone/AbstractMojoTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link AbstractMojo}.
- *
  * @since 0.1.0
  */
 final class AbstractMojoTest {
@@ -20,14 +19,14 @@ final class AbstractMojoTest {
     void returnsDefaultPhinoVersion() throws IOException {
         MatcherAssert.assertThat(
             "the default phino version must be returned from resource file",
-            new FakeAbstractMojo().phino(),
+            new AbstractMojoTest.FakeAbstractMojo().phino(),
             Matchers.matchesPattern("\\d+\\.\\d+\\.\\d+\\.\\d+")
         );
     }
 
     @Test
     void returnsSamePhinoVersionOnMultipleCalls() throws IOException {
-        final FakeAbstractMojo mojo = new FakeAbstractMojo();
+        final AbstractMojoTest.FakeAbstractMojo mojo = new AbstractMojoTest.FakeAbstractMojo();
         MatcherAssert.assertThat(
             "the phino version must be consistent across multiple calls",
             mojo.phino(),
@@ -37,7 +36,6 @@ final class AbstractMojoTest {
 
     /**
      * Fake implementation of AbstractMojo for testing.
-     *
      * @since 0.1.0
      */
     private static final class FakeAbstractMojo extends AbstractMojo {

--- a/src/test/java/org/eolang/hone/BuildMojoTest.java
+++ b/src/test/java/org/eolang/hone/BuildMojoTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 
 /**
  * Test case for {@link BuildMojo}.
- *
  * @since 0.1.0
  */
 @Execution(ExecutionMode.SAME_THREAD)
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 final class BuildMojoTest {
 
     @Test
-    @SuppressWarnings("PMD.UnitTestShouldIncludeAssert")
     void skipsOptimizationOnFlag(@Mktmp final Path dir) throws Exception {
         new Farea(dir).together(
             f -> {
@@ -58,7 +56,6 @@ final class BuildMojoTest {
     @Tag("deep")
     @ExtendWith(MayBeSlow.class)
     @DisabledWithoutDocker
-    @SuppressWarnings("PMD.UnitTestShouldIncludeAssert")
     void buildsDockerImage(@Mktmp final Path dir,
         @RandomImage final String image) throws Exception {
         new Farea(dir).together(

--- a/src/test/java/org/eolang/hone/CSVTest.java
+++ b/src/test/java/org/eolang/hone/CSVTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for {@link CSV}.
- *
  * @since 0.1.0
  * @checkstyle AbbreviationAsWordInNameCheck (3 lines)
  */
@@ -28,7 +27,14 @@ final class CSVTest {
         final Path path = temp.resolve("test.csv");
         Files.write(
             path,
-            "ID,Before,After,Changed,LinesPerSec\n1/3,a.phi,b.phi,5,1000\n2/3,c.phi,d.phi,0,0\n3/3,e.phi,f.phi,3,800\n".getBytes(StandardCharsets.UTF_8)
+            String.join(
+                System.lineSeparator(),
+                "ID,Before,After,Changed,LinesPerSec",
+                "1/3,a.phi,b.phi,5,1000",
+                "2/3,c.phi,d.phi,0,0",
+                "3/3,e.phi,f.phi,3,800",
+                ""
+            ).getBytes(StandardCharsets.UTF_8)
         );
         MatcherAssert.assertThat(
             "two files have Changed > 0",
@@ -42,7 +48,13 @@ final class CSVTest {
         final Path path = temp.resolve("test.csv");
         Files.write(
             path,
-            "ID,Before,After,Changed,LinesPerSec\n1/2,a.phi,b.phi,0,0\n2/2,c.phi,d.phi,0,0\n".getBytes(StandardCharsets.UTF_8)
+            String.join(
+                System.lineSeparator(),
+                "ID,Before,After,Changed,LinesPerSec",
+                "1/2,a.phi,b.phi,0,0",
+                "2/2,c.phi,d.phi,0,0",
+                ""
+            ).getBytes(StandardCharsets.UTF_8)
         );
         MatcherAssert.assertThat(
             "no files have Changed > 0",

--- a/src/test/java/org/eolang/hone/DisabledWithoutDocker.java
+++ b/src/test/java/org/eolang/hone/DisabledWithoutDocker.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 /**
  * This annotation disables JUnit tests when Docker is
  * not runnable in command line.
- *
  * @since 0.1.0
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })

--- a/src/test/java/org/eolang/hone/DisabledWithoutDockerCondition.java
+++ b/src/test/java/org/eolang/hone/DisabledWithoutDockerCondition.java
@@ -12,10 +12,10 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 /**
  * This annotation disables JUnit tests when Docker is
  * not runnable in command line.
- *
  * @since 0.1.0
  */
 public final class DisabledWithoutDockerCondition implements ExecutionCondition {
+
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(final ExtensionContext ctx) {
         ConditionEvaluationResult result;

--- a/src/test/java/org/eolang/hone/DisabledWithoutPhino.java
+++ b/src/test/java/org/eolang/hone/DisabledWithoutPhino.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 /**
  * This annotation disables JUnit tests when phino is
  * not runnable in command line.
- *
  * @since 0.1.0
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })

--- a/src/test/java/org/eolang/hone/DisabledWithoutPhinoCondition.java
+++ b/src/test/java/org/eolang/hone/DisabledWithoutPhinoCondition.java
@@ -11,10 +11,10 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 /**
  * This annotation disables JUnit tests when phino is
  * not runnable in command line.
- *
  * @since 0.1.0
  */
 public final class DisabledWithoutPhinoCondition implements ExecutionCondition {
+
     @Override
     @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
     public ConditionEvaluationResult evaluateExecutionCondition(final ExtensionContext ctx) {

--- a/src/test/java/org/eolang/hone/DockerTest.java
+++ b/src/test/java/org/eolang/hone/DockerTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for {@link Docker}.
- *
  * @since 0.1.0
  */
 @ExtendWith(RandomImageResolver.class)

--- a/src/test/java/org/eolang/hone/MktempTest.java
+++ b/src/test/java/org/eolang/hone/MktempTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Mktemp}.
- *
  * @since 0.1.0
  */
 final class MktempTest {

--- a/src/test/java/org/eolang/hone/OptimizeMojoTest.java
+++ b/src/test/java/org/eolang/hone/OptimizeMojoTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 
 /**
  * Test case for {@link OptimizeMojo}.
- *
  * @since 0.1.0
  * @todo #440:90min enable 'grep-in' tests.
  *  The following tests are disabled because they fail on Rultor:
@@ -46,8 +45,7 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 @ExtendWith(MktmpResolver.class)
 @SuppressWarnings({
     "PMD.AvoidDuplicateLiterals",
-    "PMD.TooManyMethods",
-    "PMD.UnitTestShouldIncludeAssert"
+    "PMD.TooManyMethods"
 })
 final class OptimizeMojoTest {
 
@@ -637,7 +635,6 @@ final class OptimizeMojoTest {
     @Tag("deep")
     @DisabledWithoutDocker
     @ExtendWith(MayBeSlow.class)
-    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void optimizesJustOneLargeJnaClass(@Mktmp final Path dir,
         @RandomImage final String image) throws Exception {
         final String path = "com/sun/jna/Pointer.class";
@@ -1199,7 +1196,6 @@ final class OptimizeMojoTest {
      * Fixed-value stub of {@link OptimizeMojo.CLibrary} that returns
      * distinct values for uid, euid, and gid so callers can be checked
      * for picking up the right one.
-     *
      * @since 0.6.0
      */
     private static final class FakeCLibrary implements OptimizeMojo.CLibrary {

--- a/src/test/java/org/eolang/hone/PullMojoTest.java
+++ b/src/test/java/org/eolang/hone/PullMojoTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for {@link PullMojo}.
- *
  * @since 0.1.0
  */
 @ExtendWith(MktmpResolver.class)
@@ -27,7 +26,6 @@ final class PullMojoTest {
     @Tag("deep")
     @DisabledWithoutDocker
     @ExtendWith(MayBeSlow.class)
-    @SuppressWarnings("PMD.UnitTestShouldIncludeAssert")
     void pullsDockerImage(@Mktmp final Path dir) throws Exception {
         new Farea(dir).together(
             f -> {

--- a/src/test/java/org/eolang/hone/RandomImage.java
+++ b/src/test/java/org/eolang/hone/RandomImage.java
@@ -13,7 +13,6 @@ import java.lang.annotation.Target;
  * This annotation is used in unit tests in order to signal
  * to JUnit that a certain method argument must be generated
  * through the {@link RandomImageResolver}.
- *
  * @since 0.1.0
  */
 @Target(ElementType.PARAMETER)

--- a/src/test/java/org/eolang/hone/RandomImageResolver.java
+++ b/src/test/java/org/eolang/hone/RandomImageResolver.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.extension.ParameterResolver;
  * This class is instantiated and then called by JUnit when
  * an argument of a test method is marked with the {@link RandomImage}
  * annotation.
- *
  * @since 0.1.0
  */
 public final class RandomImageResolver implements ParameterResolver {
@@ -32,5 +31,4 @@ public final class RandomImageResolver implements ParameterResolver {
             context.getParameter().getDeclaringExecutable().getName()
         );
     }
-
 }

--- a/src/test/java/org/eolang/hone/RmiMojoTest.java
+++ b/src/test/java/org/eolang/hone/RmiMojoTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for {@link RmiMojo}.
- *
  * @since 0.1.0
  */
 @ExtendWith(MktmpResolver.class)
@@ -27,7 +26,6 @@ final class RmiMojoTest {
     @Tag("deep")
     @DisabledWithoutDocker
     @ExtendWith(MayBeSlow.class)
-    @SuppressWarnings("PMD.UnitTestShouldIncludeAssert")
     void pullsAndRemovesDockerImage(@Mktmp final Path dir) throws Exception {
         new Farea(dir).together(
             f -> {

--- a/src/test/java/org/eolang/hone/RulesTest.java
+++ b/src/test/java/org/eolang/hone/RulesTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for {@link Rules}.
- *
  * @since 0.1.0
  */
 @ExtendWith(MktmpResolver.class)
@@ -109,5 +108,4 @@ final class RulesTest {
             previous = yaml;
         }
     }
-
 }

--- a/src/test/java/org/eolang/hone/SummaryTest.java
+++ b/src/test/java/org/eolang/hone/SummaryTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for {@link Rules}.
- *
  * @since 0.1.0
  */
 @ExtendWith(MktmpResolver.class)

--- a/src/test/java/org/eolang/hone/TimingsTest.java
+++ b/src/test/java/org/eolang/hone/TimingsTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Timings}.
- *
  * @since 0.1.0
  */
 final class TimingsTest {
@@ -36,7 +35,7 @@ final class TimingsTest {
                 new String(Files.readAllBytes(file), StandardCharsets.UTF_8),
                 Matchers.allOf(
                     Matchers.containsString("foo,"),
-                    Matchers.containsString("\nbar,")
+                    Matchers.containsString(String.format("%nbar,"))
                 )
             );
         }

--- a/src/test/java/org/eolang/hone/package-info.java
+++ b/src/test/java/org/eolang/hone/package-info.java
@@ -4,7 +4,6 @@
  */
 /**
  * Test cases.
- *
  * @since 0.1.0
  */
 package org.eolang.hone;


### PR DESCRIPTION
@yegor256 this PR upgrades the Qulice plugin in `hone-maven-plugin` from `0.25.1` to the latest stable `0.27.6` and fixes the **130 new violations** that the upgraded Checkstyle, PMD and ErrorProne rule sets surface in `master`. All 27 unit tests still pass on JDK 21. Renovate's existing #468 stops at the version bump and leaves the failures open; this PR carries the fixes through, then ships green CI on all 17 pull-request checks.

## Plugin bump

- `com.qulice:qulice-maven-plugin` `0.25.1` → `0.27.6` (in the `qulice` profile of `pom.xml`).

## Code / config hygiene (qulice 0.27.6)

- Javadoc — trimmed trailing dots from `@param`/`@return`/`@throws` tags and re-aligned the empty-line policy (no blank line before tags when the description is one paragraph; one blank line when the description has `<p>...</p>` paragraphs).
- Visibility — dropped `public` from members of package-private classes (`Docker`, `Mktemp`, `Phino`, `Rules`, `Timings`) so PMD's `PublicMemberInNonPublicType` is satisfied.
- Collections — replaced `LinkedList` with `ArrayList` in `BuildMojo`, `Docker`, `OptimizeMojo`, and `Rules` (ErrorProne's `JdkObsolete`).
- String splitting — precompiled a static `Pattern` for the comma separator in `Rules` and `OptimizeMojo`, and used `Pattern.splitAsStream` where it reads naturally (`StringSplitter`, `SimpleStringSplitCheck`).
- Resource handling — wrapped the `Files.list` stream in `OptimizeMojo#saveExtra` in try-with-resources (`StreamResourceLeak`), and switched the CSV reader from the platform-default `FileReader` to an explicit UTF-8 `InputStreamReader` over `Files.newInputStream` (`DefaultCharset`).
- Line separators — replaced literal `\n` in string literals with `String.format("%n")` / `System.lineSeparator()` in `Timings`, `CSVTest`, and `TimingsTest` (`ProhibitLineSeparatorInStringsCheck`).
- Suppressions — removed now-unnecessary `@SuppressWarnings` annotations across `Summary`, `OptimizeMojo`, `BuildMojoTest`, `OptimizeMojoTest`, `PullMojoTest`, and `RmiMojoTest` (`UnnecessaryWarningSuppression`); added inline `@checkstyle ConstructorsCodeFreeCheck (N lines)` suppressions for the existing `this(...)` delegating constructors in `CSV`, `Mktemp`, `Rules`.
- Misc — reordered methods in `Mktemp` by visibility (`MethodsOrderCheck`), qualified static inner classes in `AbstractMojoTest` (`QualifyInnerClassCheck`), tightened bracket / fluent-call layouts in `CSV`, `Docker`, `OptimizeMojo`, `Rules`, and adjusted import order in `Rules`.

## Build config

- Added `errorprone:/src/test/resources/org/eolang/hone/rules/streams/.*` to the qulice `<excludes>` so the intentionally-default-package `Foo.java` fixture is no longer flagged by ErrorProne's `DefaultPackage` check (the path was already excluded for `pmd` and `checkstyle`).
- Raised the `docker` workflow `timeout-minutes` from `15` to `30`. The Dockerfile compiles GHC from source and pulls a sizeable apt-get install layer; on this PR's runs the build was reproducibly hitting the old 15-minute limit while still linking GHC. Past `master` runs typically finished in 10–12 minutes but the margin is small enough that any transient slowness on Hackage or the Ubuntu mirrors tips it over the limit. The Dockerfile itself is unchanged.

## Build / tests

- `mvn clean install -ntp --errors --batch-mode -Dinvoker.skip` passes locally on JDK 21 with **27/27** tests green (one Docker-gated test stays `@Disabled` as before).
- `mvn clean install -ntp --errors --batch-mode -DskipTests -Dinvoker.skip -Pqulice` reports `Qulice quality check completed` with **0 violations** on JDK 21.
- On the upstream PR, every relevant workflow now passes: `actionlint`, `bashate`, `copyrights`, `docker`, `hadolint`, `make`, `markdown-lint`, `mvn (ubuntu-24.04)`, `mvn (ubuntu-24.04, 17)`, `mvn (ubuntu-24.04, 22)`, `pdd`, `qulice`, `reuse`, `shellcheck`, `typos`, `xcop`, `yamllint` — 17/17 ✅.

## Not changed (intentional)

- The parent `com.jcabi:parent` is already at the latest `0.73.1`; no parent bump.
- All other direct dependencies (`asm`, `Saxon-HE`, `cactoos`, `classgraph`, `commons-csv`, `jaxec`, `jcabi-log`, `jcabi-maven-slf4j`, `jna`, the `maven-*` APIs, `slf4j-reload4j`, `reload4j`) are already at their latest stable versions.
- The `<jdk.version>8</jdk.version>` constraint and the comment forbidding raises is left untouched, so the plugin still compiles for Java 8 consumers.

Ready for review and merge.
