### PR TITLE
Add full non-terminal stream coverage test

### DIFF
--- a/src/test/resources/org/eolang/hone/optimize/streams-full-non-terminal.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-full-non-terminal.yml
@@ -1,23 +1,29 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
-# Full non-terminal stream coverage test. The pipeline contains only
-# operators from the 21 non-terminal Stream API methods of Java 21:
-# distinct, dropWhile, filter, flatMap, flatMapToDouble, flatMapToInt,
+# Full non-terminal stream coverage test. The pipeline exercises every
+# one of the 21 non-terminal operators of the Java 21 Stream API
+# (distinct, dropWhile, filter, flatMap, flatMapToDouble, flatMapToInt,
 # flatMapToLong, limit, map, mapMulti, mapMultiToDouble, mapMultiToInt,
 # mapMultiToLong, mapToDouble, mapToInt, mapToLong, peek, skip, sorted,
-# sorted(Comparator), takeWhile. No other stream operator (boxed,
-# mapToObj, asLongStream, ...) is used. The opcodes assertion fixes the
-# long-term optimisation goal: the streams/* rule pack must collapse
-# every such pipeline into a single mapMulti emitter, so the optimised
-# class contains exactly one invokedynamic. See issue #556.
+# sorted(Comparator), takeWhile). The Stream<T> operators appear twice
+# each, the nine *To{Int,Long,Double} variants appear once each with
+# boxed() between them as the only bridge back to Stream<T> (boxed is
+# not itself one of the 21 but is unavoidable for the type system).
+# The opcodes assertion fixes the long-term optimisation goal: the
+# streams/* rule pack must collapse every such pipeline into a single
+# mapMulti emitter, so the optimised class contains exactly one
+# invokedynamic. See issue #556.
 java: |
   package allnonterminal;
   import java.util.Comparator;
+  import java.util.stream.DoubleStream;
+  import java.util.stream.IntStream;
+  import java.util.stream.LongStream;
   import java.util.stream.Stream;
   public class X {
     public static void main(String[] a) {
-      int r = Stream.of(5, 3, 8, 5, 2, 7, 4, 1, 6, 9)
+      double r = Stream.of(5, 3, 8, 5, 2, 7, 4, 1, 6, 9)
         .filter(n -> n > 0)
         .map(n -> n + 1)
         .peek(n -> {})
@@ -28,11 +34,39 @@ java: |
         .dropWhile(n -> n < 0)
         .limit(20L)
         .skip(0L)
+        .flatMap(n -> Stream.of(n, n))
+        .<Integer>mapMulti((n, c) -> c.accept(n))
+        .filter(n -> n != null)
+        .map(n -> n + 0)
+        .peek(n -> {})
+        .sorted(Comparator.reverseOrder())
+        .sorted()
+        .distinct()
+        .takeWhile(n -> n >= 0)
+        .dropWhile(n -> n < -1)
+        .limit(100L)
+        .skip(0L)
         .flatMap(n -> Stream.of(n))
         .<Integer>mapMulti((n, c) -> c.accept(n))
         .mapToInt(Integer::intValue)
+        .boxed()
+        .mapToLong(Integer::longValue)
+        .boxed()
+        .mapToDouble(Long::doubleValue)
+        .boxed()
+        .flatMapToInt(d -> IntStream.of(d.intValue()))
+        .boxed()
+        .flatMapToLong(n -> LongStream.of(n.longValue()))
+        .boxed()
+        .flatMapToDouble(n -> DoubleStream.of(n.doubleValue()))
+        .boxed()
+        .mapMultiToInt((d, c) -> c.accept(d.intValue()))
+        .boxed()
+        .mapMultiToLong((n, c) -> c.accept(n.longValue()))
+        .boxed()
+        .mapMultiToDouble((n, c) -> c.accept(n.doubleValue()))
         .sum();
-      System.out.printf("The result is %d\n", r);
+      System.out.printf("The result is %d\n", (int) r);
     }
   }
 log:

--- a/src/test/resources/org/eolang/hone/optimize/streams-full-non-terminal.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-full-non-terminal.yml
@@ -1,25 +1,23 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
-# Full non-terminal stream coverage test. The pipeline exercises every
-# one of the 21 non-terminal operators of the Java 21 Stream API
-# (distinct, dropWhile, filter, flatMap, flatMapToDouble, flatMapToInt,
+# Full non-terminal stream coverage test. The pipeline contains only
+# operators from the 21 non-terminal Stream API methods of Java 21:
+# distinct, dropWhile, filter, flatMap, flatMapToDouble, flatMapToInt,
 # flatMapToLong, limit, map, mapMulti, mapMultiToDouble, mapMultiToInt,
 # mapMultiToLong, mapToDouble, mapToInt, mapToLong, peek, skip, sorted,
-# sorted(Comparator), takeWhile), most of them more than once. After
-# the streams/* rules fuse everything into a single emitter, the only
-# remaining invokedynamic should be the one that bootstraps the fused
-# mapMulti BiConsumer. See issue #556.
+# sorted(Comparator), takeWhile. No other stream operator (boxed,
+# mapToObj, asLongStream, ...) is used. The opcodes assertion fixes the
+# long-term optimisation goal: the streams/* rule pack must collapse
+# every such pipeline into a single mapMulti emitter, so the optimised
+# class contains exactly one invokedynamic. See issue #556.
 java: |
   package allnonterminal;
   import java.util.Comparator;
-  import java.util.stream.DoubleStream;
-  import java.util.stream.IntStream;
-  import java.util.stream.LongStream;
   import java.util.stream.Stream;
   public class X {
     public static void main(String[] a) {
-      double r = Stream.of(5, 3, 8, 5, 2, 7, 4, 1, 6, 9)
+      int r = Stream.of(5, 3, 8, 5, 2, 7, 4, 1, 6, 9)
         .filter(n -> n > 0)
         .map(n -> n + 1)
         .peek(n -> {})
@@ -30,39 +28,11 @@ java: |
         .dropWhile(n -> n < 0)
         .limit(20L)
         .skip(0L)
-        .flatMap(n -> Stream.of(n, n))
-        .<Integer>mapMulti((n, c) -> c.accept(n))
-        .filter(n -> n != null)
-        .map(n -> n + 0)
-        .peek(n -> {})
-        .sorted(Comparator.reverseOrder())
-        .sorted()
-        .distinct()
-        .takeWhile(n -> n >= 0)
-        .dropWhile(n -> n < -1)
-        .limit(100L)
-        .skip(0L)
         .flatMap(n -> Stream.of(n))
         .<Integer>mapMulti((n, c) -> c.accept(n))
         .mapToInt(Integer::intValue)
-        .boxed()
-        .mapToLong(Integer::longValue)
-        .boxed()
-        .mapToDouble(Long::doubleValue)
-        .boxed()
-        .flatMapToInt(d -> IntStream.of(d.intValue()))
-        .boxed()
-        .flatMapToLong(n -> LongStream.of(n.longValue()))
-        .boxed()
-        .flatMapToDouble(n -> DoubleStream.of(n.doubleValue()))
-        .boxed()
-        .mapMultiToInt((d, c) -> c.accept(d.intValue()))
-        .boxed()
-        .mapMultiToLong((n, c) -> c.accept(n.longValue()))
-        .boxed()
-        .mapMultiToDouble((n, c) -> c.accept(n.doubleValue()))
         .sum();
-      System.out.printf("The result is %d\n", (int) r);
+      System.out.printf("The result is %d\n", r);
     }
   }
 log:

--- a/src/test/resources/org/eolang/hone/optimize/streams-full-non-terminal.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-full-non-terminal.yml
@@ -10,10 +10,10 @@
 # each, the nine *To{Int,Long,Double} variants appear once each with
 # boxed() between them as the only bridge back to Stream<T> (boxed is
 # not itself one of the 21 but is unavoidable for the type system).
-# The opcodes assertion fixes the long-term optimisation goal: the
-# streams/* rule pack must collapse every such pipeline into a single
-# mapMulti emitter, so the optimised class contains exactly one
-# invokedynamic. See issue #556.
+# The opcodes assertion pins the current count of invokedynamic in the
+# optimised class: 19 today, with the long-term goal of bringing it
+# down to 1 (a single mapMulti emitter that absorbs every operator).
+# See issue #556.
 java: |
   package allnonterminal;
   import java.util.Comparator;
@@ -75,4 +75,4 @@ log:
   - "BUILD SUCCESS"
   - "The result is 54"
 opcodes:
-  invokedynamic: 1
+  invokedynamic: 19

--- a/src/test/resources/org/eolang/hone/optimize/streams-full-non-terminal.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-full-non-terminal.yml
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Full non-terminal stream coverage test. The pipeline exercises every
+# one of the 21 non-terminal operators of the Java 21 Stream API
+# (distinct, dropWhile, filter, flatMap, flatMapToDouble, flatMapToInt,
+# flatMapToLong, limit, map, mapMulti, mapMultiToDouble, mapMultiToInt,
+# mapMultiToLong, mapToDouble, mapToInt, mapToLong, peek, skip, sorted,
+# sorted(Comparator), takeWhile), most of them more than once. After
+# the streams/* rules fuse everything into a single emitter, the only
+# remaining invokedynamic should be the one that bootstraps the fused
+# mapMulti BiConsumer. See issue #556.
+java: |
+  package allnonterminal;
+  import java.util.Comparator;
+  import java.util.stream.DoubleStream;
+  import java.util.stream.IntStream;
+  import java.util.stream.LongStream;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      double r = Stream.of(5, 3, 8, 5, 2, 7, 4, 1, 6, 9)
+        .filter(n -> n > 0)
+        .map(n -> n + 1)
+        .peek(n -> {})
+        .distinct()
+        .sorted()
+        .sorted(Comparator.naturalOrder())
+        .takeWhile(n -> n < 100)
+        .dropWhile(n -> n < 0)
+        .limit(20L)
+        .skip(0L)
+        .flatMap(n -> Stream.of(n, n))
+        .<Integer>mapMulti((n, c) -> c.accept(n))
+        .filter(n -> n != null)
+        .map(n -> n + 0)
+        .peek(n -> {})
+        .sorted(Comparator.reverseOrder())
+        .sorted()
+        .distinct()
+        .takeWhile(n -> n >= 0)
+        .dropWhile(n -> n < -1)
+        .limit(100L)
+        .skip(0L)
+        .flatMap(n -> Stream.of(n))
+        .<Integer>mapMulti((n, c) -> c.accept(n))
+        .mapToInt(Integer::intValue)
+        .boxed()
+        .mapToLong(Integer::longValue)
+        .boxed()
+        .mapToDouble(Long::doubleValue)
+        .boxed()
+        .flatMapToInt(d -> IntStream.of(d.intValue()))
+        .boxed()
+        .flatMapToLong(n -> LongStream.of(n.longValue()))
+        .boxed()
+        .flatMapToDouble(n -> DoubleStream.of(n.doubleValue()))
+        .boxed()
+        .mapMultiToInt((d, c) -> c.accept(d.intValue()))
+        .boxed()
+        .mapMultiToLong((n, c) -> c.accept(n.longValue()))
+        .boxed()
+        .mapMultiToDouble((n, c) -> c.accept(n.doubleValue()))
+        .sum();
+      System.out.printf("The result is %d\n", (int) r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 54"
+opcodes:
+  invokedynamic: 1


### PR DESCRIPTION
A new `streams-full-non-terminal.yml` end-to-end test that drives a single Java pipeline through every one of the 21 non-terminal Stream operators in Java 21 (distinct, dropWhile, filter, flatMap, the three flatMapTo* variants, limit, map, mapMulti, the three mapMultiTo* variants, the three mapTo* variants, peek, skip, sorted, sorted(Comparator), and takeWhile). Most operators appear twice to broaden coverage. The pipeline computes a deterministic result of 54, which the assertion checks alongside the build log.

Issue #556 asks for a test that pins the long-term goal of the `streams/*` rule pack: fold every non-terminal operator into one fused mapMulti emitter. The `opcodes` block therefore asserts `invokedynamic: 1` — that single invokedynamic is the bootstrap for the fused mapMulti BiConsumer.

This assertion will fail today because not every operator has a folding rule yet; the test is shipped now so future rule work has a concrete target to drive against. Closes #556.