### PR TITLE
#546: Recognize and eliminate Stream.skip(0L) as no-op

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/210-recognize-skip.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/210-recognize-skip.phr
@@ -34,7 +34,7 @@ result: |
     𝐵-before,
     𝜏-skip ↦ ⟦
       φ ↦ Φ.hone.skip,
-      class ↦ "java/util/stream/Stream",
+      stream-class ↦ "java/util/stream/Stream",
       count ↦ "0"
     ⟧,
     𝐵-after

--- a/src/main/resources/org/eolang/hone/rules/streams/210-recognize-skip.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/210-recognize-skip.phr
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Recognizes a stream `.skip(0L)` call — the `lconst_0` that pushes the
+# count followed by the `invokeinterface java/util/stream/Stream.skip:(J)
+# Ljava/util/stream/Stream;` — and abstracts the pair into a single
+# Φ.hone.skip block. This is the bytecode-level entry point for the skip
+# recognizer; it currently captures only the `lconst_0` push (i.e. the
+# canonical `.skip(0L)` idiom which is a no-op slice). The downstream
+# rule 311 folds Φ.hone.skip with count="0" away. Larger counts and the
+# primitive specializations (IntStream/LongStream/DoubleStream) will be
+# handled by sibling rules in follow-up work.
+name: recognize-skip
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-push ↦ ⟦
+      φ ↦ Φ.jeo.opcode.lconst_0,
+      ρ ↦ ∅
+    ⟧,
+    𝜏-invokeinterface ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      𝜏1 ↦ "java/util/stream/Stream",
+      𝜏2 ↦ "skip",
+      𝜏3 ↦ "(J)Ljava/util/stream/Stream;",
+      𝜏4 ↦ Φ.true,
+      ρ ↦ ∅
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-skip ↦ ⟦
+      φ ↦ Φ.hone.skip,
+      class ↦ "java/util/stream/Stream",
+      count ↦ "0"
+    ⟧,
+    𝐵-after
+  ⟧
+where:
+  - meta: 𝜏-skip
+    function: random-tau
+    args: [ '𝐵-before', '𝐵-after' ]

--- a/src/main/resources/org/eolang/hone/rules/streams/311-skip-zero-to-noop.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/311-skip-zero-to-noop.phr
@@ -14,7 +14,7 @@ pattern: |
     𝐵-before,
     𝜏-skip ↦ ⟦
       φ ↦ Φ.hone.skip,
-      class ↦ 𝑒-class,
+      stream-class ↦ 𝑒-stream-class,
       count ↦ "0",
       ρ ↦ ∅
     ⟧,

--- a/src/main/resources/org/eolang/hone/rules/streams/311-skip-zero-to-noop.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/311-skip-zero-to-noop.phr
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Eliminates Φ.hone.skip when its count is "0" — `.skip(0L)` discards
+# nothing and is semantically a no-op slice, so the whole block is
+# replaced with a single Φ.jeo.opcode.nop. The matching 210 rule only
+# produces count="0", so this is currently the only fold for skip;
+# future rules will handle non-zero counters by folding into a
+# state-carrying distill variant.
+name: skip-zero-to-noop
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-skip ↦ ⟦
+      φ ↦ Φ.hone.skip,
+      class ↦ 𝑒-class,
+      count ↦ "0",
+      ρ ↦ ∅
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-nop ↦ ⟦
+      φ ↦ Φ.jeo.opcode.nop
+    ⟧,
+    𝐵-after
+  ⟧
+where:
+  - meta: 𝜏-nop
+    function: random-tau
+    args: [ '𝐵-before', '𝐵-after' ]

--- a/src/test/phino/210-recognize-skip.yml
+++ b/src/test/phino/210-recognize-skip.yml
@@ -27,7 +27,7 @@ expected:
       𝐵-before,
       𝜏-skip ↦ ⟦
         φ ↦ Φ.hone.skip,
-        class ↦ "java/util/stream/Stream",
+        stream-class ↦ "java/util/stream/Stream",
         count ↦ "0"
       ⟧,
       𝐵-after

--- a/src/test/phino/210-recognize-skip.yml
+++ b/src/test/phino/210-recognize-skip.yml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 210 recognizes the bytecode pair `lconst_0` + `invokeinterface
+# java/util/stream/Stream.skip:(J)Ljava/util/stream/Stream;` and folds
+# it into a single Φ.hone.skip block carrying count="0". This is the
+# canonical `.skip(0L)` idiom that the next stage (311) eliminates.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/210-recognize-skip.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      i1 ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_0 ⟧,
+      i2 ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokeinterface,
+        v1 ↦ "java/util/stream/Stream",
+        v2 ↦ "skip",
+        v3 ↦ "(J)Ljava/util/stream/Stream;",
+        v4 ↦ Φ.true
+      ⟧
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      𝐵-before,
+      𝜏-skip ↦ ⟦
+        φ ↦ Φ.hone.skip,
+        class ↦ "java/util/stream/Stream",
+        count ↦ "0"
+      ⟧,
+      𝐵-after
+    ⟧

--- a/src/test/phino/311-skip-zero-to-noop.yml
+++ b/src/test/phino/311-skip-zero-to-noop.yml
@@ -14,7 +14,7 @@ input: |
     body ↦ ⟦
       i1 ↦ ⟦
         φ ↦ Φ.hone.skip,
-        class ↦ "java/util/stream/Stream",
+        stream-class ↦ "java/util/stream/Stream",
         count ↦ "0"
       ⟧
     ⟧

--- a/src/test/phino/311-skip-zero-to-noop.yml
+++ b/src/test/phino/311-skip-zero-to-noop.yml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 311 folds away Φ.hone.skip with count="0" — the `.skip(0L)` idiom —
+# replacing the whole block with a Φ.jeo.opcode.nop. The matching 210
+# rule only emits count="0", so this is currently the only fold for
+# skip; higher counts will be handled by future state-carrying distill
+# variants.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/311-skip-zero-to-noop.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      i1 ↦ ⟦
+        φ ↦ Φ.hone.skip,
+        class ↦ "java/util/stream/Stream",
+        count ↦ "0"
+      ⟧
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      𝐵-before,
+      𝜏-nop ↦ ⟦
+        φ ↦ Φ.jeo.opcode.nop
+      ⟧,
+      𝐵-after
+    ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams-skipped.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-skipped.yml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Asserts that `.skip(0L)` in a Stream pipeline is eliminated as a
+# no-op. The recognition rule (210) folds the `lconst_0 +
+# invokeinterface Stream.skip:(J)Ljava/util/stream/Stream;` pair into a
+# single Φ.hone.skip block, and the matching fold (311) then replaces
+# it with Φ.jeo.opcode.nop. Without the rules, the skip stage would
+# remain an opaque pass-through invokeinterface.
+java: |
+  package skipped;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      long r = Stream.of(1, 2, 3, 4, 5)
+        .skip(0L)
+        .count();
+      System.out.printf("The result is %d\n", r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 5"

--- a/src/test/resources/org/eolang/hone/optimize/streams-skipped.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-skipped.yml
@@ -23,3 +23,5 @@ log:
   - "Finished rewriting 1 file"
   - "BUILD SUCCESS"
   - "The result is 5"
+opcodes:
+  invokeinterface: 1


### PR DESCRIPTION
## Summary

Closes #546 (partially). Adds the bytecode-level recognizer for `Stream.skip(long)` and folds the canonical `.skip(0L)` idiom away.

- **`210-recognize-skip.phr`** — matches the pair `lconst_0` + `invokeinterface java/util/stream/Stream.skip:(J)Ljava/util/stream/Stream;` and abstracts it into a single `Φ.hone.skip` block carrying `count="0"`.
- **`311-skip-zero-to-noop.phr`** — folds `Φ.hone.skip(count="0")` into `Φ.jeo.opcode.nop`. `.skip(0L)` discards nothing, so the whole stage collapses.
- **Phino unit tests** for both rules, plus the integration pack `streams-skipped.yml` that exercises a `Stream.of(...).skip(0L).count()` pipeline end-to-end.

## Scope

The issue sketches a full state-carrying distill variant covering arbitrary counts and the primitive specializations (`IntStream`/`LongStream`/`DoubleStream`). This PR is the first slice: it lands the recognizer at the 2xx stage with the `Φ.hone.skip` form requested in the sketch, and the only fold currently emitted is the zero-count one. Non-zero counters and primitive-stream skip are left to follow-up rules — those need the state-carrying distill machinery referenced in #540, which is a larger change than belongs in one PR.

## Test plan

- [x] `bash src/test/phino/run.sh` — all 13 phino tests pass (the existing 11 plus the two new ones).
- [x] `yamllint` clean on the new files (matches `.yamllint.yml` config).
- [ ] CI runs the Docker-backed end-to-end pack `streams-skipped.yml` against a real build to confirm the optimized class still prints `The result is 5`.