### PR TITLE
#551: broaden Stream pipeline YAML test coverage

### DIFF
--- a/src/test/resources/org/eolang/hone/optimize/streams-any-match.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-any-match.yml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Confirms that a Stream pipeline terminating in a boolean-returning
+# short-circuit operation (anyMatch) survives the roundtrip. anyMatch
+# takes a Predicate so the lambda must be recognised by the same 201
+# rule as filter, but it must not be folded into the filter chain
+# because that would change short-circuiting semantics.
+java: |
+  package anymatch;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      boolean r = Stream.of(1, 2, 3, 4, 5)
+        .filter(n -> n > 0)
+        .map(n -> n + 1)
+        .anyMatch(n -> n > 4);
+      System.out.printf("The result is %b\n", r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is true"

--- a/src/test/resources/org/eolang/hone/optimize/streams-arrays-stream.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-arrays-stream.yml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# The source of the pipeline is Arrays.stream(int[]) — a different
+# entry point from Stream.of / IntStream.of, since it desugars to
+# Arrays.stream(int[], int, int). The rest of the chain is map +
+# filter + sum, exercising primitive int lowering on a non-Stream.of
+# source.
+java: |
+  package arraysstream;
+  import java.util.Arrays;
+  public class X {
+    public static void main(String[] a) {
+      int[] input = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+      int r = Arrays.stream(input)
+        .filter(n -> n % 3 == 0)
+        .map(n -> n * 10)
+        .sum();
+      System.out.printf("The result is %d\n", r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 180"

--- a/src/test/resources/org/eolang/hone/optimize/streams-bound-method-ref.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-bound-method-ref.yml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Bound (unbound-instance) method reference: `String::length` is a
+# Function<String,Integer> whose receiver is the stream element
+# rather than a captured object. The bootstrap method uses
+# H_INVOKEVIRTUAL with no captured argument — different from a
+# bound instance reference and from a static method reference. The
+# rule pipeline must keep this shape so map() receives the right
+# Function instance.
+java: |
+  package boundref;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      int r = Stream.of("a", "bb", "ccc", "dddd", "eeeee")
+        .filter(s -> s.length() > 1)
+        .map(String::length)
+        .mapToInt(Integer::intValue)
+        .sum();
+      System.out.printf("The result is %d\n", r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 14"

--- a/src/test/resources/org/eolang/hone/optimize/streams-captured-object.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-captured-object.yml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A lambda that captures a reference-typed local — here a List used
+# as a lookup table. The bootstrap method binds the List reference
+# at the indy site and the synthetic lambda body invokes contains()
+# on it. The rule pipeline must keep the capture aligned so the
+# predicate sees the populated list, not an empty default.
+java: |
+  package capturedobject;
+  import java.util.*;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      List<Integer> allowed = Arrays.asList(2, 4, 6, 8);
+      int r = Stream.of(1, 2, 3, 4, 5, 6, 7, 8, 9)
+        .filter(n -> allowed.contains(n))
+        .map(n -> n * 10)
+        .mapToInt(Integer::intValue)
+        .sum();
+      System.out.printf("The result is %d\n", r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 200"

--- a/src/test/resources/org/eolang/hone/optimize/streams-closure-array.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-closure-array.yml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# The classic "effectively-final" workaround: a one-cell int[] used
+# as a mutable counter from inside a Stream lambda. The lambda
+# captures a reference to the array (not the int) and mutates it on
+# every element. The rule pipeline must preserve both the capture
+# and the side-effecting aastore/iaload sequence so the final
+# counter value is the iteration count.
+java: |
+  package closurearray;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      int[] counter = {0};
+      Stream.of(1, 2, 3, 4, 5)
+        .filter(n -> n > 1)
+        .map(n -> {
+          counter[0] += n;
+          return n;
+        })
+        .mapToInt(Integer::intValue)
+        .sum();
+      System.out.printf("The result is %d\n", counter[0]);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 14"

--- a/src/test/resources/org/eolang/hone/optimize/streams-closure-field.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-closure-field.yml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Stream pipeline driven from an instance method whose lambdas read
+# an instance field via the enclosing `this`. Each lambda receives
+# `this` as its first synthetic argument; the synthetic method then
+# performs a getfield on it. The rule pipeline must keep the
+# implicit-this capture intact for both the filter and the map
+# stages so the predicate sees the field value the caller wrote.
+java: |
+  package closurefield;
+  import java.util.stream.Stream;
+  public class X {
+    private final int factor;
+    private final int floor;
+    X(int f, int fl) { this.factor = f; this.floor = fl; }
+    int run() {
+      return Stream.of(1, 2, 3, 4, 5)
+        .filter(n -> n > this.floor)
+        .map(n -> n * this.factor)
+        .mapToInt(Integer::intValue)
+        .sum();
+    }
+    public static void main(String[] a) {
+      int r = new X(7, 2).run();
+      System.out.printf("The result is %d\n", r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 84"

--- a/src/test/resources/org/eolang/hone/optimize/streams-closure-local.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-closure-local.yml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A lambda that closes over a local (effectively-final) variable.
+# The closure becomes a synthetic method whose first argument is the
+# captured value and whose remaining arguments are the SAM
+# parameters; the bootstrap method binds the captured value at the
+# invokedynamic site. The rule pipeline must keep the capture wired
+# correctly so the predicate compares against the captured threshold
+# rather than a default value.
+java: |
+  package closurelocal;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      int threshold = 3;
+      int offset = 100;
+      int r = Stream.of(1, 2, 3, 4, 5, 6)
+        .filter(n -> n > threshold)
+        .map(n -> n + offset)
+        .mapToInt(Integer::intValue)
+        .sum();
+      System.out.printf("The result is %d\n", r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 315"

--- a/src/test/resources/org/eolang/hone/optimize/streams-collect-joining.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-collect-joining.yml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A Stream<String> pipeline whose terminal operation is
+# Collectors.joining. The element type is reference (String), the
+# intermediate map produces another reference, and the collector
+# threads a Function through CharSequence handling. The roundtrip
+# must keep the joined string identical to the unoptimised one.
+java: |
+  package joining;
+  import java.util.stream.*;
+  public class X {
+    public static void main(String[] a) {
+      String r = Stream.of("apple", "banana", "cherry", "date")
+        .filter(s -> s.length() > 4)
+        .map(String::toUpperCase)
+        .collect(Collectors.joining("-"));
+      System.out.printf("The result is %s\n", r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is APPLE-BANANA-CHERRY"

--- a/src/test/resources/org/eolang/hone/optimize/streams-collect-list.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-collect-list.yml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Confirms that a Stream pipeline terminating in collect(toList())
+# survives the roundtrip. The List size is printed so that the
+# correctness of the filter/map chain is observable; the optimization
+# pipeline must not corrupt the collector's handle on the resulting
+# list type.
+java: |
+  package collectlist;
+  import java.util.*;
+  import java.util.stream.*;
+  public class X {
+    public static void main(String[] a) {
+      List<Integer> r = Stream.of(1, 2, 3, 4, 5, 6)
+        .filter(n -> n > 2)
+        .map(n -> n * 10)
+        .collect(Collectors.toList());
+      System.out.printf("The result is %d\n", r.size());
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 4"

--- a/src/test/resources/org/eolang/hone/optimize/streams-collect-set.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-collect-set.yml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# collect(Collectors.toSet()) deduplicates as a side-effect of the
+# collector, not of the stream operations. The test feeds duplicates
+# through map and filter and asserts that the resulting Set size
+# matches the deduplicated count — proving the collector handle
+# survived the rewrite intact.
+java: |
+  package collectset;
+  import java.util.Set;
+  import java.util.stream.*;
+  public class X {
+    public static void main(String[] a) {
+      Set<Integer> r = Stream.of(1, 2, 2, 3, 3, 3, 4, 4, 4, 4)
+        .filter(n -> n > 1)
+        .map(n -> n * 2)
+        .collect(Collectors.toSet());
+      System.out.printf("The result is %d\n", r.size());
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 3"

--- a/src/test/resources/org/eolang/hone/optimize/streams-concat.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-concat.yml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Stream.concat takes two streams (each pre-built with its own map
+# pipeline) and produces a single stream. The rule pipeline therefore
+# sees three independent lambda groups in the same method — two
+# pre-concat and one post-concat. They must each be rewritten
+# correctly without crossing references.
+java: |
+  package concat;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      int r = Stream.concat(
+          Stream.of(1, 2, 3).map(n -> n * 10),
+          Stream.of(4, 5, 6).map(n -> n * 100)
+        )
+        .filter(n -> n > 15)
+        .mapToInt(Integer::intValue)
+        .sum();
+      System.out.printf("The result is %d\n", r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 1550"

--- a/src/test/resources/org/eolang/hone/optimize/streams-double-stream.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-double-stream.yml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Drives a DoubleStream through map/filter/sum to confirm that the
+# double-primitive lowering path survives the roundtrip. The integer
+# part of the sum is asserted, so the test is insensitive to any
+# floating-point rounding that may occur during jeo-disassemble or
+# the rewriting itself.
+java: |
+  package doublestream;
+  import java.util.stream.DoubleStream;
+  public class X {
+    public static void main(String[] a) {
+      double r = DoubleStream.of(1.5, 2.5, 3.5, 4.5, 5.5)
+        .filter(d -> d > 2.0)
+        .map(d -> d + 1.0)
+        .sum();
+      System.out.printf("The result is %d\n", (int) r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 20"

--- a/src/test/resources/org/eolang/hone/optimize/streams-find-first.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-find-first.yml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Drives a Stream pipeline whose terminal operation is findFirst() —
+# a short-circuiting Optional-returning terminal. The pipeline filters
+# out small values and then doubles the rest; findFirst() returns the
+# first value after both transforms, which proves that map runs in
+# the expected order with respect to filter even after the rewrite.
+java: |
+  package findfirst;
+  import java.util.Optional;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      Optional<Integer> r = Stream.of(1, 2, 3, 4, 5)
+        .filter(n -> n > 2)
+        .map(n -> n * 10)
+        .findFirst();
+      System.out.printf("The result is %d\n", r.orElse(-1));
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 30"

--- a/src/test/resources/org/eolang/hone/optimize/streams-foreach.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-foreach.yml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Verifies a Stream pipeline whose terminal operation is forEach with
+# a side-effecting Consumer lambda. forEach is special-cased by the
+# stream API because it accepts a Consumer; the lambda must remain
+# attached to its captured StringBuilder after rewriting so the
+# observed result reflects the correct iteration order.
+java: |
+  package foreach;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      StringBuilder sb = new StringBuilder();
+      Stream.of(1, 2, 3, 4, 5)
+        .filter(n -> n % 2 == 1)
+        .map(n -> n * n)
+        .forEach(n -> sb.append(n).append(','));
+      System.out.printf("The result is %s\n", sb.toString());
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 1,9,25,"

--- a/src/test/resources/org/eolang/hone/optimize/streams-instance-method-ref.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-instance-method-ref.yml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A method reference bound to an instance receiver, captured by the
+# lambda. The bootstrap method has to carry the receiver through, so
+# the lowering of the invokedynamic differs from the static-method
+# reference case. The rule pipeline must preserve the capture so the
+# observable result includes the prefix from the captured object.
+java: |
+  package instanceref;
+  import java.util.stream.Stream;
+  public class X {
+    private final String prefix;
+    X(String p) { this.prefix = p; }
+    String decorate(Integer n) { return this.prefix + n; }
+    public static void main(String[] a) {
+      X self = new X(">");
+      String r = Stream.of(1, 2, 3, 4)
+        .filter(n -> n > 1)
+        .map(self::decorate)
+        .reduce("", (x, y) -> x + y);
+      System.out.printf("The result is %s\n", r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is >2>3>4"

--- a/src/test/resources/org/eolang/hone/optimize/streams-int-range.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-int-range.yml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Exercises an IntStream pipeline whose source is IntStream.range(),
+# i.e. an infinite-style bounded primitive source. Confirms that the
+# 2xx recognition rules pick up primitive map/filter on int and the
+# 5xx emission rules lower the chain back to invokedynamic without
+# changing the observable result.
+java: |
+  package intrange;
+  import java.util.stream.IntStream;
+  public class X {
+    public static void main(String[] a) {
+      int r = IntStream.range(0, 10)
+        .filter(n -> n % 2 == 0)
+        .map(n -> n * n)
+        .sum();
+      System.out.printf("The result is %d\n", r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 120"

--- a/src/test/resources/org/eolang/hone/optimize/streams-iterate-limit.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-iterate-limit.yml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A potentially-infinite source: Stream.iterate. The pipeline must
+# remain lazy after rewriting — if any rule were to materialise the
+# entire iterate() output before the limit() takes effect, the JVM
+# would hang. The presence of map afterwards confirms that lazy
+# evaluation order is preserved past intermediate rewrites.
+java: |
+  package iterate;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      int r = Stream.iterate(1, n -> n + 2)
+        .limit(5)
+        .filter(n -> n > 1)
+        .map(n -> n * 10)
+        .mapToInt(Integer::intValue)
+        .sum();
+      System.out.printf("The result is %d\n", r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 240"

--- a/src/test/resources/org/eolang/hone/optimize/streams-long-stream.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-long-stream.yml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Drives a LongStream through map/filter/sum to verify that the
+# primitive-long flavour of the lambda lowering rules (204 for map,
+# 203 for filter) recognises and rewrites the chain. The sum of the
+# original elements is 30; selecting only the even ones (2,4,6,8,10)
+# and doubling them gives 60.
+java: |
+  package longstream;
+  import java.util.stream.LongStream;
+  public class X {
+    public static void main(String[] a) {
+      long r = LongStream.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L)
+        .filter(n -> n % 2 == 0)
+        .map(n -> n * 2)
+        .sum();
+      System.out.printf("The result is %d\n", r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 60"

--- a/src/test/resources/org/eolang/hone/optimize/streams-method-ref-arg.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-method-ref-arg.yml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A Stream pipeline whose Function and Predicate are passed in as
+# parameters to the enclosing method. From the lambda's point of
+# view, the predicate is just a captured local — but its origin
+# (caller's method reference, then passed through one stack frame)
+# exercises the bootstrap method's handling of non-literal
+# functional arguments. The rule pipeline must not specialise to a
+# specific implementation method when the lambda body is opaque.
+java: |
+  package methodrefarg;
+  import java.util.function.*;
+  import java.util.stream.Stream;
+  public class X {
+    static int run(Predicate<Integer> p, Function<Integer, Integer> f) {
+      return Stream.of(1, 2, 3, 4, 5)
+        .filter(p)
+        .map(f)
+        .mapToInt(Integer::intValue)
+        .sum();
+    }
+    static boolean keep(Integer n) { return n > 2; }
+    static Integer triple(Integer n) { return n * 3; }
+    public static void main(String[] a) {
+      int r = run(X::keep, X::triple);
+      System.out.printf("The result is %d\n", r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 36"

--- a/src/test/resources/org/eolang/hone/optimize/streams-method-refs.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-method-refs.yml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Drives a Stream pipeline whose every intermediate operation uses a
+# method reference rather than a lambda body. Method references can
+# produce no synthetic 'lambda$' bridge methods at all when their
+# signature is already exact, so the rule pipeline must cope with
+# bootstrap method calls whose implementation is a direct
+# H_INVOKESTATIC/H_INVOKEVIRTUAL handle.
+java: |
+  package methodrefs;
+  import java.util.stream.Stream;
+  public class X {
+    static boolean isOdd(int n) { return (n & 1) == 1; }
+    static int triple(int n) { return n * 3; }
+    public static void main(String[] a) {
+      int r = Stream.of(1, 2, 3, 4, 5, 6)
+        .mapToInt(Integer::intValue)
+        .filter(X::isOdd)
+        .map(X::triple)
+        .sum();
+      System.out.printf("The result is %d\n", r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 27"

--- a/src/test/resources/org/eolang/hone/optimize/streams-min-max.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-min-max.yml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Drives a Stream<Integer> through map then a terminal min() that
+# takes a Comparator. The Comparator method reference is itself a
+# bootstrap method call, so this test exercises a different shape
+# from the more common Predicate / Function lambdas; the rule
+# pipeline must leave the Comparator handle intact.
+java: |
+  package minmax;
+  import java.util.Comparator;
+  import java.util.Optional;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      Optional<Integer> r = Stream.of(5, 3, 8, 1, 9, 2)
+        .filter(n -> n > 0)
+        .map(n -> n + 100)
+        .min(Comparator.naturalOrder());
+      System.out.printf("The result is %d\n", r.orElse(-1));
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 101"

--- a/src/test/resources/org/eolang/hone/optimize/streams-multiple-pipelines.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-multiple-pipelines.yml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Two independent Stream pipelines in the same method. Each lambda
+# generates its own synthetic lambda$main$N method, so the rule
+# pipeline must rewrite both correctly without crossing references —
+# in particular, 511 must produce two distinct private static helper
+# methods rather than collapsing them.
+java: |
+  package multiple;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      int r1 = Stream.of(1, 2, 3, 4)
+        .filter(n -> n > 1)
+        .map(n -> n * 2)
+        .mapToInt(Integer::intValue)
+        .sum();
+      int r2 = Stream.of(10, 20, 30)
+        .filter(n -> n < 25)
+        .map(n -> n + 5)
+        .mapToInt(Integer::intValue)
+        .sum();
+      System.out.printf("The result is %d\n", r1 + r2);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 58"

--- a/src/test/resources/org/eolang/hone/optimize/streams-nested-flatmap.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-nested-flatmap.yml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A flatMap whose mapper is itself a Stream pipeline. The inner
+# pipeline's lambdas and the outer pipeline's lambdas live side by
+# side in the same enclosing method, so the rule pipeline must
+# rewrite each one without confusing their captured locals or
+# bootstrap method references.
+java: |
+  package nestedflatmap;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      int r = Stream.of(1, 2, 3)
+        .flatMap(n -> Stream.of(n, n * 10)
+          .filter(m -> m > 1)
+          .map(m -> m + 1))
+        .mapToInt(Integer::intValue)
+        .sum();
+      System.out.printf("The result is %d\n", r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 70"

--- a/src/test/resources/org/eolang/hone/optimize/streams-reduce.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-reduce.yml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Confirms that a Stream pipeline terminating in reduce() with an
+# identity value and a method-reference accumulator survives the
+# roundtrip. Integer::sum is a static method reference that turns
+# into a lambda metafactory bootstrap call, so this test cross-checks
+# that 111 + 121 + 701 chain through cleanly even when the lambda is
+# fed to a non-intermediate stage.
+java: |
+  package reduce;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      int r = Stream.of(1, 2, 3, 4, 5)
+        .filter(n -> n > 1)
+        .map(n -> n + 10)
+        .reduce(0, Integer::sum);
+      System.out.printf("The result is %d\n", r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 54"

--- a/src/test/resources/org/eolang/hone/optimize/streams-static-field.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-static-field.yml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Lambdas that read a private static field of the enclosing class.
+# A static-field read does not require a captured `this`, so the
+# synthetic lambda method has the same arity as the SAM and the
+# bootstrap method binds no extra arguments. The rule pipeline must
+# leave the getstatic in place so the predicate and the transform
+# both see the same constant.
+java: |
+  package staticfield;
+  import java.util.stream.Stream;
+  public class X {
+    private static final int LIMIT = 4;
+    private static final int BIAS = 1000;
+    public static void main(String[] a) {
+      int r = Stream.of(1, 2, 3, 4, 5, 6, 7)
+        .filter(n -> n < LIMIT)
+        .map(n -> n + BIAS)
+        .mapToInt(Integer::intValue)
+        .sum();
+      System.out.printf("The result is %d\n", r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 3006"

--- a/src/test/resources/org/eolang/hone/optimize/streams-static-helper-call.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-static-helper-call.yml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Lambda bodies (not method references) that delegate to a private
+# static helper. Javac compiles the lambda body into a synthetic
+# private static `lambda$main$N` method that ends with an
+# invokestatic to the helper. The rule pipeline's 511 stage extracts
+# the synthetic body into the same shape; the helper invocation must
+# survive without being inlined or rewritten away.
+java: |
+  package statichelper;
+  import java.util.stream.Stream;
+  public class X {
+    private static boolean isPrime(int n) {
+      if (n < 2) {
+        return false;
+      }
+      for (int i = 2; i * i <= n; ++i) {
+        if (n % i == 0) {
+          return false;
+        }
+      }
+      return true;
+    }
+    private static int square(int n) {
+      return n * n;
+    }
+    public static void main(String[] a) {
+      int r = Stream.of(1, 2, 3, 4, 5, 6, 7, 8, 9)
+        .filter(n -> isPrime(n))
+        .map(n -> square(n))
+        .mapToInt(Integer::intValue)
+        .sum();
+      System.out.printf("The result is %d\n", r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 87"

--- a/src/test/resources/org/eolang/hone/optimize/streams-to-array.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-to-array.yml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Terminates a Stream<Integer> pipeline with toArray(IntFunction).
+# The IntFunction generator (Integer[]::new) is yet another lambda
+# metafactory shape — a constructor reference — and must survive the
+# rewrite without losing the Integer[] return type.
+java: |
+  package toarray;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      Integer[] r = Stream.of(1, 2, 3, 4)
+        .filter(n -> n > 1)
+        .map(n -> n * n)
+        .toArray(Integer[]::new);
+      System.out.printf("The result is %d\n", r.length);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 3"


### PR DESCRIPTION
Adds 19 new end-to-end YAML test packs under
`src/test/resources/org/eolang/hone/optimize/`. Each pack
compiles a small Java program that exercises a different
shape of the `java.util.stream` API, runs it through the
`streams/*` rule pipeline, and asserts on the program's
post-optimization output.

The packs cover primitive stream sources (`IntStream.range`,
`LongStream.of`, `DoubleStream.of`, `Arrays.stream`), varied
terminal operations (`reduce`, `forEach`, `findFirst`,
`anyMatch`, `min`, `toArray`, and three flavours of
`collect`), every kind of method reference (static,
instance-bound, and constructor), two independent pipelines
in one method, a `flatMap` whose mapper is itself a stream,
plus `Stream.concat` and `Stream.iterate` sources. Every
fixture invokes `.map` or `.filter` so the default `grep-in`
pattern matches and the rule pipeline actually fires.

Closes #551.