### PR TITLE
feat(streams): recognize Stream.limit(long) via ldc

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/216-recognize-limit-ldc.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/216-recognize-limit-ldc.phr
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Recognizes a stream `.limit(N)` call where the count is loaded via a
+# generic `ldc` carrying a `Φ.jeo.long` literal (the canonical javac
+# encoding for any long argument such as `20L` or `5L`). The pair is
+# abstracted into Φ.hone.limit with count captured as the underlying
+# Φ.number. Mirror rule 722 lowers it back to ldc + invokeinterface
+# when no fold matches; future state-carrying limit optimizations will
+# consume the recognized pragma instead. Sibling of 220 for skip; see
+# issue #548.
+name: recognize-limit-ldc
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-push ↦ ⟦
+      φ ↦ Φ.jeo.opcode.ldc,
+      𝜏1 ↦ ⟦
+        φ ↦ Φ.jeo.long,
+        𝜏2 ↦ 𝑒-count,
+        ρ ↦ ∅
+      ⟧,
+      ρ ↦ ∅
+    ⟧,
+    𝜏-invokeinterface ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      𝜏3 ↦ "java/util/stream/Stream",
+      𝜏4 ↦ "limit",
+      𝜏5 ↦ "(J)Ljava/util/stream/Stream;",
+      𝜏6 ↦ Φ.true,
+      ρ ↦ ∅
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-limit ↦ ⟦
+      φ ↦ Φ.hone.limit,
+      stream-class ↦ "java/util/stream/Stream",
+      count ↦ 𝑒-count
+    ⟧,
+    𝐵-after
+  ⟧
+where:
+  - meta: 𝜏-limit
+    function: random-tau
+    args: [ '𝐵-before', '𝐵-after' ]

--- a/src/main/resources/org/eolang/hone/rules/streams/722-limit-ldc-to-invokeinterface.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/722-limit-ldc-to-invokeinterface.phr
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Inverse of 216: lowers Φ.hone.limit whose count was captured as a
+# Φ.number (ldc-based recognition) back into the `ldc Φ.jeo.long(N) +
+# invokeinterface java/util/stream/Stream.limit:(J)Ljava/util/stream/
+# Stream;` byte pair. Fires only when no earlier rule has folded the
+# limit into something else; ensures any recognized `.limit(N)` is
+# always emitted as valid bytecode by 7xx, even when the eventual
+# state-carrying fusion path is not yet in place. Sibling of 720 for
+# skip; see issue #548.
+name: limit-ldc-to-invokeinterface
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-limit ↦ ⟦
+      φ ↦ Φ.hone.limit,
+      stream-class ↦ 𝑒-stream-class,
+      count ↦ 𝑒-count,
+      ρ ↦ ∅
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-push ↦ ⟦
+      φ ↦ Φ.jeo.opcode.ldc,
+      i1 ↦ ⟦
+        φ ↦ Φ.jeo.long,
+        i1 ↦ 𝑒-count
+      ⟧
+    ⟧,
+    𝜏-invokeinterface ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      i2 ↦ 𝑒-stream-class,
+      i3 ↦ "limit",
+      i4 ↦ "(J)Ljava/util/stream/Stream;",
+      i5 ↦ Φ.true
+    ⟧,
+    𝐵-after
+  ⟧
+where:
+  - meta: 𝜏-push
+    function: random-tau
+    args: [ '𝐵-before', '𝐵-after' ]
+  - meta: 𝜏-invokeinterface
+    function: random-tau
+    args: [ '𝐵-before', '𝐵-after', '𝜏-push' ]

--- a/src/test/resources/org/eolang/hone/rules/streams/expressions/216-recognize-limit-ldc.phi
+++ b/src/test/resources/org/eolang/hone/rules/streams/expressions/216-recognize-limit-ldc.phi
@@ -1,0 +1,49 @@
+{⟦
+  j$Foo ↦ ⟦
+    φ ↦ Φ.jeo.class,
+    version ↦ 66,
+    access ↦ 33,
+    modifiers ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+    name ↦ "Foo",
+    supername ↦ "java/lang/Object",
+    interfaces ↦ ⟦
+      φ ↦ Φ.jeo.seq.of0
+    ⟧,
+    j$main ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 4096,
+      modifiers ↦ ⟦ static ↦ Φ.true ⟧,
+      name ↦ "main",
+      descriptor ↦ "()V",
+      signature ↦ "",
+      exceptions ↦ "Exceptions",
+      maxs ↦ ⟦
+        φ ↦ Φ.jeo.seq.of2,
+        v1 ↦ 5,
+        v2 ↦ 5
+      ⟧,
+      params ↦ ⟦ φ ↦ Φ.jeo.seq.of2 ⟧,
+      annotations ↦ ⟦ φ ↦ Φ.jeo.seq.of2 ⟧,
+      body ↦ ⟦
+        φ ↦ Φ.jeo.seq.of2,
+        i2186 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.ldc,
+          v2194 ↦ ⟦
+            φ ↦ Φ.jeo.long,
+            v2196 ↦ 20
+          ⟧
+        ⟧,
+        i2362 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          v2369 ↦ "java/util/stream/Stream",
+          v2371 ↦ "limit",
+          v2372 ↦ "(J)Ljava/util/stream/Stream;",
+          v2376 ↦ Φ.true
+        ⟧
+      ⟧,
+      trycatchblocks ↦ ⟦⟧,
+      local-variable-table ↦ ⟦⟧
+    ⟧,
+    signature ↦ ""
+  ⟧
+⟧}


### PR DESCRIPTION
Adds a recognizer for `.limit(long)` so the byte pair `ldc(Φ.jeo.long N) + invokeinterface java/util/stream/Stream.limit:(J)Ljava/util/stream/Stream;` is abstracted into a single `Φ.hone.limit` pragma. A companion 7xx rule lowers the pragma back to the same byte pair when nothing else consumes it, so the round-trip is observationally a no-op.

The motivation is on the ticket: the 2xx stage has recognizers for filter, map, flatMap, unbox, box, skip, sorted, takeWhile and dropWhile, but no recognizer for limit. As a result `.limit(N)` sits in the body as raw bytecode and blocks 3xx/4xx fusion across it — for example `.map(...).limit(k).map(...)` cannot collapse into one mapMulti. Recognition alone is enough to unblock the neighbour rules; the two new files mirror the existing skip family one-for-one (216 mirrors 220, 722 mirrors 720).

Folding `Φ.hone.limit` into the distill chain is deliberately out of scope here — that's the state-carrying fusion path and it deserves its own ticket. The mirror in 722 keeps the bytecode valid until that lands.

Closes #548