### PR TITLE
Add phino test suite for .phr files

### DIFF
--- a/.github/workflows/phino.yml
+++ b/.github/workflows/phino.yml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+name: phino
+'on':
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+concurrency:
+  group: phino-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  phino:
+    timeout-minutes: 15
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - run: |
+          sudo wget -q -O /usr/bin/phino http://phino.objectionary.com/releases/ubuntu-24.04/phino-latest
+          sudo chmod a+x /usr/bin/phino
+      - uses: mikefarah/yq@master
+      - run: src/test/phino/run.sh

--- a/.github/workflows/phino.yml
+++ b/.github/workflows/phino.yml
@@ -22,5 +22,5 @@ jobs:
       - run: |
           sudo wget -q -O /usr/bin/phino http://phino.objectionary.com/releases/ubuntu-24.04/phino-latest
           sudo chmod a+x /usr/bin/phino
-      - uses: mikefarah/yq@master
+      - uses: mikefarah/yq@v4.44.3
       - run: src/test/phino/run.sh

--- a/src/test/phino/121-nonstatic-lambda-to-static.yml
+++ b/src/test/phino/121-nonstatic-lambda-to-static.yml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/121-nonstatic-lambda-to-static.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      φ ↦ Φ.hone.lambda,
+      class ↦ "Foo",
+      method ↦ "bar",
+      interface ↦ "()Ljava/util/function/Function;",
+      lambda-signature ↦ "(Ljava/lang/Object;)Ljava/lang/Object;",
+      bridge-signature ↦ "(Ljava/lang/Object;)Ljava/lang/Object;",
+      static ↦ "false",
+      opcode ↦ Φ.jeo.opcode.invokestatic,
+      target ↦ "x",
+      stream ↦ "y"
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.hone.lambda, class ↦ 𝑒-class, method ↦ 𝑒-method, interface ↦ 𝑒-interface, lambda-signature ↦ 𝑒-lambda-signature, bridge-signature ↦ 𝑒-bridge-signature, static ↦ "true", opcode ↦ 𝑒-opcode, target ↦ 𝑒-target, stream ↦ 𝑒-stream ⟧

--- a/src/test/phino/121-nonstatic-lambda-to-static.yml
+++ b/src/test/phino/121-nonstatic-lambda-to-static.yml
@@ -20,4 +20,4 @@ input: |
     ⟧
   ⟧}
 expected:
-  - ⟦ φ ↦ Φ.hone.lambda, class ↦ 𝑒-class, method ↦ 𝑒-method, interface ↦ 𝑒-interface, lambda-signature ↦ 𝑒-lambda-signature, bridge-signature ↦ 𝑒-bridge-signature, static ↦ "true", opcode ↦ 𝑒-opcode, target ↦ 𝑒-target, stream ↦ 𝑒-stream ⟧
+  - ⟦ φ ↦ Φ.hone.lambda, 𝐵-before, static ↦ "true", 𝐵-after ⟧

--- a/src/test/phino/131-remove-this-before-nonstatic-lambda.yml
+++ b/src/test/phino/131-remove-this-before-nonstatic-lambda.yml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/131-remove-this-before-nonstatic-lambda.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      op1 ↦ ⟦
+        φ ↦ Φ.jeo.opcode.aload,
+        v1 ↦ 0,
+        ρ ↦ ∅
+      ⟧,
+      op2 ↦ ⟦
+        φ ↦ Φ.hone.lambda,
+        class ↦ "Foo",
+        method ↦ "bar",
+        interface ↦ "()Ljava/util/function/Function;",
+        lambda-signature ↦ "(Ljava/lang/Object;)Ljava/lang/Object;",
+        bridge-signature ↦ "(Ljava/lang/Object;)Ljava/lang/Object;",
+        static ↦ "false",
+        opcode ↦ Φ.jeo.opcode.invokestatic,
+        target ↦ "x",
+        stream ↦ "y"
+      ⟧
+    ⟧
+  ⟧}
+expected:
+  - ⟦ body ↦ ⟦ op2 ↦ ⟦ φ ↦ Φ.hone.lambda, 𝐵-lambda ⟧ ⟧ ⟧

--- a/src/test/phino/131-remove-this-before-nonstatic-lambda.yml
+++ b/src/test/phino/131-remove-this-before-nonstatic-lambda.yml
@@ -27,4 +27,4 @@ input: |
     ⟧
   ⟧}
 expected:
-  - ⟦ body ↦ ⟦ op2 ↦ ⟦ φ ↦ Φ.hone.lambda, 𝐵-lambda ⟧ ⟧ ⟧
+  - ⟦ body ↦ ⟦ 𝜏-only ↦ ⟦ φ ↦ Φ.hone.lambda, 𝐵 ⟧, ρ ↦ ∅ ⟧ ⟧

--- a/src/test/phino/271-remove-useless-types.yml
+++ b/src/test/phino/271-remove-useless-types.yml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/271-remove-useless-types.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      op1 ↦ ⟦
+        φ ↦ Φ.hone.type,
+        from ↦ "I",
+        to ↦ "I",
+        class ↦ "Foo"
+      ⟧,
+      op2 ↦ ⟦
+        φ ↦ Φ.jeo.opcode.aload,
+        v1 ↦ 0
+      ⟧
+    ⟧
+  ⟧}
+expected:
+  - ⟦ body ↦ ⟦ op2 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v1 ↦ 0 ⟧ ⟧ ⟧

--- a/src/test/phino/271-remove-useless-types.yml
+++ b/src/test/phino/271-remove-useless-types.yml
@@ -20,4 +20,4 @@ input: |
     ⟧
   ⟧}
 expected:
-  - ⟦ body ↦ ⟦ op2 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v1 ↦ 0 ⟧ ⟧ ⟧
+  - ⟦ body ↦ ⟦ 𝜏-only ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, 𝐵 ⟧, ρ ↦ ∅ ⟧ ⟧

--- a/src/test/phino/602-box-to-boxed.yml
+++ b/src/test/phino/602-box-to-boxed.yml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/602-box-to-boxed.phr
+input: |
+  {⟦
+    foo ↦ ⟦
+      φ ↦ Φ.hone.box,
+      stream-class ↦ "MyStream"
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i1 ↦ "MyStream", i2 ↦ "boxed", i3 ↦ "()Ljava/util/stream/Stream;", i4 ↦ Φ.true ⟧

--- a/src/test/phino/602-box-to-boxed.yml
+++ b/src/test/phino/602-box-to-boxed.yml
@@ -12,4 +12,4 @@ input: |
     ⟧
   ⟧}
 expected:
-  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i1 ↦ "MyStream", i2 ↦ "boxed", i3 ↦ "()Ljava/util/stream/Stream;", i4 ↦ Φ.true ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, 𝐵-before, i2 ↦ "boxed", i3 ↦ "()Ljava/util/stream/Stream;", i4 ↦ Φ.true, 𝐵-after ⟧

--- a/src/test/phino/pipeline-map-filter-to-mapMulti.yml
+++ b/src/test/phino/pipeline-map-filter-to-mapMulti.yml
@@ -1,0 +1,280 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The input below is the phi representation of this Java class:
+#
+#   import java.util.stream.IntStream;
+#   public class Foo {
+#       public static int run() {
+#           return IntStream.of(1, 2, 3)
+#               .map(x -> x + 1)
+#               .filter(x -> x > 1)
+#               .sum();
+#       }
+#   }
+#
+# Compiled with javac, disassembled with jeo:disassemble, then converted to
+# phi with `phino rewrite --input=xmir`. After all rules in the streams/
+# directory are applied, the .map().filter() pair must collapse into a
+# single invokeinterface call to .mapMulti() on java/util/stream/IntStream.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/*.phr
+input: |
+  {⟦
+    jeo$packageless$jeo ↦ ⟦
+      j$Foo ↦ ⟦
+        φ ↦ Φ.jeo.class,
+        version ↦ 68,
+        access ↦ 33,
+        modifiers ↦ ⟦
+          φ ↦ Φ.jeo.modifiers,
+          public ↦ Φ.true,
+          private ↦ Φ.false,
+          protected ↦ Φ.false,
+          final ↦ Φ.false,
+          super ↦ Φ.true,
+          interface ↦ Φ.false,
+          abstract ↦ Φ.false,
+          synthetic ↦ Φ.false,
+          annotation ↦ Φ.false,
+          enum ↦ Φ.false,
+          mandated ↦ Φ.false,
+          module ↦ Φ.false,
+          record ↦ Φ.false,
+          deprecated ↦ Φ.false
+        ⟧,
+        name ↦ "Foo",
+        supername ↦ "java/lang/Object",
+        interfaces ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+        jm$run ↦ ⟦
+          φ ↦ Φ.jeo.method,
+          access ↦ 9,
+          modifiers ↦ ⟦
+            φ ↦ Φ.jeo.modifiers,
+            public ↦ Φ.true,
+            private ↦ Φ.false,
+            protected ↦ Φ.false,
+            static ↦ Φ.true,
+            final ↦ Φ.false,
+            synchronized ↦ Φ.false,
+            bridge ↦ Φ.false,
+            varargs ↦ Φ.false,
+            native ↦ Φ.false,
+            abstract ↦ Φ.false,
+            strict ↦ Φ.false,
+            synthetic ↦ Φ.false,
+            mandated ↦ Φ.false
+          ⟧,
+          name ↦ "run",
+          descriptor ↦ "()I",
+          signature ↦ "",
+          exceptions ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+          maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, m1 ↦ 4, m2 ↦ 0 ⟧,
+          params ↦ ⟦ φ ↦ Φ.jeo.params ⟧,
+          annotations ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+          body ↦ ⟦
+            φ ↦ Φ.jeo.seq.of21,
+            i0 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_3 ⟧,
+            i1 ↦ ⟦ φ ↦ Φ.jeo.opcode.newarray, v0 ↦ 10 ⟧,
+            i2 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+            i3 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+            i4 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_1 ⟧,
+            i5 ↦ ⟦ φ ↦ Φ.jeo.opcode.iastore ⟧,
+            i6 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+            i7 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_1 ⟧,
+            i8 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_2 ⟧,
+            i9 ↦ ⟦ φ ↦ Φ.jeo.opcode.iastore ⟧,
+            i10 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+            i11 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_2 ⟧,
+            i12 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_3 ⟧,
+            i13 ↦ ⟦ φ ↦ Φ.jeo.opcode.iastore ⟧,
+            i14 ↦ ⟦
+              φ ↦ Φ.jeo.opcode.invokestatic,
+              v0 ↦ "java/util/stream/IntStream",
+              v1 ↦ "of",
+              v2 ↦ "([I)Ljava/util/stream/IntStream;",
+              v3 ↦ Φ.true
+            ⟧,
+            i15 ↦ ⟦
+              φ ↦ Φ.jeo.opcode.invokedynamic,
+              v0 ↦ "applyAsInt",
+              v1 ↦ "()Ljava/util/function/IntUnaryOperator;",
+              h2 ↦ ⟦
+                φ ↦ Φ.jeo.handle,
+                v0 ↦ 6,
+                v1 ↦ "java/lang/invoke/LambdaMetafactory",
+                v2 ↦ "metafactory",
+                v3 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+                v4 ↦ Φ.false
+              ⟧,
+              t3 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(I)I" ⟧,
+              h4 ↦ ⟦
+                φ ↦ Φ.jeo.handle,
+                v0 ↦ 6,
+                v1 ↦ "Foo",
+                v2 ↦ "lambda$run$0",
+                v3 ↦ "(I)I",
+                v4 ↦ Φ.false
+              ⟧,
+              t5 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(I)I" ⟧
+            ⟧,
+            i16 ↦ ⟦
+              φ ↦ Φ.jeo.opcode.invokeinterface,
+              v0 ↦ "java/util/stream/IntStream",
+              v1 ↦ "map",
+              v2 ↦ "(Ljava/util/function/IntUnaryOperator;)Ljava/util/stream/IntStream;",
+              v3 ↦ Φ.true
+            ⟧,
+            i17 ↦ ⟦
+              φ ↦ Φ.jeo.opcode.invokedynamic,
+              v0 ↦ "test",
+              v1 ↦ "()Ljava/util/function/IntPredicate;",
+              h2 ↦ ⟦
+                φ ↦ Φ.jeo.handle,
+                v0 ↦ 6,
+                v1 ↦ "java/lang/invoke/LambdaMetafactory",
+                v2 ↦ "metafactory",
+                v3 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+                v4 ↦ Φ.false
+              ⟧,
+              t3 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(I)Z" ⟧,
+              h4 ↦ ⟦
+                φ ↦ Φ.jeo.handle,
+                v0 ↦ 6,
+                v1 ↦ "Foo",
+                v2 ↦ "lambda$run$1",
+                v3 ↦ "(I)Z",
+                v4 ↦ Φ.false
+              ⟧,
+              t5 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(I)Z" ⟧
+            ⟧,
+            i18 ↦ ⟦
+              φ ↦ Φ.jeo.opcode.invokeinterface,
+              v0 ↦ "java/util/stream/IntStream",
+              v1 ↦ "filter",
+              v2 ↦ "(Ljava/util/function/IntPredicate;)Ljava/util/stream/IntStream;",
+              v3 ↦ Φ.true
+            ⟧,
+            i19 ↦ ⟦
+              φ ↦ Φ.jeo.opcode.invokeinterface,
+              v0 ↦ "java/util/stream/IntStream",
+              v1 ↦ "sum",
+              v2 ↦ "()I",
+              v3 ↦ Φ.true
+            ⟧,
+            i20 ↦ ⟦ φ ↦ Φ.jeo.opcode.ireturn ⟧
+          ⟧,
+          trycatchblocks ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+          local-variable-table ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
+        ⟧,
+        jm$lambda$run$1 ↦ ⟦
+          φ ↦ Φ.jeo.method,
+          access ↦ 4106,
+          modifiers ↦ ⟦
+            φ ↦ Φ.jeo.modifiers,
+            public ↦ Φ.false,
+            private ↦ Φ.true,
+            protected ↦ Φ.false,
+            static ↦ Φ.true,
+            final ↦ Φ.false,
+            synchronized ↦ Φ.false,
+            bridge ↦ Φ.false,
+            varargs ↦ Φ.false,
+            native ↦ Φ.false,
+            abstract ↦ Φ.false,
+            strict ↦ Φ.false,
+            synthetic ↦ Φ.true,
+            mandated ↦ Φ.false
+          ⟧,
+          name ↦ "lambda$run$1",
+          descriptor ↦ "(I)Z",
+          signature ↦ "",
+          exceptions ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+          maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, m1 ↦ 2, m2 ↦ 1 ⟧,
+          params ↦ ⟦ φ ↦ Φ.jeo.params ⟧,
+          annotations ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+          body ↦ ⟦
+            φ ↦ Φ.jeo.seq.of11,
+            i0 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 0 ⟧,
+            i1 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_1 ⟧,
+            i2 ↦ ⟦
+              φ ↦ Φ.jeo.opcode.if_icmple,
+              l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ "L157201184" ⟧
+            ⟧,
+            i3 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_1 ⟧,
+            i4 ↦ ⟦ φ ↦ Φ.jeo.opcode.goto, l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ "L49619396" ⟧ ⟧,
+            l5 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ "L157201184" ⟧,
+            f6 ↦ ⟦
+              φ ↦ Φ.jeo.frame,
+              type ↦ 3,
+              locals ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+              stack ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
+            ⟧,
+            i7 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+            l8 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ "L49619396" ⟧,
+            f9 ↦ ⟦
+              φ ↦ Φ.jeo.frame,
+              type ↦ 4,
+              locals ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+              stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, x0 ↦ "integer" ⟧
+            ⟧,
+            i10 ↦ ⟦ φ ↦ Φ.jeo.opcode.ireturn ⟧
+          ⟧,
+          trycatchblocks ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+          local-variable-table ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
+        ⟧,
+        jm$lambda$run$0 ↦ ⟦
+          φ ↦ Φ.jeo.method,
+          access ↦ 4106,
+          modifiers ↦ ⟦
+            φ ↦ Φ.jeo.modifiers,
+            public ↦ Φ.false,
+            private ↦ Φ.true,
+            protected ↦ Φ.false,
+            static ↦ Φ.true,
+            final ↦ Φ.false,
+            synchronized ↦ Φ.false,
+            bridge ↦ Φ.false,
+            varargs ↦ Φ.false,
+            native ↦ Φ.false,
+            abstract ↦ Φ.false,
+            strict ↦ Φ.false,
+            synthetic ↦ Φ.true,
+            mandated ↦ Φ.false
+          ⟧,
+          name ↦ "lambda$run$0",
+          descriptor ↦ "(I)I",
+          signature ↦ "",
+          exceptions ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+          maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, m1 ↦ 2, m2 ↦ 1 ⟧,
+          params ↦ ⟦ φ ↦ Φ.jeo.params ⟧,
+          annotations ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+          body ↦ ⟦
+            φ ↦ Φ.jeo.seq.of4,
+            i0 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 0 ⟧,
+            i1 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_1 ⟧,
+            i2 ↦ ⟦ φ ↦ Φ.jeo.opcode.iadd ⟧,
+            i3 ↦ ⟦ φ ↦ Φ.jeo.opcode.ireturn ⟧
+          ⟧,
+          trycatchblocks ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+          local-variable-table ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
+        ⟧,
+        signature ↦ "",
+        annotations ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+        attributes ↦ ⟦
+          φ ↦ Φ.jeo.seq.of1,
+          a0 ↦ ⟦
+            φ ↦ Φ.jeo.inner-class,
+            name ↦ "java/lang/invoke/MethodHandles$Lookup",
+            outer ↦ "java/lang/invoke/MethodHandles",
+            inner ↦ "Lookup",
+            access ↦ 25
+          ⟧
+        ⟧
+      ⟧,
+      λ ⤍ Package
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, 𝐵-before, i3 ↦ "mapMulti", 𝐵-after ⟧

--- a/src/test/phino/run.sh
+++ b/src/test/phino/run.sh
@@ -36,6 +36,7 @@ for yml in "${tests[@]}"; do
   name="$(basename "${yml}" .yml)"
   echo "Running ${name}..."
   tmp="$(mktemp -d)"
+  trap 'rm -rf -- "${tmp}"' EXIT INT TERM
   input="${tmp}/input.phi"
   output="${tmp}/output.phi"
   raw="$(yq -r '.input' "${yml}")"

--- a/src/test/phino/run.sh
+++ b/src/test/phino/run.sh
@@ -78,7 +78,21 @@ for yml in "${tests[@]}"; do
     continue
   fi
   ok=true
+  if [ "$(yq -r 'has("expected")' "${yml}")" != 'true' ]; then
+    echo "  FAIL: 'expected' key is missing in ${name}.yml"
+    failed=$(( failed + 1 ))
+    failed_names+=("${name}")
+    rm -rf "${tmp}"
+    continue
+  fi
   count="$(yq -r '.expected | length' "${yml}")"
+  if [ "${count}" -eq 0 ]; then
+    echo "  FAIL: 'expected' is empty in ${name}.yml, must list at least one pattern"
+    failed=$(( failed + 1 ))
+    failed_names+=("${name}")
+    rm -rf "${tmp}"
+    continue
+  fi
   for (( i = 0; i < count; i++ )); do
     pattern="$(yq -r ".expected[${i}]" "${yml}")"
     if ! phino match --pattern "${pattern}" "${output}" > "${tmp}/match" 2>&1; then

--- a/src/test/phino/run.sh
+++ b/src/test/phino/run.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+
+set -e -o pipefail
+shopt -s globstar nullglob
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd "${here}/../../.." && pwd)"
+
+if ! command -v phino >/dev/null 2>&1; then
+  echo "phino is not installed, see https://github.com/objectionary/phino"
+  exit 1
+fi
+
+if ! command -v yq >/dev/null 2>&1; then
+  echo "yq is not installed, see https://github.com/mikefarah/yq"
+  exit 1
+fi
+
+cd "${root}"
+
+tests=("${here}"/*.yml)
+total=${#tests[@]}
+if [ "${total}" -eq 0 ]; then
+  echo "No test files found in ${here}"
+  exit 1
+fi
+
+passed=0
+failed=0
+failed_names=()
+echo "Found ${total} test(s) in ${here}"
+
+for yml in "${tests[@]}"; do
+  name="$(basename "${yml}" .yml)"
+  echo "Running ${name}..."
+  tmp="$(mktemp -d)"
+  input="${tmp}/input.phi"
+  output="${tmp}/output.phi"
+  raw="$(yq -r '.input' "${yml}")"
+  trimmed="${raw#"${raw%%[![:space:]]*}"}"
+  if [ "${trimmed:0:1}" = '{' ] || [ "${trimmed:0:1}" = 'Φ' ]; then
+    printf '%s\n' "${raw}" > "${input}"
+  else
+    printf '{%s}\n' "${raw}" > "${input}"
+  fi
+  rules=()
+  while IFS= read -r pat; do
+    [ -z "${pat}" ] && continue
+    # shellcheck disable=SC2206
+    matched=("${root}"/${pat})
+    if [ ${#matched[@]} -eq 0 ] || [ ! -e "${matched[0]}" ]; then
+      echo "  no files matched '${pat}'"
+      rules=()
+      break
+    fi
+    for f in "${matched[@]}"; do
+      if [ -f "${f}" ]; then
+        rules+=("--rule=${f}")
+      fi
+    done
+  done < <(yq -r '.rules[]' "${yml}")
+  if [ ${#rules[@]} -eq 0 ]; then
+    echo "  FAIL: no rules to apply"
+    failed=$(( failed + 1 ))
+    failed_names+=("${name}")
+    rm -rf "${tmp}"
+    continue
+  fi
+  if ! phino rewrite --sweet "${rules[@]}" "${input}" > "${output}" 2> "${tmp}/err"; then
+    echo "  FAIL: phino rewrite returned non-zero"
+    sed 's/^/    /' "${tmp}/err"
+    failed=$(( failed + 1 ))
+    failed_names+=("${name}")
+    rm -rf "${tmp}"
+    continue
+  fi
+  ok=true
+  count="$(yq -r '.expected | length' "${yml}")"
+  for (( i = 0; i < count; i++ )); do
+    pattern="$(yq -r ".expected[${i}]" "${yml}")"
+    if ! phino match --pattern "${pattern}" "${output}" > "${tmp}/match" 2>&1; then
+      echo "  FAIL: expected pattern #$(( i + 1 )) did not match"
+      printf '    pattern:\n'
+      printf '%s\n' "${pattern}" | sed 's/^/      /'
+      printf '    actual:\n'
+      sed 's/^/      /' "${output}"
+      ok=false
+      break
+    fi
+  done
+  if ${ok}; then
+    echo "  OK (${count} pattern(s) matched)"
+    passed=$(( passed + 1 ))
+  else
+    failed=$(( failed + 1 ))
+    failed_names+=("${name}")
+  fi
+  rm -rf "${tmp}"
+done
+
+echo ""
+echo "Total: ${total}, passed: ${passed}, failed: ${failed}"
+if [ "${failed}" -gt 0 ]; then
+  echo "Failures:"
+  for n in "${failed_names[@]}"; do
+    echo "  - ${n}"
+  done
+  exit 1
+fi


### PR DESCRIPTION
Adds a small test suite that exercises the `.phr` rewriting rules under `src/main/resources/org/eolang/hone/rules/`. Each YAML file under `src/test/phino/` names a list of rule files (globs allowed), a phi input, and one or more phino patterns the rewritten output must match. A `run.sh` driver walks the directory, runs `phino rewrite` with the listed rules, then verifies each expected pattern via `phino match`.

The rules had no isolated coverage so far, so a bad rewrite was only caught indirectly through the integration tests. This suite makes it cheap to add a focused check whenever a new `.phr` file lands, and the GitHub workflow `phino.yml` wires it into CI alongside the existing checks.

Four sample tests are included to cover the schema shapes — a value rewrite (602), a conditional removal (271), a value mutation (121), and the pre-lambda aload-0 drop (131) from the issue description. More tests can be added simply by dropping another YAML file into the directory.

Closes #531