### PR TITLE
fix(#506): drop --tmpdir to avoid virtiofs fstat bug

### DIFF
--- a/src/main/java/org/eolang/hone/Phino.java
+++ b/src/main/java/org/eolang/hone/Phino.java
@@ -36,8 +36,8 @@ final class Phino {
                 } else {
                     Logger.info(
                         this,
-                        "The 'phino' executable is found, but its version (%s) is not equal to the expected one (%s)",
-                        version, expected
+                        "The 'phino' executable is found, but its version (%s) is not equal to the expected one (%s); you can upgrade it via 'cabal update && cabal install --overwrite-policy=always phino-%s' (see https://github.com/objectionary/phino for details)",
+                        version, expected, expected
                     );
                 }
             } else {

--- a/src/main/resources/org/eolang/hone/scaffolding/rewrite.sh
+++ b/src/main/resources/org/eolang/hone/scaffolding/rewrite.sh
@@ -232,11 +232,9 @@ else
   echo "Starting to rewrite ${total} file(s) in ${threads} thread(s)..."
   export PARALLEL_HOME=${TARGET}/parallel
   mkdir -p "${PARALLEL_HOME}"
-  mkdir -p "${PARALLEL_HOME}/tmp"
   parallel --record-env
   parallel --retries=0 "--joblog=${PARALLEL_HOME}/tasks.log" --will-cite \
     "--max-procs=${threads}" \
-    "--tmpdir=${PARALLEL_HOME}/tmp" \
     --env _ \
     --halt-on-error=now,fail=1 --halt=now,fail=1 < "${tasks}"
 fi

--- a/src/test/java/org/eolang/hone/OptimizeMojoTest.java
+++ b/src/test/java/org/eolang/hone/OptimizeMojoTest.java
@@ -1200,15 +1200,15 @@ final class OptimizeMojoTest {
     }
 
     @Test
-    void createsParallelTmpdirBeforeRunningParallel() throws Exception {
+    void doesNotPlaceParallelTmpdirOnHostMountedVolume() throws Exception {
         MatcherAssert.assertThat(
-            "rewrite.sh must create the parallel tmpdir before invoking 'parallel', otherwise GNU parallel fails with 'Cant dup STDOUT: No such file or directory' (see #506)",
+            "rewrite.sh must not point parallel --tmpdir at the host-mounted ${TARGET} volume, since virtiofs (Docker Desktop on macOS) makes fstat fail with ENOENT on deleted-but-open files, which breaks parallel's grouped output and triggers 'Cant dup STDOUT: No such file or directory' (see #506)",
             new IoCheckedText(
                 new TextOf(
                     new ResourceOf("org/eolang/hone/scaffolding/rewrite.sh")
                 )
             ).asString(),
-            Matchers.containsString("mkdir -p \"${PARALLEL_HOME}/tmp\"")
+            Matchers.not(Matchers.containsString("--tmpdir=${PARALLEL_HOME}"))
         );
     }
 


### PR DESCRIPTION
## Summary

- The previous fix in #507 was a misdiagnosis: it added `mkdir -p ${PARALLEL_HOME}/tmp`, but the tmpdir already existed at runtime — the real failure is virtiofs returning ENOENT from `fstat` on a deleted-but-still-open fd. `0.26.1` still throws "Can't dup STDOUT: No such file or directory" on Docker Desktop for macOS.
- GNU parallel 20210822 spools per-job stdout/stderr in `--tmpdir` via the standard open-then-unlink pattern, then later runs `open OUT, '>&', $fh`. Perl's dup performs an `fstat` under the hood; virtiofs returns ENOENT for the unlinked-but-open fd; parallel aborts before launching any job.
- Drop `--tmpdir` from the parallel invocation so it falls back to the container's own `/tmp` (overlayfs), which handles deleted-but-open files normally. `joblog` and `PARALLEL_HOME` stay on the host volume — they are plain append-only files and do not exercise the broken pattern.
- Replace the previous string-match test with one that asserts `--tmpdir=${PARALLEL_HOME}` is NOT in `rewrite.sh`. The new test fails on master and passes on this branch, capturing the real bug as executable evidence.

## Diagnosis

Patching `parallel` inline to print fd state at the failure site shows:

```
DBG: about-to-dup stdout_fd=6 stderr_fd=7
DBG: stdout fstat result:  (errno=No such file or directory)
DBG: /proc/self/fd/6 -> /mnt/par/parPrGsN.par (deleted)
```

The fd is alive, the file path is gone (correct POSIX behavior), but `fstat` returns ENOENT — virtiofs-specific. Same minimal repro on overlayfs/ext4/tmpfs succeeds. `--ungroup` and `--linebuffer` also work on virtiofs because they bypass the spool path entirely; that confirms grouped-output spooling is the affected code path.

A draft upstream bug report (for `bug-parallel@gnu.org` / Savannah) is staged locally as `parallel-bug-report.md` — not included in this PR.

## Test plan

- [x] New test `OptimizeMojoTest#doesNotPlaceParallelTmpdirOnHostMountedVolume` fails on master, passes on this branch
- [x] Minimal `parallel --tmpdir=…` reproducer fails on virtiofs and succeeds without `--tmpdir`, inside `yegor256/hone:0.26.1`
- [x] End-to-end: same flag combo `--retries=0 --joblog=… --will-cite --max-procs=N --env _ --halt-on-error=now,fail=1` runs three sample tasks to completion and writes the joblog rows
- [ ] Re-run the cactoos build against a snapshot containing this fix to confirm the original `Can't dup STDOUT` log line goes away on a real downstream project