### PR TITLE
#546: Recognize non-zero Stream.skip(N) variants

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/212-recognize-skip-one.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/212-recognize-skip-one.phr
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Recognizes a stream `.skip(1L)` call — the `lconst_1` that pushes the
+# count followed by the `invokeinterface java/util/stream/Stream.skip:(J)
+# Ljava/util/stream/Stream;` — and abstracts the pair into a single
+# Φ.hone.skip block with count="1". Sibling of 210 (which handles
+# `lconst_0`). Currently there is no fold for count="1", so 710 mirrors
+# it back to `lconst_1 + invokeinterface`; a state-carrying distill
+# variant would replace 710 with a real fusion path.
+name: recognize-skip-one
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-push ↦ ⟦
+      φ ↦ Φ.jeo.opcode.lconst_1,
+      ρ ↦ ∅
+    ⟧,
+    𝜏-invokeinterface ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      𝜏1 ↦ "java/util/stream/Stream",
+      𝜏2 ↦ "skip",
+      𝜏3 ↦ "(J)Ljava/util/stream/Stream;",
+      𝜏4 ↦ Φ.true,
+      ρ ↦ ∅
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-skip ↦ ⟦
+      φ ↦ Φ.hone.skip,
+      stream-class ↦ "java/util/stream/Stream",
+      count ↦ "1"
+    ⟧,
+    𝐵-after
+  ⟧
+where:
+  - meta: 𝜏-skip
+    function: random-tau
+    args: [ '𝐵-before', '𝐵-after' ]

--- a/src/main/resources/org/eolang/hone/rules/streams/220-recognize-skip-ldc.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/220-recognize-skip-ldc.phr
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Recognizes a stream `.skip(N)` call where the count is loaded via a
+# generic `ldc` carrying a `Φ.jeo.long` literal (the canonical javac
+# encoding for any long argument other than 0L / 1L). The pair is
+# abstracted into Φ.hone.skip with count captured as the underlying
+# Φ.number. Mirror rule 720 lowers it back to ldc + invokeinterface
+# when no fold matches; future state-carrying skip optimizations will
+# consume the recognized pragma instead.
+name: recognize-skip-ldc
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-push ↦ ⟦
+      φ ↦ Φ.jeo.opcode.ldc,
+      𝜏1 ↦ ⟦
+        φ ↦ Φ.jeo.long,
+        𝜏2 ↦ 𝑒-count,
+        ρ ↦ ∅
+      ⟧,
+      ρ ↦ ∅
+    ⟧,
+    𝜏-invokeinterface ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      𝜏3 ↦ "java/util/stream/Stream",
+      𝜏4 ↦ "skip",
+      𝜏5 ↦ "(J)Ljava/util/stream/Stream;",
+      𝜏6 ↦ Φ.true,
+      ρ ↦ ∅
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-skip ↦ ⟦
+      φ ↦ Φ.hone.skip,
+      stream-class ↦ "java/util/stream/Stream",
+      count ↦ 𝑒-count
+    ⟧,
+    𝐵-after
+  ⟧
+where:
+  - meta: 𝜏-skip
+    function: random-tau
+    args: [ '𝐵-before', '𝐵-after' ]

--- a/src/main/resources/org/eolang/hone/rules/streams/710-skip-one-to-invokeinterface.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/710-skip-one-to-invokeinterface.phr
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Inverse of 212: lowers Φ.hone.skip with count="1" back into the
+# `lconst_1 + invokeinterface java/util/stream/Stream.skip:(J)Ljava/
+# util/stream/Stream;` byte pair. Fires only when no earlier rule has
+# folded the skip into something else; ensures any recognized `.skip(1L)`
+# is always emitted as valid bytecode by 7xx, even when the eventual
+# state-carrying fusion path is not yet in place.
+name: skip-one-to-invokeinterface
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-skip ↦ ⟦
+      φ ↦ Φ.hone.skip,
+      stream-class ↦ 𝑒-stream-class,
+      count ↦ "1",
+      ρ ↦ ∅
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-push ↦ ⟦
+      φ ↦ Φ.jeo.opcode.lconst_1
+    ⟧,
+    𝜏-invokeinterface ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      i2 ↦ 𝑒-stream-class,
+      i3 ↦ "skip",
+      i4 ↦ "(J)Ljava/util/stream/Stream;",
+      i5 ↦ Φ.true
+    ⟧,
+    𝐵-after
+  ⟧
+where:
+  - meta: 𝜏-push
+    function: random-tau
+    args: [ '𝐵-before', '𝐵-after' ]
+  - meta: 𝜏-invokeinterface
+    function: random-tau
+    args: [ '𝐵-before', '𝐵-after', '𝜏-push' ]

--- a/src/main/resources/org/eolang/hone/rules/streams/720-skip-ldc-to-invokeinterface.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/720-skip-ldc-to-invokeinterface.phr
@@ -5,11 +5,11 @@
 # Inverse of 220: lowers Φ.hone.skip whose count was captured as a
 # Φ.number (ldc-based recognition) back into the `ldc Φ.jeo.long(N) +
 # invokeinterface java/util/stream/Stream.skip:(J)Ljava/util/stream/
-# Stream;` byte pair. Only matches when count is a Φ.number, so the
-# string-typed count="0" / count="1" cases (handled by 311 / 710) are
-# left alone. The when-clause excludes count=0 so the rule never
-# round-trips a no-op back to bytecode after 311 elimination would
-# have applied.
+# Stream;` byte pair. The when-clause excludes the string-typed
+# count="0" / count="1" cases produced by 210 / 212 so they stay on
+# their dedicated lowering paths (311 → nop and 710 → lconst_1) and
+# never get round-tripped through a `Φ.jeo.long("0"/"1")` wrapper —
+# which would be invalid bytecode.
 name: skip-ldc-to-invokeinterface
 pattern: |
   ⟦
@@ -41,6 +41,12 @@ result: |
     ⟧,
     𝐵-after
   ⟧
+when:
+  and:
+    - not:
+        eq: [ 𝑒-count, '"0"' ]
+    - not:
+        eq: [ 𝑒-count, '"1"' ]
 where:
   - meta: 𝜏-push
     function: random-tau

--- a/src/main/resources/org/eolang/hone/rules/streams/720-skip-ldc-to-invokeinterface.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/720-skip-ldc-to-invokeinterface.phr
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Inverse of 220: lowers Φ.hone.skip whose count was captured as a
+# Φ.number (ldc-based recognition) back into the `ldc Φ.jeo.long(N) +
+# invokeinterface java/util/stream/Stream.skip:(J)Ljava/util/stream/
+# Stream;` byte pair. Only matches when count is a Φ.number, so the
+# string-typed count="0" / count="1" cases (handled by 311 / 710) are
+# left alone. The when-clause excludes count=0 so the rule never
+# round-trips a no-op back to bytecode after 311 elimination would
+# have applied.
+name: skip-ldc-to-invokeinterface
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-skip ↦ ⟦
+      φ ↦ Φ.hone.skip,
+      stream-class ↦ 𝑒-stream-class,
+      count ↦ 𝑒-count,
+      ρ ↦ ∅
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-push ↦ ⟦
+      φ ↦ Φ.jeo.opcode.ldc,
+      i1 ↦ ⟦
+        φ ↦ Φ.jeo.long,
+        i1 ↦ 𝑒-count
+      ⟧
+    ⟧,
+    𝜏-invokeinterface ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      i2 ↦ 𝑒-stream-class,
+      i3 ↦ "skip",
+      i4 ↦ "(J)Ljava/util/stream/Stream;",
+      i5 ↦ Φ.true
+    ⟧,
+    𝐵-after
+  ⟧
+where:
+  - meta: 𝜏-push
+    function: random-tau
+    args: [ '𝐵-before', '𝐵-after' ]
+  - meta: 𝜏-invokeinterface
+    function: random-tau
+    args: [ '𝐵-before', '𝐵-after', '𝜏-push' ]

--- a/src/test/phino/212-recognize-skip-one.yml
+++ b/src/test/phino/212-recognize-skip-one.yml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 212 recognizes the bytecode pair `lconst_1` + `invokeinterface
+# java/util/stream/Stream.skip:(J)Ljava/util/stream/Stream;` and folds
+# it into a single Φ.hone.skip block carrying count="1" — the
+# canonical `.skip(1L)` idiom that 710 mirrors back to bytecode when
+# no later rule has folded it.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/212-recognize-skip-one.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      i1 ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_1 ⟧,
+      i2 ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokeinterface,
+        v1 ↦ "java/util/stream/Stream",
+        v2 ↦ "skip",
+        v3 ↦ "(J)Ljava/util/stream/Stream;",
+        v4 ↦ Φ.true
+      ⟧
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      𝐵-before,
+      𝜏-skip ↦ ⟦
+        φ ↦ Φ.hone.skip,
+        stream-class ↦ "java/util/stream/Stream",
+        count ↦ "1"
+      ⟧,
+      𝐵-after
+    ⟧

--- a/src/test/phino/220-recognize-skip-ldc.yml
+++ b/src/test/phino/220-recognize-skip-ldc.yml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 220 recognizes the bytecode pair `ldc Φ.jeo.long(N)` + `invokeinterface
+# java/util/stream/Stream.skip:(J)Ljava/util/stream/Stream;` — the
+# canonical javac encoding for `.skip(N)` when N is neither 0L nor 1L —
+# and folds it into a single Φ.hone.skip block whose count is the
+# underlying Φ.number.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/220-recognize-skip-ldc.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      i1 ↦ ⟦
+        φ ↦ Φ.jeo.opcode.ldc,
+        v0 ↦ ⟦
+          φ ↦ Φ.jeo.long,
+          n0 ↦ 5
+        ⟧
+      ⟧,
+      i2 ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokeinterface,
+        v1 ↦ "java/util/stream/Stream",
+        v2 ↦ "skip",
+        v3 ↦ "(J)Ljava/util/stream/Stream;",
+        v4 ↦ Φ.true
+      ⟧
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      𝐵-before,
+      𝜏-skip ↦ ⟦
+        φ ↦ Φ.hone.skip,
+        stream-class ↦ "java/util/stream/Stream",
+        count ↦ 5
+      ⟧,
+      𝐵-after
+    ⟧

--- a/src/test/phino/710-skip-one-to-invokeinterface.yml
+++ b/src/test/phino/710-skip-one-to-invokeinterface.yml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 710 is the inverse of 212: a Φ.hone.skip block with count="1" that
+# survived to the 7xx lowering phase is rewritten back into the
+# `lconst_1 + invokeinterface java/util/stream/Stream.skip:(J)Ljava/
+# util/stream/Stream;` byte pair. This is the bytecode fallback when
+# no fold consumed the pragma.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/710-skip-one-to-invokeinterface.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      i1 ↦ ⟦
+        φ ↦ Φ.hone.skip,
+        stream-class ↦ "java/util/stream/Stream",
+        count ↦ "1"
+      ⟧
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      𝐵-before,
+      𝜏-push ↦ ⟦
+        φ ↦ Φ.jeo.opcode.lconst_1
+      ⟧,
+      𝜏-invokeinterface ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokeinterface,
+        i2 ↦ "java/util/stream/Stream",
+        i3 ↦ "skip",
+        i4 ↦ "(J)Ljava/util/stream/Stream;",
+        i5 ↦ Φ.true
+      ⟧,
+      𝐵-after
+    ⟧

--- a/src/test/phino/720-skip-ldc-to-invokeinterface.yml
+++ b/src/test/phino/720-skip-ldc-to-invokeinterface.yml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 720 is the inverse of 220: a Φ.hone.skip block whose count is a
+# Φ.number (the form produced by ldc-based recognition) is rewritten
+# back into the `ldc Φ.jeo.long(N) + invokeinterface java/util/stream/
+# Stream.skip:(J)Ljava/util/stream/Stream;` byte pair when no fold
+# consumed it.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/720-skip-ldc-to-invokeinterface.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      i1 ↦ ⟦
+        φ ↦ Φ.hone.skip,
+        stream-class ↦ "java/util/stream/Stream",
+        count ↦ 5
+      ⟧
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      𝐵-before,
+      𝜏-push ↦ ⟦
+        φ ↦ Φ.jeo.opcode.ldc,
+        i1 ↦ ⟦
+          φ ↦ Φ.jeo.long,
+          i1 ↦ 5
+        ⟧
+      ⟧,
+      𝜏-invokeinterface ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokeinterface,
+        i2 ↦ "java/util/stream/Stream",
+        i3 ↦ "skip",
+        i4 ↦ "(J)Ljava/util/stream/Stream;",
+        i5 ↦ Φ.true
+      ⟧,
+      𝐵-after
+    ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams-skipped-non-zero.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-skipped-non-zero.yml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Asserts that a non-zero `.skip(N)` survives the rewrite pipeline
+# unchanged in observable behavior. 220 recognizes `ldc Φ.jeo.long +
+# invokeinterface Stream.skip(J)` into Φ.hone.skip; without a fold the
+# 720 mirror lowers it back, so the runtime output is identical. This
+# is the round-trip regression guard for the non-zero variants until
+# a state-carrying fusion lands.
+java: |
+  package skippednonzero;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      long r = Stream.of(1, 2, 3, 4, 5)
+        .skip(2L)
+        .count();
+      System.out.printf("The result is %d\n", r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 3"
+opcodes:
+  invokeinterface: 2


### PR DESCRIPTION
## Summary

Continues #546 from [#550](https://github.com/objectionary/hone-maven-plugin/pull/550). Adds bytecode-level recognition for the **non-zero** `.skip(N)` variants and their inverse lowering rules.

- **`212-recognize-skip-one.phr`** — folds `lconst_1 + invokeinterface Stream.skip(J)` into `Φ.hone.skip` with `count="1"` (the canonical `.skip(1L)` shape).
- **`220-recognize-skip-ldc.phr`** — folds `ldc Φ.jeo.long(N) + invokeinterface Stream.skip(J)` into `Φ.hone.skip` with the count captured as the underlying `Φ.number` (javac encodes every long literal other than `0L` and `1L` this way).
- **`710-skip-one-to-invokeinterface.phr`** — inverse of 212 (`count="1"` → `lconst_1 + invokeinterface`).
- **`720-skip-ldc-to-invokeinterface.phr`** — inverse of 220 (`Φ.number` count → `ldc Φ.jeo.long(N) + invokeinterface`).
- Phino unit tests for each new rule plus the integration pack `streams-skipped-non-zero.yml` that exercises `Stream.of(...).skip(2L).count()` end-to-end and asserts the runtime output (`The result is 3`) and the invokeinterface count.

## Why two count representations?

Recognition is type-faithful to the source opcode:

| Source bytecode | `Φ.hone.skip.count` |
|---|---|
| `lconst_0 + invokeinterface skip` | `"0"` (string) — from PR #550 |
| `lconst_1 + invokeinterface skip` | `"1"` (string) — this PR |
| `ldc Φ.jeo.long(N) + invokeinterface skip` | `Φ.number(N)` — this PR |

Keeping the literal form means each inverse rule can route on the count type without losing fidelity: `311` only ever folds the string `"0"`, `710` only matches `"1"`, `720` only fires when count is a `Φ.number`. None of them overlap. The string vs. number distinction is exclusive — verified by phino's matcher (a literal `0` pattern does not match a `"0"` value).

## Scope (still partial)

This PR adds **recognition and lowering only** for the non-zero variants — there is still no fold that beats the round-trip:

- `.skip(0L)` ⇒ `nop` (real optimization, from PR #550)
- `.skip(1L)` ⇒ `Φ.hone.skip → lconst_1 + invokeinterface` (identity)
- `.skip(N)` for N ≥ 2 ⇒ `Φ.hone.skip → ldc + invokeinterface` (identity)

The state-carrying fold (analogous to `351-take-while-to-mapMulti` — a captured `long[1]` counter wrapped in a `Stream.mapMulti(BiConsumer)`) is the next chunk of work and belongs in its own PR. With this PR in place, that fold has a single canonical `Φ.hone.skip` pragma to consume regardless of which push opcode the source bytecode used.

Primitive specializations (`IntStream` / `LongStream` / `DoubleStream`) are also still pending — same pattern shape, separate rules, separate PR.

## Test plan

- [x] `bash src/test/phino/run.sh` — 22 tests pass (the 18 existing plus 4 new).
- [x] `yamllint` clean on all new files.
- [x] Manually verified the full pipeline (210/212/220 + 311/710/720 together) on a body containing all three push variants in sequence: zero collapses to `nop`, one and ldc round-trip exactly.
- [ ] CI runs the Docker-backed end-to-end pack `streams-skipped-non-zero.yml` against a real build to confirm the optimized class prints `The result is 3`.