### PR TITLE
#537: Optimize .peek(Consumer) in stream pipelines

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/209-lambda-to-peek.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/209-lambda-to-peek.phr
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Recognizes a Φ.hone.lambda whose stream call is Stream.peek(Consumer)
+# and converts it to Φ.hone.peek — analogous to lambda-to-map. peek is
+# a pass-through observer: the consumer is invoked with each element and
+# the same element is re-emitted downstream. The bridge-output, returned
+# and bridge-input are therefore all identical to the input type.
+name: lambda-to-peek
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.lambda,
+    class ↦ 𝑒-class,
+    method ↦ "accept",
+    interface ↦ "()Ljava/util/function/Consumer;",
+    lambda-signature ↦ "(Ljava/lang/Object;)V",
+    bridge-signature ↦ 𝑒-bridge-signature,
+    static ↦ 𝑒-static,
+    opcode ↦ 𝑒-opcode,
+    target ↦ ⟦
+      handle ↦ 𝑒-target-handle,
+      class ↦ 𝑒-target-class,
+      method ↦ 𝑒-target-method,
+      signature ↦ 𝑒-target-signature,
+      is-interface ↦ 𝑒-target-is-interface
+    ⟧,
+    stream ↦ ⟦
+      class ↦ "java/util/stream/Stream",
+      method ↦ "peek",
+      signature ↦ "(Ljava/util/function/Consumer;)Ljava/util/stream/Stream;"
+    ⟧
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.peek,
+    opcode ↦ 𝑒-opcode,
+    class ↦ 𝑒-class,
+    bridge-input ↦ 𝑒-bridge-input,
+    bridge-output ↦ 𝑒-bridge-input,
+    accepted ↦ 𝑒-accepted,
+    returned ↦ 𝑒-bridge-input,
+    static ↦ 𝑒-static,
+    target ↦ ⟦
+      handle ↦ 𝑒-target-handle,
+      class ↦ 𝑒-target-class,
+      method ↦ 𝑒-target-method,
+      signature ↦ 𝑒-target-signature,
+      is-interface ↦ 𝑒-target-is-interface
+    ⟧
+  ⟧
+when:
+  eq: [𝑒-static, '"true"']
+where:
+  - meta: 𝑒-bridge-input
+    function: sed
+    # "(Ljava/lang/Integer;)V"
+    args:
+      - 𝑒-bridge-signature
+      - '"s/\\((.*)\\)V/$1/g"'
+  - meta: 𝑒-target-class-pattern
+    function: sed
+    # java\\/lang\\/String
+    args:
+      - 𝑒-target-class
+      - '"s/\\//\\\\\\//g"'
+  - meta: 𝑒-virtual-accepted-pattern
+    function: concat
+    # s/\\(\\).+/Ljava\\/lang\\/String;/g
+    args: ['"s/\\(\\).+/L"', 𝑒-target-class-pattern, '";/g"']
+  - meta: 𝑒-bridge-input-pattern
+    function: sed
+    # Ljava\\/lang\\/String;
+    args:
+      - 𝑒-bridge-input
+      - '"s/\\//\\\\\\//g"'
+  - meta: 𝑒-java-object-pattern
+    function: concat
+    # s/\\(Ljava\\/lang\\/Object;\\).+/Ljava\\/lang\\/String;/g
+    args: ['"s/\\(Ljava\\/lang\\/Object;\\).+/"', 𝑒-bridge-input-pattern, '"/g"']
+  - meta: 𝑒-accepted
+    function: sed
+    args:
+      - 𝑒-target-signature
+      - 𝑒-virtual-accepted-pattern
+      - 𝑒-java-object-pattern
+      - '"s/\\((.+)\\).+/$1/g"'

--- a/src/main/resources/org/eolang/hone/rules/streams/281-insert-dup-before-filter.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/281-insert-dup-before-filter.phr
@@ -68,6 +68,7 @@ when:
         - eq: [𝜏-one, 'map']
         - eq: [𝜏-one, 'o-filter']
         - eq: [𝜏-one, 'p-filter']
+        - eq: [𝜏-one, 'peek']
     - or:
         - eq: [𝜏-two, 'o-filter']
         - eq: [𝜏-two, 'p-filter']

--- a/src/main/resources/org/eolang/hone/rules/streams/282-insert-dup-before-transformed-filter.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/282-insert-dup-before-transformed-filter.phr
@@ -76,6 +76,7 @@ when:
         - eq: [𝜏-one, 'map']
         - eq: [𝜏-one, 'o-filter']
         - eq: [𝜏-one, 'p-filter']
+        - eq: [𝜏-one, 'peek']
     - or:
         - eq: [𝜏-two, 'o-filter']
         - eq: [𝜏-two, 'p-filter']

--- a/src/main/resources/org/eolang/hone/rules/streams/307-peek-to-distill.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/307-peek-to-distill.phr
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Folds Φ.hone.peek into the uniform Φ.hone.distill form. The body
+# duplicates the element on the stack, invokes the consumer (which
+# pops one copy) and leaves the original element behind for the
+# downstream stage. The matching 209 rule restricts to static=true,
+# so this rule does not need to handle pre-distill (instance) targets.
+name: peek-to-distill
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.peek,
+    opcode ↦ 𝑒-opcode,
+    class ↦ 𝑒-class,
+    bridge-input ↦ 𝑒-bridge-input,
+    bridge-output ↦ 𝑒-bridge-output,
+    accepted ↦ 𝑒-accepted,
+    returned ↦ 𝑒-returned,
+    static ↦ 𝑒-static,
+    target ↦ ⟦
+      handle ↦ 𝑒-target-handle,
+      class ↦ 𝑒-target-class,
+      method ↦ 𝑒-target-method,
+      signature ↦ 𝑒-target-signature,
+      is-interface ↦ 𝑒-target-is-interface
+    ⟧
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.distill,
+    class ↦ 𝑒-class,
+    bridge-input ↦ 𝑒-bridge-input,
+    bridge-output ↦ 𝑒-bridge-output,
+    start ↦ "peek",
+    accepted ↦ 𝑒-accepted,
+    returned ↦ 𝑒-returned,
+    static ↦ 𝑒-static,
+    body ↦ ⟦
+      i1 ↦ ⟦ φ ↦ Φ.jeo.opcode.𝜏-dup ⟧,
+      i2 ↦ ⟦
+        φ ↦ Φ.jeo.opcode.𝜏-opcode,
+        i2 ↦ 𝑒-target-class,
+        i3 ↦ 𝑒-target-method,
+        i4 ↦ 𝑒-target-signature,
+        i5 ↦ 𝑒-target-is-interface
+      ⟧
+    ⟧
+  ⟧
+where:
+  - meta: 𝜏-opcode
+    function: tau
+    args: [𝑒-opcode]
+  - meta: 𝑒-dup
+    function: sed
+    args:
+      - 𝑒-bridge-input
+      - '"s/^[DJ]$/dup2/g"'
+      - '"s/^(B|C|F|I|S|Z|L.+;)$/dup/g"'
+  - meta: 𝜏-dup
+    function: tau
+    args: [𝑒-dup]

--- a/src/test/phino/209-lambda-to-peek.yml
+++ b/src/test/phino/209-lambda-to-peek.yml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 209 recognizes a Φ.hone.lambda whose stream call is Stream.peek with a
+# Consumer and rewrites it into the canonical Φ.hone.peek pragma — the
+# pass-through shape that 307 later folds into Φ.hone.distill.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/209-lambda-to-peek.phr
+input: |
+  {⟦
+    φ ↦ Φ.hone.lambda,
+    class ↦ "Foo",
+    method ↦ "accept",
+    interface ↦ "()Ljava/util/function/Consumer;",
+    lambda-signature ↦ "(Ljava/lang/Object;)V",
+    bridge-signature ↦ "(Ljava/lang/Integer;)V",
+    static ↦ "true",
+    opcode ↦ "invokestatic",
+    target ↦ ⟦
+      handle ↦ 6,
+      class ↦ "Foo",
+      method ↦ "lambda$main$0",
+      signature ↦ "(Ljava/lang/Integer;)V",
+      is-interface ↦ Φ.false
+    ⟧,
+    stream ↦ ⟦
+      class ↦ "java/util/stream/Stream",
+      method ↦ "peek",
+      signature ↦ "(Ljava/util/function/Consumer;)Ljava/util/stream/Stream;"
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      φ ↦ Φ.hone.peek,
+      opcode ↦ "invokestatic",
+      class ↦ "Foo",
+      bridge-input ↦ "Ljava/lang/Integer;",
+      bridge-output ↦ "Ljava/lang/Integer;",
+      accepted ↦ "Ljava/lang/Integer;",
+      returned ↦ "Ljava/lang/Integer;",
+      static ↦ "true",
+      target ↦ ⟦
+        handle ↦ 6,
+        class ↦ "Foo",
+        method ↦ "lambda$main$0",
+        signature ↦ "(Ljava/lang/Integer;)V",
+        is-interface ↦ Φ.false
+      ⟧
+    ⟧

--- a/src/test/phino/307-peek-to-distill.yml
+++ b/src/test/phino/307-peek-to-distill.yml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 307 folds Φ.hone.peek into the uniform Φ.hone.distill form. The body
+# duplicates the element on the stack and invokes the consumer, so the
+# original element is preserved for the downstream stage.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/307-peek-to-distill.phr
+input: |
+  {⟦
+    φ ↦ Φ.hone.peek,
+    opcode ↦ "invokestatic",
+    class ↦ "Foo",
+    bridge-input ↦ "Ljava/lang/Integer;",
+    bridge-output ↦ "Ljava/lang/Integer;",
+    accepted ↦ "Ljava/lang/Integer;",
+    returned ↦ "Ljava/lang/Integer;",
+    static ↦ "true",
+    target ↦ ⟦
+      handle ↦ 6,
+      class ↦ "Foo",
+      method ↦ "lambda$main$0",
+      signature ↦ "(Ljava/lang/Integer;)V",
+      is-interface ↦ Φ.false
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      φ ↦ Φ.hone.distill,
+      class ↦ "Foo",
+      bridge-input ↦ "Ljava/lang/Integer;",
+      bridge-output ↦ "Ljava/lang/Integer;",
+      start ↦ "peek",
+      accepted ↦ "Ljava/lang/Integer;",
+      returned ↦ "Ljava/lang/Integer;",
+      static ↦ "true",
+      body ↦ ⟦
+        i1 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+        i2 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokestatic,
+          i2 ↦ "Foo",
+          i3 ↦ "lambda$main$0",
+          i4 ↦ "(Ljava/lang/Integer;)V",
+          i5 ↦ Φ.false
+        ⟧
+      ⟧
+    ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams-all-ops.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-all-ops.yml
@@ -47,7 +47,7 @@ log:
   - "The result is 54"
 opcodes:
   invokespecial: 1
-  invokestatic: 22
+  invokestatic: 23
   invokevirtual: 11
-  invokedynamic: 16
+  invokedynamic: 15
   return: 12

--- a/src/test/resources/org/eolang/hone/optimize/streams-peeked.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-peeked.yml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Asserts that .peek() in a Stream pipeline is folded into the adjacent
+# operations and ultimately re-emitted as a single .mapMulti() — the
+# whole .map().peek() chain collapses into one invokedynamic. Without
+# the peek rules (209/307), peek would remain an opaque second
+# invokedynamic + invokeinterface Stream.peek, so invokedynamic would
+# be 2. The expectation of 1 proves both that peek was recognised and
+# that it fused with the preceding map.
+java: |
+  package peeked;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      long r = Stream.of(1, 2, 3, 4, 5)
+        .map(n -> n + 1)
+        .peek(n -> {})
+        .count();
+      System.out.printf("The result is %d\n", r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 5"
+opcodes:
+  invokedynamic: 1


### PR DESCRIPTION
Closes #537.

## Summary

Before, `Stream.peek(Consumer)` was unrecognized: the `Φ.hone.lambda`
emitted by 111 had `stream.method = "peek"` and flowed untouched through
the entire 2xx–5xx pipeline, leaving an opaque `invokedynamic` + raw
`invokeinterface Stream.peek` between any adjacent map/filter stages and
blocking fusion across it.

This patch teaches the pipeline how to fold peek into the uniform
`Φ.hone.distill` form so it can fuse with its neighbours, exactly the way
map and filter already do.

## Changes

- `streams/209-lambda-to-peek.phr` — recognises a `Stream.peek(Consumer)`
  lambda and rewrites it to `Φ.hone.peek`, analogous to `202-lambda-to-map`.
  Restricted to `static = "true"` targets (which is what 111 + 121 always
  produce for non-capturing lambdas; capturing peek lambdas stay raw, as
  before).
- `streams/307-peek-to-distill.phr` — folds `Φ.hone.peek` into the
  canonical `Φ.hone.distill` shape. The body is `dup; invokeXXX target`,
  so the element is preserved on the stack for the downstream stage while
  the consumer is invoked with a duplicate.
- `streams/281-insert-dup-before-filter.phr` and
  `streams/282-insert-dup-before-transformed-filter.phr` — add `peek` to
  the allowed `𝜏-one` operations so the pre-filter dup is still inserted
  when a `peek` sits immediately before a filter.
- `src/test/phino/209-lambda-to-peek.yml` and
  `src/test/phino/307-peek-to-distill.yml` — phino-level unit tests for
  the new rules.
- `src/test/resources/org/eolang/hone/optimize/streams-all-ops.yml` —
  bump expected `invokestatic` (22→23) and drop `invokedynamic` (16→15)
  to reflect the peek lambda being absorbed into the adjacent mapMulti.

## Test plan

- [ ] `phino` workflow exercises the two new phino tests.
- [ ] `deep` workflow re-checks the updated opcode tally for
      `streams-all-ops` once the PR lands on master.
- [ ] No existing test fixture changes are expected to break: peek is
      only used in `streams-all-ops.yml`, and `Foo.java` in the make
      workflow does not exercise peek.

https://claude.ai/code/session_01PtnoH3KL5kBcESPnGKBe81


---
_Generated by [Claude Code](https://claude.ai/code/session_01PtnoH3KL5kBcESPnGKBe81)_