### PR TITLE
fix(#506): create parallel tmpdir before invoking parallel

### DIFF
--- a/src/main/resources/org/eolang/hone/scaffolding/rewrite.sh
+++ b/src/main/resources/org/eolang/hone/scaffolding/rewrite.sh
@@ -232,6 +232,7 @@ else
   echo "Starting to rewrite ${total} file(s) in ${threads} thread(s)..."
   export PARALLEL_HOME=${TARGET}/parallel
   mkdir -p "${PARALLEL_HOME}"
+  mkdir -p "${PARALLEL_HOME}/tmp"
   parallel --record-env
   parallel --retries=0 "--joblog=${PARALLEL_HOME}/tasks.log" --will-cite \
     "--max-procs=${threads}" \

--- a/src/test/java/org/eolang/hone/OptimizeMojoTest.java
+++ b/src/test/java/org/eolang/hone/OptimizeMojoTest.java
@@ -1200,6 +1200,19 @@ final class OptimizeMojoTest {
     }
 
     @Test
+    void createsParallelTmpdirBeforeRunningParallel() throws Exception {
+        MatcherAssert.assertThat(
+            "rewrite.sh must create the parallel tmpdir before invoking 'parallel', otherwise GNU parallel fails with 'Cant dup STDOUT: No such file or directory' (see #506)",
+            new IoCheckedText(
+                new TextOf(
+                    new ResourceOf("org/eolang/hone/scaffolding/rewrite.sh")
+                )
+            ).asString(),
+            Matchers.containsString("mkdir -p \"${PARALLEL_HOME}/tmp\"")
+        );
+    }
+
+    @Test
     void formatsWhoamiAsUidColonGid() {
         MatcherAssert.assertThat(
             "whoami must format the Docker --user value as 'uid:gid', not 'uid:euid' (see #492)",


### PR DESCRIPTION
Closes #506. GNU parallel 20210822 fails with "Can't dup STDOUT: No such file or directory" when --tmpdir points at a directory that does not yet exist. The rewrite.sh script created ${PARALLEL_HOME} but not its tmp subdirectory, while passing --tmpdir=${PARALLEL_HOME}/tmp to parallel; the fix is to mkdir -p that tmp directory before invoking parallel. A unit test on the script's text guards against the regression.