### PR TITLE
Optimize Stream.dropWhile via mapMulti with boolean[1] guard

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/217-lambda-to-drop-while.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/217-lambda-to-drop-while.phr
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+name: lambda-to-drop-while
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.lambda,
+    class ↦ 𝑒-class,
+    method ↦ "test",
+    interface ↦ "()Ljava/util/function/Predicate;",
+    lambda-signature ↦ "(Ljava/lang/Object;)Z",
+    bridge-signature ↦ 𝑒-bridge-signature,
+    static ↦ 𝑒-static,
+    opcode ↦ 𝑒-opcode,
+    target ↦ ⟦
+      handle ↦ 𝑒-target-handle,
+      class ↦ 𝑒-target-class,
+      method ↦ 𝑒-target-method,
+      signature ↦ 𝑒-target-signature,
+      is-interface ↦ 𝑒-target-is-interface
+    ⟧,
+    stream ↦ ⟦
+      class ↦ "java/util/stream/Stream",
+      method ↦ "dropWhile",
+      signature ↦ "(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;"
+    ⟧
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.drop-while,
+    opcode ↦ 𝑒-opcode,
+    class ↦ 𝑒-class,
+    bridge-signature ↦ 𝑒-bridge-signature,
+    static ↦ 𝑒-static,
+    target ↦ ⟦
+      handle ↦ 𝑒-target-handle,
+      class ↦ 𝑒-target-class,
+      method ↦ 𝑒-target-method,
+      signature ↦ 𝑒-target-signature,
+      is-interface ↦ 𝑒-target-is-interface
+    ⟧
+  ⟧

--- a/src/main/resources/org/eolang/hone/rules/streams/218-lambda-to-primitive-drop-while.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/218-lambda-to-primitive-drop-while.phr
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+name: lambda-to-primitive-drop-while
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.lambda,
+    class ↦ 𝑒-class,
+    method ↦ "test",
+    interface ↦ 𝑒-interface,
+    lambda-signature ↦ 𝑒-lambda-signature,
+    bridge-signature ↦ 𝑒-bridge-signature,
+    static ↦ 𝑒-static,
+    opcode ↦ 𝑒-opcode,
+    target ↦ 𝑒-target,
+    stream ↦ ⟦
+      class ↦ 𝑒-stream-class,
+      method ↦ "dropWhile",
+      signature ↦ 𝑒-stream-signature
+    ⟧
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.primitive-drop-while,
+    opcode ↦ 𝑒-opcode,
+    class ↦ 𝑒-class,
+    stream-class ↦ 𝑒-stream-class,
+    stream-signature ↦ 𝑒-stream-signature,
+    interface ↦ 𝑒-interface,
+    lambda-signature ↦ 𝑒-lambda-signature,
+    bridge-signature ↦ 𝑒-bridge-signature,
+    static ↦ 𝑒-static,
+    target ↦ 𝑒-target
+  ⟧
+when:
+  or:
+    - and:
+        - matches: ['\(\)Ljava/util/function/IntPredicate;', 𝑒-interface]
+        - eq: [𝑒-lambda-signature, '"(I)Z"']
+        - eq: [𝑒-bridge-signature, '"(I)Z"']
+        - eq: [𝑒-stream-class, '"java/util/stream/IntStream"']
+        - eq: [𝑒-stream-signature, '"(Ljava/util/function/IntPredicate;)Ljava/util/stream/IntStream;"']
+    - and:
+        - matches: ['\(\)Ljava/util/function/LongPredicate;', 𝑒-interface]
+        - eq: [𝑒-lambda-signature, '"(J)Z"']
+        - eq: [𝑒-bridge-signature, '"(J)Z"']
+        - eq: [𝑒-stream-class, '"java/util/stream/LongStream"']
+        - eq: [𝑒-stream-signature, '"(Ljava/util/function/LongPredicate;)Ljava/util/stream/LongStream;"']
+    - and:
+        - matches: ['\(\)Ljava/util/function/DoublePredicate;', 𝑒-interface]
+        - eq: [𝑒-lambda-signature, '"(D)Z"']
+        - eq: [𝑒-bridge-signature, '"(D)Z"']
+        - eq: [𝑒-stream-class, '"java/util/stream/DoubleStream"']
+        - eq: [𝑒-stream-signature, '"(Ljava/util/function/DoublePredicate;)Ljava/util/stream/DoubleStream;"']

--- a/src/main/resources/org/eolang/hone/rules/streams/352-drop-while-to-mapMulti.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/352-drop-while-to-mapMulti.phr
@@ -2,17 +2,18 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-# 351-take-while-to-mapMulti
+# 352-drop-while-to-mapMulti
 #
-# Lowers Φ.hone.take-while (object Stream variant produced by 213) into:
+# Lowers Φ.hone.drop-while (object Stream variant produced by 217) into:
 #   * Raw bytecode that allocates a boolean[1] guard array on the stack
 #     (iconst_1 + newarray boolean)
 #   * A Φ.hone.lambda pragma that creates a BiConsumer capturing that
 #     guard, then calls Stream.mapMulti(BiConsumer)
 #   * A new synthetic private static wrapper method that implements
-#     takeWhile semantics: short-circuits once the original predicate
-#     first returns false (via guard[0] = true), and forwards accepted
-#     elements to the mapMulti Consumer.
+#     dropWhile semantics: drops elements while the original predicate
+#     returns true and the guard cell is unset, flips guard[0] = true
+#     on the first false the predicate returns, and from that moment
+#     forwards every element to the mapMulti Consumer.
 #
 # After this rule:
 #   * 701 picks up the Φ.hone.lambda and lowers it to invokedynamic +
@@ -20,11 +21,10 @@
 #   * The original predicate lambda$N method is untouched; the wrapper
 #     calls it via invokestatic.
 #
-# This is the takeWhile counterpart of the filter chain 201 → 305 → 501
-# → 511 → 601 → 701, but in a single rule because Stream.takeWhile's
-# once-false-always-false semantics need a captured state cell that the
-# stateless distill pipeline cannot express.
-name: take-while-to-mapMulti
+# Mirror of 351 with inverted control flow: guard means "have we started
+# emitting yet" rather than "have we stopped"; the predicate's truth value
+# means "still dropping" rather than "still taking".
+name: drop-while-to-mapMulti
 pattern: |
   ⟦
     φ ↦ Φ.jeo.class,
@@ -36,8 +36,8 @@ pattern: |
       𝐵-caller-head,
       body ↦ ⟦
         𝐵-body-head,
-        𝜏-take-while ↦ ⟦
-          φ ↦ Φ.hone.take-while,
+        𝜏-drop-while ↦ ⟦
+          φ ↦ Φ.hone.drop-while,
           opcode ↦ 𝑒-opcode,
           class ↦ 𝑒-class,
           bridge-signature ↦ 𝑒-bridge-signature,
@@ -125,7 +125,7 @@ result: |
         w2 ↦ ⟦ φ ↦ Φ.jeo.opcode.baload ⟧,
         w3 ↦ ⟦
           φ ↦ Φ.jeo.opcode.ifne,
-          i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label-end ⟧
+          i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label-accept ⟧
         ⟧,
         w4 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
         w5 ↦ ⟦
@@ -137,15 +137,14 @@ result: |
         ⟧,
         w6 ↦ ⟦
           φ ↦ Φ.jeo.opcode.ifne,
-          i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label-accept ⟧
+          i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label-end ⟧
         ⟧,
         w7 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 0 ⟧,
         w8 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
         w9 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_1 ⟧,
         w10 ↦ ⟦ φ ↦ Φ.jeo.opcode.bastore ⟧,
-        w11 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
-        w12 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label-accept ⟧,
-        w13 ↦ ⟦
+        w11 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label-accept ⟧,
+        w12 ↦ ⟦
           φ ↦ Φ.jeo.frame,
           type ↦ 3,
           nlocal ↦ 0,
@@ -153,17 +152,17 @@ result: |
           nstack ↦ 0,
           stack ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
         ⟧,
-        w14 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 2 ⟧,
-        w15 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
-        w16 ↦ ⟦
+        w13 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 2 ⟧,
+        w14 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
+        w15 ↦ ⟦
           φ ↦ Φ.jeo.opcode.invokeinterface,
           i2 ↦ "java/util/function/Consumer",
           i3 ↦ "accept",
           i4 ↦ "(Ljava/lang/Object;)V",
           i5 ↦ Φ.true
         ⟧,
-        w17 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label-end ⟧,
-        w18 ↦ ⟦
+        w16 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label-end ⟧,
+        w17 ↦ ⟦
           φ ↦ Φ.jeo.frame,
           type ↦ 3,
           nlocal ↦ 0,
@@ -171,7 +170,7 @@ result: |
           nstack ↦ 0,
           stack ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
         ⟧,
-        w19 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+        w18 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
         ρ ↦ ∅
       ⟧,
       name ↦ 𝑒-wrapper-method
@@ -194,7 +193,7 @@ where:
     args: ['𝐵-body-head', '𝐵-body-tail', '𝜏-iconst-1', '𝜏-newarray']
   - meta: 𝑒-wrapper-method
     function: random-string
-    args: ['"hone_takeWhile_%d"']
+    args: ['"hone_dropWhile_%d"']
   - meta: 𝜏-wrapper
     function: random-tau
     args: ['name', '𝐵-class-head-before', '𝐵-class-head-after', '𝐵-class-tail', '𝜏-caller']
@@ -211,7 +210,7 @@ where:
     args: ['"("', 𝑒-item-type, '"Ljava/util/function/Consumer;)V"']
   - meta: 𝑒-label-end
     function: random-string
-    args: ['"LtakeWhileEnd%d"']
+    args: ['"LdropWhileEnd%d"']
   - meta: 𝑒-label-accept
     function: random-string
-    args: ['"LtakeWhileAccept%d"']
+    args: ['"LdropWhileAccept%d"']

--- a/src/main/resources/org/eolang/hone/rules/streams/607-drop-while-to-lambda.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/607-drop-while-to-lambda.phr
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Inverse of 217: turns a Φ.hone.drop-while pragma back into a
+# Φ.hone.lambda with the original Stream.dropWhile(Predicate)
+# invokeinterface call. Fires for any Φ.hone.drop-while that has not
+# been consumed by 352, ensuring the pragma is always lowered to valid
+# bytecode by 7xx.
+name: drop-while-to-lambda
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.drop-while,
+    opcode ↦ 𝑒-opcode,
+    class ↦ 𝑒-class,
+    bridge-signature ↦ 𝑒-bridge-signature,
+    static ↦ 𝑒-static,
+    target ↦ ⟦
+      handle ↦ 𝑒-target-handle,
+      class ↦ 𝑒-target-class,
+      method ↦ 𝑒-target-method,
+      signature ↦ 𝑒-target-signature,
+      is-interface ↦ 𝑒-target-is-interface
+    ⟧
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.lambda,
+    class ↦ 𝑒-class,
+    method ↦ "test",
+    interface ↦ "()Ljava/util/function/Predicate;",
+    lambda-signature ↦ "(Ljava/lang/Object;)Z",
+    bridge-signature ↦ 𝑒-bridge-signature,
+    static ↦ 𝑒-static,
+    opcode ↦ 𝑒-opcode,
+    target ↦ ⟦
+      handle ↦ 𝑒-target-handle,
+      class ↦ 𝑒-target-class,
+      method ↦ 𝑒-target-method,
+      signature ↦ 𝑒-target-signature,
+      is-interface ↦ 𝑒-target-is-interface
+    ⟧,
+    stream ↦ ⟦
+      class ↦ "java/util/stream/Stream",
+      method ↦ "dropWhile",
+      signature ↦ "(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;"
+    ⟧
+  ⟧

--- a/src/main/resources/org/eolang/hone/rules/streams/608-primitive-drop-while-to-lambda.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/608-primitive-drop-while-to-lambda.phr
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Inverse of 218: turns a Φ.hone.primitive-drop-while pragma back into
+# a Φ.hone.lambda with the original {Int,Long,Double}Stream.dropWhile(...)
+# invokeinterface call, so the 7xx phase can lower it back to
+# invokedynamic + invokeinterface.
+name: primitive-drop-while-to-lambda
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.primitive-drop-while,
+    opcode ↦ 𝑒-opcode,
+    class ↦ 𝑒-class,
+    stream-class ↦ 𝑒-stream-class,
+    stream-signature ↦ 𝑒-stream-signature,
+    interface ↦ 𝑒-interface,
+    lambda-signature ↦ 𝑒-lambda-signature,
+    bridge-signature ↦ 𝑒-bridge-signature,
+    static ↦ 𝑒-static,
+    target ↦ 𝑒-target
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.lambda,
+    class ↦ 𝑒-class,
+    method ↦ "test",
+    interface ↦ 𝑒-interface,
+    lambda-signature ↦ 𝑒-lambda-signature,
+    bridge-signature ↦ 𝑒-bridge-signature,
+    static ↦ 𝑒-static,
+    opcode ↦ 𝑒-opcode,
+    target ↦ 𝑒-target,
+    stream ↦ ⟦
+      class ↦ 𝑒-stream-class,
+      method ↦ "dropWhile",
+      signature ↦ 𝑒-stream-signature
+    ⟧
+  ⟧

--- a/src/test/phino/217-lambda-to-drop-while.yml
+++ b/src/test/phino/217-lambda-to-drop-while.yml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 217 recognizes a Φ.hone.lambda whose stream call is Stream.dropWhile
+# (i.e. a source-level .dropWhile(Predicate) invocation on the object
+# Stream) and converts it into a Φ.hone.drop-while pragma. This is
+# analogous to 213 (take-while); see issue #540. 352 then folds the
+# pragma into Stream.mapMulti with a captured boolean[] guard; 607 is
+# the unrecognise fallback for pragmas not consumed by 352.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/217-lambda-to-drop-while.phr
+input: |
+  {⟦
+    φ ↦ Φ.hone.lambda,
+    class ↦ "Foo",
+    method ↦ "test",
+    interface ↦ "()Ljava/util/function/Predicate;",
+    lambda-signature ↦ "(Ljava/lang/Object;)Z",
+    bridge-signature ↦ "(Ljava/lang/Integer;)Z",
+    static ↦ "true",
+    opcode ↦ "invokestatic",
+    target ↦ ⟦
+      handle ↦ 6,
+      class ↦ "Foo",
+      method ↦ "lambda$main$0",
+      signature ↦ "(Ljava/lang/Integer;)Z",
+      is-interface ↦ Φ.false
+    ⟧,
+    stream ↦ ⟦
+      class ↦ "java/util/stream/Stream",
+      method ↦ "dropWhile",
+      signature ↦ "(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;"
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      φ ↦ Φ.hone.drop-while,
+      opcode ↦ "invokestatic",
+      class ↦ "Foo",
+      bridge-signature ↦ "(Ljava/lang/Integer;)Z",
+      static ↦ "true",
+      target ↦ ⟦
+        handle ↦ 6,
+        class ↦ "Foo",
+        method ↦ "lambda$main$0",
+        signature ↦ "(Ljava/lang/Integer;)Z",
+        is-interface ↦ Φ.false
+      ⟧
+    ⟧

--- a/src/test/phino/218-lambda-to-primitive-drop-while.yml
+++ b/src/test/phino/218-lambda-to-primitive-drop-while.yml
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 218 recognizes a Φ.hone.lambda whose stream call is one of the
+# primitive {Int,Long,Double}Stream.dropWhile(...) variants and rewrites
+# it into a Φ.hone.primitive-drop-while pragma. Analogous to 214
+# (primitive-take-while); see issue #540.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/218-lambda-to-primitive-drop-while.phr
+input: |
+  {⟦
+    φ ↦ Φ.hone.lambda,
+    class ↦ "Foo",
+    method ↦ "test",
+    interface ↦ "()Ljava/util/function/IntPredicate;",
+    lambda-signature ↦ "(I)Z",
+    bridge-signature ↦ "(I)Z",
+    static ↦ "true",
+    opcode ↦ "invokestatic",
+    target ↦ ⟦
+      handle ↦ 6,
+      class ↦ "Foo",
+      method ↦ "lambda$main$0",
+      signature ↦ "(I)Z",
+      is-interface ↦ Φ.false
+    ⟧,
+    stream ↦ ⟦
+      class ↦ "java/util/stream/IntStream",
+      method ↦ "dropWhile",
+      signature ↦ "(Ljava/util/function/IntPredicate;)Ljava/util/stream/IntStream;"
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      φ ↦ Φ.hone.primitive-drop-while,
+      opcode ↦ "invokestatic",
+      class ↦ "Foo",
+      stream-class ↦ "java/util/stream/IntStream",
+      stream-signature ↦ "(Ljava/util/function/IntPredicate;)Ljava/util/stream/IntStream;",
+      interface ↦ "()Ljava/util/function/IntPredicate;",
+      lambda-signature ↦ "(I)Z",
+      bridge-signature ↦ "(I)Z",
+      static ↦ "true",
+      target ↦ ⟦
+        handle ↦ 6,
+        class ↦ "Foo",
+        method ↦ "lambda$main$0",
+        signature ↦ "(I)Z",
+        is-interface ↦ Φ.false
+      ⟧
+    ⟧

--- a/src/test/phino/607-drop-while-to-lambda.yml
+++ b/src/test/phino/607-drop-while-to-lambda.yml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 607 unrecognises a Φ.hone.drop-while pragma back into a Φ.hone.lambda
+# with the original Stream.dropWhile(Predicate) invokeinterface call, so
+# the 7xx phase can lower it to invokedynamic + invokeinterface.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/607-drop-while-to-lambda.phr
+input: |
+  {⟦
+    φ ↦ Φ.hone.drop-while,
+    opcode ↦ "invokestatic",
+    class ↦ "Foo",
+    bridge-signature ↦ "(Ljava/lang/Integer;)Z",
+    static ↦ "true",
+    target ↦ ⟦
+      handle ↦ 6,
+      class ↦ "Foo",
+      method ↦ "lambda$main$0",
+      signature ↦ "(Ljava/lang/Integer;)Z",
+      is-interface ↦ Φ.false
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      φ ↦ Φ.hone.lambda,
+      class ↦ "Foo",
+      method ↦ "test",
+      interface ↦ "()Ljava/util/function/Predicate;",
+      lambda-signature ↦ "(Ljava/lang/Object;)Z",
+      bridge-signature ↦ "(Ljava/lang/Integer;)Z",
+      static ↦ "true",
+      opcode ↦ "invokestatic",
+      target ↦ ⟦
+        handle ↦ 6,
+        class ↦ "Foo",
+        method ↦ "lambda$main$0",
+        signature ↦ "(Ljava/lang/Integer;)Z",
+        is-interface ↦ Φ.false
+      ⟧,
+      stream ↦ ⟦
+        class ↦ "java/util/stream/Stream",
+        method ↦ "dropWhile",
+        signature ↦ "(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;"
+      ⟧
+    ⟧

--- a/src/test/phino/608-primitive-drop-while-to-lambda.yml
+++ b/src/test/phino/608-primitive-drop-while-to-lambda.yml
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 608 unrecognises a Φ.hone.primitive-drop-while pragma back into a
+# Φ.hone.lambda with the original {Int,Long,Double}Stream.dropWhile(...)
+# invokeinterface call, so the 7xx phase can lower it back to
+# invokedynamic + invokeinterface.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/608-primitive-drop-while-to-lambda.phr
+input: |
+  {⟦
+    φ ↦ Φ.hone.primitive-drop-while,
+    opcode ↦ "invokestatic",
+    class ↦ "Foo",
+    stream-class ↦ "java/util/stream/IntStream",
+    stream-signature ↦ "(Ljava/util/function/IntPredicate;)Ljava/util/stream/IntStream;",
+    interface ↦ "()Ljava/util/function/IntPredicate;",
+    lambda-signature ↦ "(I)Z",
+    bridge-signature ↦ "(I)Z",
+    static ↦ "true",
+    target ↦ ⟦
+      handle ↦ 6,
+      class ↦ "Foo",
+      method ↦ "lambda$main$0",
+      signature ↦ "(I)Z",
+      is-interface ↦ Φ.false
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      φ ↦ Φ.hone.lambda,
+      class ↦ "Foo",
+      method ↦ "test",
+      interface ↦ "()Ljava/util/function/IntPredicate;",
+      lambda-signature ↦ "(I)Z",
+      bridge-signature ↦ "(I)Z",
+      static ↦ "true",
+      opcode ↦ "invokestatic",
+      target ↦ ⟦
+        handle ↦ 6,
+        class ↦ "Foo",
+        method ↦ "lambda$main$0",
+        signature ↦ "(I)Z",
+        is-interface ↦ Φ.false
+      ⟧,
+      stream ↦ ⟦
+        class ↦ "java/util/stream/IntStream",
+        method ↦ "dropWhile",
+        signature ↦ "(Ljava/util/function/IntPredicate;)Ljava/util/stream/IntStream;"
+      ⟧
+    ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams-all-ops.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-all-ops.yml
@@ -47,7 +47,7 @@ log:
   - "The result is 54"
 opcodes:
   invokespecial: 1
-  invokestatic: 24
+  invokestatic: 25
   invokevirtual: 11
   invokedynamic: 15
-  return: 14
+  return: 15

--- a/src/test/resources/org/eolang/hone/optimize/streams-drop-while.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-drop-while.yml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Confirms that .dropWhile() on an object Stream is rewritten by rule
+# 352 into a Stream.mapMulti() call with a captured boolean[1] guard.
+#
+# The pipeline contains an element (100) that violates the predicate
+# midway through the stream. dropWhile must return [100, 4, 5, 6, 7] —
+# count() = 5 — and continue emitting every element after the first
+# false. A naive .takeWhile would yield [1, 2] (count = 2); a naive
+# filter(n -> n >= 10) would yield [100] (count = 1). The .map(n -> n)
+# is here only to satisfy the default grep-in filter (which targets
+# classes containing 'map' or 'filter' to keep the rewrite scope
+# narrow); it is a no-op semantically.
+#
+# Opcode counts (newarray, baload, bastore = 1 each) pin down that the
+# guard cell was actually allocated and consulted.
+java: |
+  package dropwhile;
+  import java.util.stream.*;
+  public class X {
+    public static void main(String[] a) {
+      long r = Stream.of(1, 2, 100, 4, 5, 6, 7)
+        .map(n -> n)
+        .dropWhile(n -> n < 10)
+        .count();
+      System.out.printf("The result is %d\n", r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 5"
+opcodes:
+  newarray: 1
+  baload: 1
+  bastore: 1

--- a/src/test/resources/org/eolang/hone/optimize/streams-take-while.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-take-while.yml
@@ -4,18 +4,23 @@
 # Confirms that .takeWhile() on an object Stream is rewritten by rule
 # 351 into a Stream.mapMulti() call with a captured boolean[1] guard.
 #
-# The source contains an element (100) that violates the predicate
+# The pipeline contains an element (100) that violates the predicate
 # before the end of the stream. takeWhile must return [1, 2, 3] —
 # count() = 3 — and stop after seeing 100. A naive filter rewrite
 # would yield [1, 2, 3, 4, 5] (count = 5) and is therefore detectable
-# in the output. Opcode counts (newarray, baload, bastore = 1 each)
-# pin down that the guard cell was actually allocated and consulted.
+# in the output. The .map(n -> n) is here only to satisfy the default
+# grep-in filter (which targets classes containing 'map' or 'filter'
+# to keep the rewrite scope narrow); it is a no-op semantically.
+#
+# Opcode counts (newarray, baload, bastore = 1 each) pin down that the
+# guard cell was actually allocated and consulted.
 java: |
   package takewhile;
   import java.util.stream.*;
   public class X {
     public static void main(String[] a) {
       long r = Stream.of(1, 2, 3, 100, 4, 5)
+        .map(n -> n)
         .takeWhile(n -> n < 10)
         .count();
       System.out.printf("The result is %d\n", r);


### PR DESCRIPTION
Closes #540.

This adds optimization for `Stream.dropWhile(Predicate)` analogous to what
#539 did for `takeWhile`. Recognition rules `217` and `218` lift a
`Φ.hone.lambda` whose stream call is `dropWhile` into a dedicated
`Φ.hone.drop-while` / `Φ.hone.primitive-drop-while` pragma. The fold rule
`352` lowers the object-Stream variant into a `Stream.mapMulti()` call that
captures a `boolean[1]` guard cell — a synthetic private static wrapper
drops elements while the original predicate returns true, flips the cell
once the predicate first returns false, and from that moment on forwards
every element to the mapMulti `Consumer`. Unrecognise fallbacks `607` and
`608` turn unconsumed pragmas back into `Φ.hone.lambda` so the 7xx phase
lowers them to standard `invokedynamic + invokeinterface` pairs.

While wiring this up I hit a bug in rule `351` (the `takeWhile` fold): its
result drops the class-level `ρ ↦ ∅` marker that the pattern requires.
That made the all-ops test break with `Unknown opcode name: distill`
because `501-distill-to-mapMulti` could no longer match the modified
class. The fix restores `ρ ↦ ∅` in `351` and adds the same marker to the
new `352`. I also tweaked the `streams-take-while` end-to-end test (and
shaped the new `streams-drop-while` test the same way) so the default
`grep-in` filter — which targets classes containing `map` or `filter` —
actually matches, otherwise the rewriter skips the file and the rule
never runs. The all-ops opcode counts are bumped by `+1 invokestatic` and
`+1 return` for the new dropWhile wrapper.

The phino test suite covers each of the four new pattern rules in
isolation; the new end-to-end fixture confirms the rewritten bytecode
yields the correct `dropWhile` semantics (it returns elements only after
the first predicate failure, never just the matching ones a naive filter
would emit).