### PR TITLE
Default `threads` to 0 so the plugin uses all CPU cores out of the box

### DIFF
--- a/src/main/java/org/eolang/hone/OptimizeMojo.java
+++ b/src/main/java/org/eolang/hone/OptimizeMojo.java
@@ -243,17 +243,16 @@ public final class OptimizeMojo extends AbstractMojo {
     /**
      * How many threads to use for rewriting?
      *
-     * <p>By default, it's a single-threaded process. However, it may be
-     * rather slow for large projects. It is recommended to use values
-     * that are close to the number of CPUs you have on your machine.</p>
-     *
-     * <p>If you set this parameter to zero, the number of threads
-     * will be set to the number of CPUs on the machine.</p>
+     * <p>By default, it is set to zero, which means the number of threads
+     * will be set to the number of CPUs on the machine. This is normally
+     * the most efficient choice for large projects. Set it to <tt>1</tt>
+     * to disable parallelism, or to any positive value to cap the number
+     * of worker threads.</p>
      *
      * @since 0.11.0
      * @checkstyle MemberNameCheck (6 lines)
      */
-    @Parameter(property = "hone.threads", defaultValue = "1")
+    @Parameter(property = "hone.threads", defaultValue = "0")
     private int threads;
 
     /**

--- a/src/test/java/org/eolang/hone/OptimizeMojoTest.java
+++ b/src/test/java/org/eolang/hone/OptimizeMojoTest.java
@@ -18,6 +18,9 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.cactoos.io.ResourceOf;
+import org.cactoos.text.IoCheckedText;
+import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Tag;
@@ -1178,6 +1181,21 @@ final class OptimizeMojoTest {
                 "<o as=\"α0\">66-69-6C-74-65-72-65-64</o>"
             ).find(),
             Matchers.is(false)
+        );
+    }
+
+    @Test
+    void hasZeroDefaultThreadsInPluginDescriptor() throws Exception {
+        MatcherAssert.assertThat(
+            "default 'threads' parameter must be 0 so that all CPUs are used by default (see #500)",
+            new IoCheckedText(
+                new TextOf(
+                    new ResourceOf("META-INF/maven/plugin.xml")
+                )
+            ).asString(),
+            Matchers.containsString(
+                "<threads implementation=\"int\" default-value=\"0\">"
+            )
         );
     }
 


### PR DESCRIPTION
## Summary
- Closes #500.
- Change the default value of the `threads` parameter from `1` to `0`. With `0`, `rewrite.sh` already falls back to `$(nproc)`, so the plugin now uses every available CPU by default — a much more sensible choice for most users.
- Refresh the Javadoc accordingly.
- Add a unit test that reads the generated Maven plugin descriptor (`META-INF/maven/plugin.xml`) and asserts the default value of `threads` is `0`, guarding against future regressions.

## Test plan
- [x] `mvn -DexcludedGroups=deep -DskipITs test` — all 28 unit tests pass.
- [x] `mvn -Pqulice -DskipTests -DskipITs verify` — qulice and jtcop pass clean.
- [x] New test `OptimizeMojoTest#hasZeroDefaultThreadsInPluginDescriptor` was first committed alone and confirmed to fail against the old `defaultValue = "1"`, then passes after the source change.