### PR TITLE
Recognize Stream.sorted(Comparator) as a barrier pragma

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/212-lambda-to-sorted.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/212-lambda-to-sorted.phr
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Recognizes a Φ.hone.lambda whose stream call is Stream.sorted(Comparator)
+# and converts it into a Φ.hone.sorted pragma — analogous to 213
+# (lambda-to-take-while). Sorted is a fully-buffering stateful barrier:
+# every upstream element must be consumed before any downstream element
+# can be emitted, so the operation cannot be folded into the running
+# distill chain the way a stateless map/filter/peek can. Recognising it
+# gives the operation a stable pragma name so the surrounding 3xx/4xx
+# phases can fuse runs of stateless ops on each side of the barrier
+# independently. Any Φ.hone.sorted left after the recognise/fuse phases
+# is lowered back to a Φ.hone.lambda by 607 so that 7xx can emit valid
+# bytecode. See issue #549.
+name: lambda-to-sorted
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.lambda,
+    class ↦ 𝑒-class,
+    method ↦ "compare",
+    interface ↦ "()Ljava/util/function/Comparator;",
+    lambda-signature ↦ "(Ljava/lang/Object;Ljava/lang/Object;)I",
+    bridge-signature ↦ 𝑒-bridge-signature,
+    static ↦ 𝑒-static,
+    opcode ↦ 𝑒-opcode,
+    target ↦ ⟦
+      handle ↦ 𝑒-target-handle,
+      class ↦ 𝑒-target-class,
+      method ↦ 𝑒-target-method,
+      signature ↦ 𝑒-target-signature,
+      is-interface ↦ 𝑒-target-is-interface
+    ⟧,
+    stream ↦ ⟦
+      class ↦ "java/util/stream/Stream",
+      method ↦ "sorted",
+      signature ↦ "(Ljava/util/function/Comparator;)Ljava/util/stream/Stream;"
+    ⟧
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.sorted,
+    opcode ↦ 𝑒-opcode,
+    class ↦ 𝑒-class,
+    bridge-signature ↦ 𝑒-bridge-signature,
+    static ↦ 𝑒-static,
+    target ↦ ⟦
+      handle ↦ 𝑒-target-handle,
+      class ↦ 𝑒-target-class,
+      method ↦ 𝑒-target-method,
+      signature ↦ 𝑒-target-signature,
+      is-interface ↦ 𝑒-target-is-interface
+    ⟧
+  ⟧

--- a/src/main/resources/org/eolang/hone/rules/streams/607-sorted-to-lambda.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/607-sorted-to-lambda.phr
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Inverse of 212: turns a Φ.hone.sorted pragma back into a Φ.hone.lambda
+# with the original Stream.sorted(Comparator) invokeinterface call. Fires
+# for any Φ.hone.sorted that has not been folded into a distill or fused
+# with a neighbouring operation by an earlier phase, ensuring the pragma
+# is always lowered to valid bytecode by 7xx. See issue #549.
+name: sorted-to-lambda
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.sorted,
+    opcode ↦ 𝑒-opcode,
+    class ↦ 𝑒-class,
+    bridge-signature ↦ 𝑒-bridge-signature,
+    static ↦ 𝑒-static,
+    target ↦ ⟦
+      handle ↦ 𝑒-target-handle,
+      class ↦ 𝑒-target-class,
+      method ↦ 𝑒-target-method,
+      signature ↦ 𝑒-target-signature,
+      is-interface ↦ 𝑒-target-is-interface
+    ⟧
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.lambda,
+    class ↦ 𝑒-class,
+    method ↦ "compare",
+    interface ↦ "()Ljava/util/function/Comparator;",
+    lambda-signature ↦ "(Ljava/lang/Object;Ljava/lang/Object;)I",
+    bridge-signature ↦ 𝑒-bridge-signature,
+    static ↦ 𝑒-static,
+    opcode ↦ 𝑒-opcode,
+    target ↦ ⟦
+      handle ↦ 𝑒-target-handle,
+      class ↦ 𝑒-target-class,
+      method ↦ 𝑒-target-method,
+      signature ↦ 𝑒-target-signature,
+      is-interface ↦ 𝑒-target-is-interface
+    ⟧,
+    stream ↦ ⟦
+      class ↦ "java/util/stream/Stream",
+      method ↦ "sorted",
+      signature ↦ "(Ljava/util/function/Comparator;)Ljava/util/stream/Stream;"
+    ⟧
+  ⟧

--- a/src/test/phino/212-lambda-to-sorted.yml
+++ b/src/test/phino/212-lambda-to-sorted.yml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 212 recognizes a Φ.hone.lambda whose stream call is Stream.sorted with
+# a Comparator (the only sorted overload that carries a lambda) and
+# converts it into a Φ.hone.sorted barrier pragma. See issue #549.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/212-lambda-to-sorted.phr
+input: |
+  {⟦
+    φ ↦ Φ.hone.lambda,
+    class ↦ "Foo",
+    method ↦ "compare",
+    interface ↦ "()Ljava/util/function/Comparator;",
+    lambda-signature ↦ "(Ljava/lang/Object;Ljava/lang/Object;)I",
+    bridge-signature ↦ "(Ljava/lang/Integer;Ljava/lang/Integer;)I",
+    static ↦ "true",
+    opcode ↦ "invokestatic",
+    target ↦ ⟦
+      handle ↦ 6,
+      class ↦ "Foo",
+      method ↦ "lambda$main$0",
+      signature ↦ "(Ljava/lang/Integer;Ljava/lang/Integer;)I",
+      is-interface ↦ Φ.false
+    ⟧,
+    stream ↦ ⟦
+      class ↦ "java/util/stream/Stream",
+      method ↦ "sorted",
+      signature ↦ "(Ljava/util/function/Comparator;)Ljava/util/stream/Stream;"
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      φ ↦ Φ.hone.sorted,
+      opcode ↦ "invokestatic",
+      class ↦ "Foo",
+      bridge-signature ↦ "(Ljava/lang/Integer;Ljava/lang/Integer;)I",
+      static ↦ "true",
+      target ↦ ⟦
+        handle ↦ 6,
+        class ↦ "Foo",
+        method ↦ "lambda$main$0",
+        signature ↦ "(Ljava/lang/Integer;Ljava/lang/Integer;)I",
+        is-interface ↦ Φ.false
+      ⟧
+    ⟧

--- a/src/test/phino/607-sorted-to-lambda.yml
+++ b/src/test/phino/607-sorted-to-lambda.yml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 607 unrecognises a Φ.hone.sorted pragma back into a Φ.hone.lambda with
+# the original Stream.sorted(Comparator) invokeinterface call, so that
+# the 7xx phase can lower it to invokedynamic + invokeinterface. See
+# issue #549.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/607-sorted-to-lambda.phr
+input: |
+  {⟦
+    φ ↦ Φ.hone.sorted,
+    opcode ↦ "invokestatic",
+    class ↦ "Foo",
+    bridge-signature ↦ "(Ljava/lang/Integer;Ljava/lang/Integer;)I",
+    static ↦ "true",
+    target ↦ ⟦
+      handle ↦ 6,
+      class ↦ "Foo",
+      method ↦ "lambda$main$0",
+      signature ↦ "(Ljava/lang/Integer;Ljava/lang/Integer;)I",
+      is-interface ↦ Φ.false
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      φ ↦ Φ.hone.lambda,
+      class ↦ "Foo",
+      method ↦ "compare",
+      interface ↦ "()Ljava/util/function/Comparator;",
+      lambda-signature ↦ "(Ljava/lang/Object;Ljava/lang/Object;)I",
+      bridge-signature ↦ "(Ljava/lang/Integer;Ljava/lang/Integer;)I",
+      static ↦ "true",
+      opcode ↦ "invokestatic",
+      target ↦ ⟦
+        handle ↦ 6,
+        class ↦ "Foo",
+        method ↦ "lambda$main$0",
+        signature ↦ "(Ljava/lang/Integer;Ljava/lang/Integer;)I",
+        is-interface ↦ Φ.false
+      ⟧,
+      stream ↦ ⟦
+        class ↦ "java/util/stream/Stream",
+        method ↦ "sorted",
+        signature ↦ "(Ljava/util/function/Comparator;)Ljava/util/stream/Stream;"
+      ⟧
+    ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams-sorted.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-sorted.yml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Confirms that .sorted(Comparator) in a Stream pipeline round-trips
+# through the optimizer: 212 recognises the Φ.hone.lambda whose stream
+# call is Stream.sorted(Comparator) and converts it into a Φ.hone.sorted
+# barrier pragma; 607 then converts the pragma back into a Φ.hone.lambda
+# so the 7xx phase can lower it to invokedynamic + invokeinterface. The
+# bytecode for the sort call itself must remain a Comparator lambda plus
+# the Stream.sorted invokeinterface, and the program must compute the
+# same result as without the optimization. See issue #549.
+java: |
+  package sorted;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      long r = Stream.of(5, 3, 8, 1, 4)
+        .map(n -> n + 1)
+        .sorted((x, y) -> y - x)
+        .count();
+      System.out.printf("The result is %d\n", r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 5"


### PR DESCRIPTION
Adds a recognition rule (212) that maps `Φ.hone.lambda` whose stream call is `Stream.sorted(Comparator)` to a fresh `Φ.hone.sorted` pragma, and the inverse rule (607) that converts any leftover `Φ.hone.sorted` back to a `Φ.hone.lambda` so the 7xx phase can lower it to `invokedynamic + invokeinterface`. Matching phino unit tests cover the lambda → sorted and sorted → lambda transforms; an end-to-end fixture exercises a real `.sorted(Comparator)` call through the whole pipeline.

`.sorted` is fully buffering and cannot fold into the running distill chain, but leaving the call as a generic `Φ.hone.lambda` meant the surrounding stateless ops in 3xx/4xx had no stable pragma name to recognize it as a barrier. Giving it its own pragma is the smallest step that lets adjacent runs of stateless ops be reasoned about independently on each side, the same shape we already use for `.peek` (209) and `.takeWhile` (213).

This change targets only the `.sorted(Comparator)` overload — the no-arg `Stream.sorted()` does not produce a lambda and is left for follow-up. Closes #549.