### PR TITLE
#546: Recognize .skip() on primitive stream specializations

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/222-recognize-primitive-skip.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/222-recognize-primitive-skip.phr
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Primitive-stream counterpart of 210. Recognizes a `.skip(0L)` call on
+# IntStream / LongStream / DoubleStream — the `lconst_0` that pushes the
+# count followed by the `invokeinterface (J)L<stream>;` — and abstracts
+# the pair into Φ.hone.primitive-skip carrying stream-class /
+# stream-signature so the reverse rules can reconstruct the exact
+# original call. The matching 313 rule folds count="0" to nop the same
+# way 311 does for object Stream.
+name: recognize-primitive-skip
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-push ↦ ⟦
+      φ ↦ Φ.jeo.opcode.lconst_0,
+      ρ ↦ ∅
+    ⟧,
+    𝜏-invokeinterface ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      𝜏1 ↦ 𝑒-stream-class,
+      𝜏2 ↦ "skip",
+      𝜏3 ↦ 𝑒-stream-signature,
+      𝜏4 ↦ Φ.true,
+      ρ ↦ ∅
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-skip ↦ ⟦
+      φ ↦ Φ.hone.primitive-skip,
+      stream-class ↦ 𝑒-stream-class,
+      stream-signature ↦ 𝑒-stream-signature,
+      count ↦ "0"
+    ⟧,
+    𝐵-after
+  ⟧
+when:
+  or:
+    - and:
+        - eq: [ 𝑒-stream-class, '"java/util/stream/IntStream"' ]
+        - eq: [ 𝑒-stream-signature, '"(J)Ljava/util/stream/IntStream;"' ]
+    - and:
+        - eq: [ 𝑒-stream-class, '"java/util/stream/LongStream"' ]
+        - eq: [ 𝑒-stream-signature, '"(J)Ljava/util/stream/LongStream;"' ]
+    - and:
+        - eq: [ 𝑒-stream-class, '"java/util/stream/DoubleStream"' ]
+        - eq: [ 𝑒-stream-signature, '"(J)Ljava/util/stream/DoubleStream;"' ]
+where:
+  - meta: 𝜏-skip
+    function: random-tau
+    args: [ '𝐵-before', '𝐵-after' ]

--- a/src/main/resources/org/eolang/hone/rules/streams/224-recognize-primitive-skip-one.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/224-recognize-primitive-skip-one.phr
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Primitive-stream counterpart of 212. Recognizes a `.skip(1L)` call on
+# IntStream / LongStream / DoubleStream — the `lconst_1` that pushes the
+# count followed by the `invokeinterface (J)L<stream>;` — and abstracts
+# the pair into Φ.hone.primitive-skip with count="1". 712 mirrors it
+# back to bytecode when no fold takes over.
+name: recognize-primitive-skip-one
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-push ↦ ⟦
+      φ ↦ Φ.jeo.opcode.lconst_1,
+      ρ ↦ ∅
+    ⟧,
+    𝜏-invokeinterface ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      𝜏1 ↦ 𝑒-stream-class,
+      𝜏2 ↦ "skip",
+      𝜏3 ↦ 𝑒-stream-signature,
+      𝜏4 ↦ Φ.true,
+      ρ ↦ ∅
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-skip ↦ ⟦
+      φ ↦ Φ.hone.primitive-skip,
+      stream-class ↦ 𝑒-stream-class,
+      stream-signature ↦ 𝑒-stream-signature,
+      count ↦ "1"
+    ⟧,
+    𝐵-after
+  ⟧
+when:
+  or:
+    - and:
+        - eq: [ 𝑒-stream-class, '"java/util/stream/IntStream"' ]
+        - eq: [ 𝑒-stream-signature, '"(J)Ljava/util/stream/IntStream;"' ]
+    - and:
+        - eq: [ 𝑒-stream-class, '"java/util/stream/LongStream"' ]
+        - eq: [ 𝑒-stream-signature, '"(J)Ljava/util/stream/LongStream;"' ]
+    - and:
+        - eq: [ 𝑒-stream-class, '"java/util/stream/DoubleStream"' ]
+        - eq: [ 𝑒-stream-signature, '"(J)Ljava/util/stream/DoubleStream;"' ]
+where:
+  - meta: 𝜏-skip
+    function: random-tau
+    args: [ '𝐵-before', '𝐵-after' ]

--- a/src/main/resources/org/eolang/hone/rules/streams/226-recognize-primitive-skip-ldc.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/226-recognize-primitive-skip-ldc.phr
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Primitive-stream counterpart of 220. Recognizes a `.skip(N)` call on
+# IntStream / LongStream / DoubleStream where the count is loaded via a
+# generic `ldc` carrying a `Φ.jeo.long` literal (the canonical javac
+# encoding for any long argument other than 0L / 1L). The pair is
+# abstracted into Φ.hone.primitive-skip with count captured as the
+# underlying Φ.number. Mirror rule 722 lowers it back to bytecode.
+name: recognize-primitive-skip-ldc
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-push ↦ ⟦
+      φ ↦ Φ.jeo.opcode.ldc,
+      𝜏1 ↦ ⟦
+        φ ↦ Φ.jeo.long,
+        𝜏2 ↦ 𝑒-count,
+        ρ ↦ ∅
+      ⟧,
+      ρ ↦ ∅
+    ⟧,
+    𝜏-invokeinterface ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      𝜏3 ↦ 𝑒-stream-class,
+      𝜏4 ↦ "skip",
+      𝜏5 ↦ 𝑒-stream-signature,
+      𝜏6 ↦ Φ.true,
+      ρ ↦ ∅
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-skip ↦ ⟦
+      φ ↦ Φ.hone.primitive-skip,
+      stream-class ↦ 𝑒-stream-class,
+      stream-signature ↦ 𝑒-stream-signature,
+      count ↦ 𝑒-count
+    ⟧,
+    𝐵-after
+  ⟧
+when:
+  or:
+    - and:
+        - eq: [ 𝑒-stream-class, '"java/util/stream/IntStream"' ]
+        - eq: [ 𝑒-stream-signature, '"(J)Ljava/util/stream/IntStream;"' ]
+    - and:
+        - eq: [ 𝑒-stream-class, '"java/util/stream/LongStream"' ]
+        - eq: [ 𝑒-stream-signature, '"(J)Ljava/util/stream/LongStream;"' ]
+    - and:
+        - eq: [ 𝑒-stream-class, '"java/util/stream/DoubleStream"' ]
+        - eq: [ 𝑒-stream-signature, '"(J)Ljava/util/stream/DoubleStream;"' ]
+where:
+  - meta: 𝜏-skip
+    function: random-tau
+    args: [ '𝐵-before', '𝐵-after' ]

--- a/src/main/resources/org/eolang/hone/rules/streams/313-primitive-skip-zero-to-noop.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/313-primitive-skip-zero-to-noop.phr
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Primitive-stream counterpart of 311. Eliminates Φ.hone.primitive-skip
+# with count="0" — `.skip(0L)` on IntStream / LongStream / DoubleStream
+# is a no-op slice, so the whole block is replaced with a single
+# Φ.jeo.opcode.nop. Future state-carrying folds will handle non-zero
+# counts; the matching 222 rule only emits count="0", so this is the
+# canonical zero-count fold for primitive streams.
+name: primitive-skip-zero-to-noop
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-skip ↦ ⟦
+      φ ↦ Φ.hone.primitive-skip,
+      stream-class ↦ 𝑒-stream-class,
+      stream-signature ↦ 𝑒-stream-signature,
+      count ↦ "0",
+      ρ ↦ ∅
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-nop ↦ ⟦
+      φ ↦ Φ.jeo.opcode.nop
+    ⟧,
+    𝐵-after
+  ⟧
+where:
+  - meta: 𝜏-nop
+    function: random-tau
+    args: [ '𝐵-before', '𝐵-after' ]

--- a/src/main/resources/org/eolang/hone/rules/streams/712-primitive-skip-one-to-invokeinterface.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/712-primitive-skip-one-to-invokeinterface.phr
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Inverse of 224: lowers Φ.hone.primitive-skip with count="1" back into
+# the `lconst_1 + invokeinterface <primitive-stream>.skip:(J)L<stream>;`
+# byte pair. The stream-class and stream-signature captured by 224 are
+# reused verbatim so the regenerated invokeinterface matches the
+# original bytecode shape exactly. Fires when no earlier fold consumed
+# the pragma.
+name: primitive-skip-one-to-invokeinterface
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-skip ↦ ⟦
+      φ ↦ Φ.hone.primitive-skip,
+      stream-class ↦ 𝑒-stream-class,
+      stream-signature ↦ 𝑒-stream-signature,
+      count ↦ "1",
+      ρ ↦ ∅
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-push ↦ ⟦
+      φ ↦ Φ.jeo.opcode.lconst_1
+    ⟧,
+    𝜏-invokeinterface ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      i2 ↦ 𝑒-stream-class,
+      i3 ↦ "skip",
+      i4 ↦ 𝑒-stream-signature,
+      i5 ↦ Φ.true
+    ⟧,
+    𝐵-after
+  ⟧
+where:
+  - meta: 𝜏-push
+    function: random-tau
+    args: [ '𝐵-before', '𝐵-after' ]
+  - meta: 𝜏-invokeinterface
+    function: random-tau
+    args: [ '𝐵-before', '𝐵-after', '𝜏-push' ]

--- a/src/main/resources/org/eolang/hone/rules/streams/722-primitive-skip-ldc-to-invokeinterface.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/722-primitive-skip-ldc-to-invokeinterface.phr
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Inverse of 226: lowers Φ.hone.primitive-skip whose count was captured
+# as a Φ.number (ldc-based recognition) back into `ldc Φ.jeo.long(N) +
+# invokeinterface <primitive-stream>.skip:(J)L<stream>;`. The
+# when-clause excludes the string-typed count="0" / count="1" cases
+# produced by 222 / 224 so they stay on their dedicated lowering paths
+# (313 → nop and 712 → lconst_1) and never get round-tripped through a
+# `Φ.jeo.long("0"/"1")` wrapper — which would be invalid bytecode.
+name: primitive-skip-ldc-to-invokeinterface
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-skip ↦ ⟦
+      φ ↦ Φ.hone.primitive-skip,
+      stream-class ↦ 𝑒-stream-class,
+      stream-signature ↦ 𝑒-stream-signature,
+      count ↦ 𝑒-count,
+      ρ ↦ ∅
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-push ↦ ⟦
+      φ ↦ Φ.jeo.opcode.ldc,
+      i1 ↦ ⟦
+        φ ↦ Φ.jeo.long,
+        i1 ↦ 𝑒-count
+      ⟧
+    ⟧,
+    𝜏-invokeinterface ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      i2 ↦ 𝑒-stream-class,
+      i3 ↦ "skip",
+      i4 ↦ 𝑒-stream-signature,
+      i5 ↦ Φ.true
+    ⟧,
+    𝐵-after
+  ⟧
+when:
+  and:
+    - not:
+        eq: [ 𝑒-count, '"0"' ]
+    - not:
+        eq: [ 𝑒-count, '"1"' ]
+where:
+  - meta: 𝜏-push
+    function: random-tau
+    args: [ '𝐵-before', '𝐵-after' ]
+  - meta: 𝜏-invokeinterface
+    function: random-tau
+    args: [ '𝐵-before', '𝐵-after', '𝜏-push' ]

--- a/src/test/phino/222-recognize-primitive-skip.yml
+++ b/src/test/phino/222-recognize-primitive-skip.yml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 222 recognizes the bytecode pair `lconst_0` + `invokeinterface
+# java/util/stream/IntStream.skip:(J)Ljava/util/stream/IntStream;` (and
+# the LongStream / DoubleStream peers) and folds it into a single
+# Φ.hone.primitive-skip block carrying stream-class / stream-signature
+# / count="0".
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/222-recognize-primitive-skip.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      i1 ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_0 ⟧,
+      i2 ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokeinterface,
+        v1 ↦ "java/util/stream/IntStream",
+        v2 ↦ "skip",
+        v3 ↦ "(J)Ljava/util/stream/IntStream;",
+        v4 ↦ Φ.true
+      ⟧
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      𝐵-before,
+      𝜏-skip ↦ ⟦
+        φ ↦ Φ.hone.primitive-skip,
+        stream-class ↦ "java/util/stream/IntStream",
+        stream-signature ↦ "(J)Ljava/util/stream/IntStream;",
+        count ↦ "0"
+      ⟧,
+      𝐵-after
+    ⟧

--- a/src/test/phino/224-recognize-primitive-skip-one.yml
+++ b/src/test/phino/224-recognize-primitive-skip-one.yml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 224 recognizes the bytecode pair `lconst_1` + `invokeinterface
+# <primitive-stream>.skip:(J)L<stream>;` and folds it into a single
+# Φ.hone.primitive-skip block carrying count="1". Same shape as 212
+# but constrained to IntStream / LongStream / DoubleStream.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/224-recognize-primitive-skip-one.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      i1 ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_1 ⟧,
+      i2 ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokeinterface,
+        v1 ↦ "java/util/stream/LongStream",
+        v2 ↦ "skip",
+        v3 ↦ "(J)Ljava/util/stream/LongStream;",
+        v4 ↦ Φ.true
+      ⟧
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      𝐵-before,
+      𝜏-skip ↦ ⟦
+        φ ↦ Φ.hone.primitive-skip,
+        stream-class ↦ "java/util/stream/LongStream",
+        stream-signature ↦ "(J)Ljava/util/stream/LongStream;",
+        count ↦ "1"
+      ⟧,
+      𝐵-after
+    ⟧

--- a/src/test/phino/226-recognize-primitive-skip-ldc.yml
+++ b/src/test/phino/226-recognize-primitive-skip-ldc.yml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 226 recognizes the bytecode pair `ldc Φ.jeo.long(N)` + `invokeinterface
+# <primitive-stream>.skip:(J)L<stream>;` and folds it into a single
+# Φ.hone.primitive-skip block whose count is the underlying Φ.number.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/226-recognize-primitive-skip-ldc.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      i1 ↦ ⟦
+        φ ↦ Φ.jeo.opcode.ldc,
+        v0 ↦ ⟦
+          φ ↦ Φ.jeo.long,
+          n0 ↦ 7
+        ⟧
+      ⟧,
+      i2 ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokeinterface,
+        v1 ↦ "java/util/stream/DoubleStream",
+        v2 ↦ "skip",
+        v3 ↦ "(J)Ljava/util/stream/DoubleStream;",
+        v4 ↦ Φ.true
+      ⟧
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      𝐵-before,
+      𝜏-skip ↦ ⟦
+        φ ↦ Φ.hone.primitive-skip,
+        stream-class ↦ "java/util/stream/DoubleStream",
+        stream-signature ↦ "(J)Ljava/util/stream/DoubleStream;",
+        count ↦ 7
+      ⟧,
+      𝐵-after
+    ⟧

--- a/src/test/phino/313-primitive-skip-zero-to-noop.yml
+++ b/src/test/phino/313-primitive-skip-zero-to-noop.yml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 313 folds away Φ.hone.primitive-skip with count="0" — the `.skip(0L)`
+# idiom on IntStream / LongStream / DoubleStream — replacing the whole
+# block with a Φ.jeo.opcode.nop. Primitive-stream counterpart of 311.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/313-primitive-skip-zero-to-noop.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      i1 ↦ ⟦
+        φ ↦ Φ.hone.primitive-skip,
+        stream-class ↦ "java/util/stream/IntStream",
+        stream-signature ↦ "(J)Ljava/util/stream/IntStream;",
+        count ↦ "0"
+      ⟧
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      𝐵-before,
+      𝜏-nop ↦ ⟦
+        φ ↦ Φ.jeo.opcode.nop
+      ⟧,
+      𝐵-after
+    ⟧

--- a/src/test/phino/712-primitive-skip-one-to-invokeinterface.yml
+++ b/src/test/phino/712-primitive-skip-one-to-invokeinterface.yml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 712 is the inverse of 224: a Φ.hone.primitive-skip block with
+# count="1" that survived to the 7xx lowering phase is rewritten back
+# into the `lconst_1 + invokeinterface <primitive-stream>.skip:(J)L
+# <stream>;` byte pair, reusing the captured stream-class and
+# stream-signature verbatim.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/712-primitive-skip-one-to-invokeinterface.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      i1 ↦ ⟦
+        φ ↦ Φ.hone.primitive-skip,
+        stream-class ↦ "java/util/stream/IntStream",
+        stream-signature ↦ "(J)Ljava/util/stream/IntStream;",
+        count ↦ "1"
+      ⟧
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      𝐵-before,
+      𝜏-push ↦ ⟦
+        φ ↦ Φ.jeo.opcode.lconst_1
+      ⟧,
+      𝜏-invokeinterface ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokeinterface,
+        i2 ↦ "java/util/stream/IntStream",
+        i3 ↦ "skip",
+        i4 ↦ "(J)Ljava/util/stream/IntStream;",
+        i5 ↦ Φ.true
+      ⟧,
+      𝐵-after
+    ⟧

--- a/src/test/phino/722-primitive-skip-ldc-to-invokeinterface.yml
+++ b/src/test/phino/722-primitive-skip-ldc-to-invokeinterface.yml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 722 is the inverse of 226: a Φ.hone.primitive-skip block whose count
+# is a Φ.number is rewritten back into `ldc Φ.jeo.long(N) +
+# invokeinterface <primitive-stream>.skip:(J)L<stream>;`. The
+# when-clause keeps string-typed count="0" / "1" cases on their own
+# lowering paths.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/722-primitive-skip-ldc-to-invokeinterface.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      i1 ↦ ⟦
+        φ ↦ Φ.hone.primitive-skip,
+        stream-class ↦ "java/util/stream/LongStream",
+        stream-signature ↦ "(J)Ljava/util/stream/LongStream;",
+        count ↦ 9
+      ⟧
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      𝐵-before,
+      𝜏-push ↦ ⟦
+        φ ↦ Φ.jeo.opcode.ldc,
+        i1 ↦ ⟦
+          φ ↦ Φ.jeo.long,
+          i1 ↦ 9
+        ⟧
+      ⟧,
+      𝜏-invokeinterface ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokeinterface,
+        i2 ↦ "java/util/stream/LongStream",
+        i3 ↦ "skip",
+        i4 ↦ "(J)Ljava/util/stream/LongStream;",
+        i5 ↦ Φ.true
+      ⟧,
+      𝐵-after
+    ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams-skipped-primitive.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-skipped-primitive.yml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Asserts that `.skip(0L)` on IntStream / LongStream / DoubleStream is
+# eliminated as a no-op, while a non-zero `.skip(N)` round-trips. The
+# 222 recognizer folds `lconst_0 + invokeinterface IntStream.skip(J)`
+# into Φ.hone.primitive-skip(count="0"); 313 then collapses it to
+# Φ.jeo.opcode.nop. Without the rules, all three .skip(0L) calls would
+# remain as opaque pass-through invokeinterface stages. The LongStream
+# .skip(2L) is recognized by 226 and mirrored back to bytecode by 722
+# unchanged. Together this proves the primitive-stream skip variants
+# behave exactly like their object-Stream counterparts.
+java: |
+  package skippedprimitive;
+  import java.util.stream.IntStream;
+  import java.util.stream.LongStream;
+  import java.util.stream.DoubleStream;
+  public class X {
+    public static void main(String[] a) {
+      int i = IntStream.of(1, 2, 3, 4, 5).skip(0L).sum();
+      long l = LongStream.of(10L, 20L, 30L, 40L).skip(2L).sum();
+      double d = DoubleStream.of(1.5, 2.5, 3.5).skip(0L).sum();
+      System.out.printf("Sums are %d %d %.1f\n", i, l, d);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "Sums are 15 70 7.5"
+opcodes:
+  invokeinterface: 4


### PR DESCRIPTION
## Summary

Continues #546 from [#550](https://github.com/objectionary/hone-maven-plugin/pull/550) and [#554](https://github.com/objectionary/hone-maven-plugin/pull/554). Adds bytecode-level recognition for `.skip(long)` on `IntStream`, `LongStream`, and `DoubleStream` — explicitly called out in the original issue ("The primitive specializations (`IntStream.skip`, `LongStream.skip`, `DoubleStream.skip`) have the same shape").

Mirrors the take-while convention that landed in `213-lambda-to-take-while.phr` / `214-lambda-to-primitive-take-while.phr`: Object Stream stays on the `Φ.hone.skip` pragma; the three primitive specializations share a new `Φ.hone.primitive-skip` pragma so the routing stays clean and the existing 210/212/220/311/710/720 chain is untouched.

## Rules added

| Rule | What it does |
|---|---|
| `222-recognize-primitive-skip.phr` | `lconst_0 + invokeinterface (J)L<primitive-stream>;` → `Φ.hone.primitive-skip(count="0")` |
| `224-recognize-primitive-skip-one.phr` | `lconst_1 + ...` → `Φ.hone.primitive-skip(count="1")` |
| `226-recognize-primitive-skip-ldc.phr` | `ldc Φ.jeo.long(N) + ...` → `Φ.hone.primitive-skip(count=Φ.number)` |
| `313-primitive-skip-zero-to-noop.phr` | `Φ.hone.primitive-skip(count="0")` → `Φ.jeo.opcode.nop` (primitive counterpart of 311) |
| `712-primitive-skip-one-to-invokeinterface.phr` | Reverse for `count="1"` |
| `722-primitive-skip-ldc-to-invokeinterface.phr` | Reverse for the `Φ.number` count case |

The pragma carries both `stream-class` and `stream-signature` verbatim, so the reverse rules can regenerate the exact original `invokeinterface` for whichever primitive stream the source used — no `concat` / `sed` signature derivation.

`when:` clauses limit recognition to the three JDK primitive stream classes; user-defined interfaces with similarly-shaped `skip(J)` methods are not rewritten.

## Scope

This completes the **recognition layer** for `.skip` across all four JDK stream types. Pipeline state after this PR:

- `Stream.skip(0L)` → `nop` (real optimization — 210 + 311)
- `Stream.skip(1L | N)` → round-trip (210/212/220 + 710/720)
- `IntStream.skip(0L)` → `nop` (new — 222 + 313)
- `IntStream.skip(1L | N)` → round-trip (224/226 + 712/722) — and same for Long / Double
- The state-carrying fold (analogous to `351-take-while-to-mapMulti`, with a captured `long[1]` counter) for non-zero counts on any of the four stream types remains follow-up work.

## Test plan

- [x] `bash src/test/phino/run.sh` — all 34 phino tests pass (28 existing + 6 new).
- [x] `yamllint` clean on all new files.
- [x] Manually verified the full pipeline (222/224/226 + 313/712/722 together) on a body containing all three push variants for three primitive streams (`IntStream` lconst_0, `LongStream` lconst_1, `DoubleStream` ldc 11L) — zero collapses to `nop`, the others round-trip with the correct stream-specific signature.
- [ ] CI runs the Docker-backed end-to-end pack `streams-skipped-primitive.yml` against a real build to confirm the optimized class prints `Sums are 15 70 7.5`.