### PR TITLE
#521: Handle header-only hone-statistics.csv without crashing

### DIFF
--- a/src/main/java/org/eolang/hone/CSV.java
+++ b/src/main/java/org/eolang/hone/CSV.java
@@ -19,6 +19,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.csv.CSVRecord;
 import org.cactoos.list.ListOf;
@@ -51,14 +52,11 @@ public final class CSV {
 
     /**
      * Constructor.
-     * @param records CSV records
-     * @checkstyle ConstructorsCodeFreeCheck (5 lines)
+     * @param other The CSV to copy fields from
+     * @checkstyle ConstructorsCodeFreeCheck (3 lines)
      */
-    private CSV(final List<CSVRecord> records) {
-        this(
-            new ListOf<>(records.get(0).toMap().keySet()),
-            CSV.rows(records)
-        );
+    private CSV(final CSV other) {
+        this(other.headers, other.records);
     }
 
     /**
@@ -158,20 +156,21 @@ public final class CSV {
     }
 
     @SuppressWarnings("PMD.UnnecessaryLocalRule")
-    private static List<CSVRecord> from(final Path csv) {
+    private static CSV from(final Path csv) {
         try (
             Reader reader = new InputStreamReader(
                 Files.newInputStream(csv),
                 StandardCharsets.UTF_8
-            )
+            );
+            CSVParser parser = CSVFormat.DEFAULT.builder()
+                .setHeader()
+                .setSkipHeaderRecord(false)
+                .get()
+                .parse(reader)
         ) {
-            return new ListOf<>(
-                CSVFormat.DEFAULT.builder()
-                    .setHeader()
-                    .setSkipHeaderRecord(false)
-                    .get()
-                    .parse(reader)
-                    .iterator()
+            return new CSV(
+                new ListOf<>(parser.getHeaderNames()),
+                CSV.rows(parser.getRecords())
             );
         } catch (final IOException exception) {
             throw new IllegalStateException(

--- a/src/test/java/org/eolang/hone/CSVTest.java
+++ b/src/test/java/org/eolang/hone/CSVTest.java
@@ -62,4 +62,28 @@ final class CSVTest {
             Matchers.is(0)
         );
     }
+
+    @Test
+    void parsesHeaderOnlyCsv(@Mktmp final Path temp) throws Exception {
+        final Path path = temp.resolve("test.csv");
+        Files.write(
+            path,
+            String.join(
+                System.lineSeparator(),
+                "ID,Before,After,Changed,LinesPerSec",
+                ""
+            ).getBytes(StandardCharsets.UTF_8)
+        );
+        final CSV csv = new CSV(path);
+        MatcherAssert.assertThat(
+            "header-only CSV has zero data rows",
+            csv.size(),
+            Matchers.is(0)
+        );
+        MatcherAssert.assertThat(
+            "header-only CSV reports zero matches",
+            csv.count("Changed", v -> Integer.parseInt(v) > 0),
+            Matchers.is(0)
+        );
+    }
 }

--- a/src/test/java/org/eolang/hone/CSVTest.java
+++ b/src/test/java/org/eolang/hone/CSVTest.java
@@ -74,15 +74,27 @@ final class CSVTest {
                 ""
             ).getBytes(StandardCharsets.UTF_8)
         );
-        final CSV csv = new CSV(path);
         MatcherAssert.assertThat(
             "header-only CSV has zero data rows",
-            csv.size(),
+            new CSV(path).size(),
             Matchers.is(0)
+        );
+    }
+
+    @Test
+    void countsZeroOnHeaderOnlyCsv(@Mktmp final Path temp) throws Exception {
+        final Path path = temp.resolve("test.csv");
+        Files.write(
+            path,
+            String.join(
+                System.lineSeparator(),
+                "ID,Before,After,Changed,LinesPerSec",
+                ""
+            ).getBytes(StandardCharsets.UTF_8)
         );
         MatcherAssert.assertThat(
             "header-only CSV reports zero matches",
-            csv.count("Changed", v -> Integer.parseInt(v) > 0),
+            new CSV(path).count("Changed", v -> Integer.parseInt(v) > 0),
             Matchers.is(0)
         );
     }


### PR DESCRIPTION
## Summary

Fixes #521.

`CSV` previously derived its header list from `records.get(0).toMap().keySet()`. When `hone-statistics.csv` contains only the header row (a normal state when every input class is filtered out by `grep-in`, or there is nothing to rewrite), the records list is empty and `get(0)` threw `IndexOutOfBoundsException`, breaking the `optimize` mojo and the `@Tag("deep")` tests.

The fix follows option 1 in the issue: headers now come from `CSVParser.getHeaderNames()`, so a header-only CSV parses to a `CSV` with zero data rows — which is the obvious semantics ("a CSV with headers and no rows is still a valid CSV with size 0").

## Changes

- `src/main/java/org/eolang/hone/CSV.java`
  - `from(Path)` now returns a fully-built `CSV` whose headers come from `CSVParser.getHeaderNames()` and whose rows come from `parser.getRecords()`. The parser is closed via try-with-resources alongside the reader.
  - Replaced the private `CSV(List<CSVRecord>)` constructor with a delegating `CSV(CSV)` so `CSV(Path)` stays a one-liner.
- `src/test/java/org/eolang/hone/CSVTest.java`
  - Added `parsesHeaderOnlyCsv` covering the previously-crashing case.

## Test plan

- [x] `mvn test -Dtest=CSVTest` — 3/3 pass, including the new `parsesHeaderOnlyCsv`.
- [x] `mvn test` — full unit suite green (30 run, 1 skipped due to no Docker socket in this env).
- [ ] `mvn test -Pdeep` — should now unblock `OptimizeMojoTest.optimizesExecutableJavaApp`, `optimizesTwice`, and the `streams-rand.yml` pack (requires Docker; not runnable here).


---
_Generated by [Claude Code](https://claude.ai/code/session_018w2ZwTq6CNHYL13ZjShd4V)_