### PR TITLE
Optimize Stream.distinct() via mapMulti with HashSet

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/216-recognize-distinct.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/216-recognize-distinct.phr
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Recognizes a stream `.distinct()` call — the bare `invokeinterface
+# java/util/stream/Stream.distinct:()Ljava/util/stream/Stream;` opcode —
+# and abstracts it into a single Φ.hone.distinct block. Unlike skip,
+# takeWhile and dropWhile, distinct takes no extra argument and no
+# lambda, so the recognition pattern is just one opcode. The downstream
+# rule 353 folds Φ.hone.distinct into Stream.mapMulti with a captured
+# java/util/HashSet seen-set; 730 is the unrecognise fallback for
+# pragmas not consumed by 353.
+name: recognize-distinct
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-invokeinterface ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      𝜏1 ↦ "java/util/stream/Stream",
+      𝜏2 ↦ "distinct",
+      𝜏3 ↦ "()Ljava/util/stream/Stream;",
+      𝜏4 ↦ Φ.true,
+      ρ ↦ ∅
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-distinct ↦ ⟦
+      φ ↦ Φ.hone.distinct,
+      stream-class ↦ "java/util/stream/Stream"
+    ⟧,
+    𝐵-after
+  ⟧
+where:
+  - meta: 𝜏-distinct
+    function: random-tau
+    args: [ '𝐵-before', '𝐵-after' ]

--- a/src/main/resources/org/eolang/hone/rules/streams/353-distinct-to-mapMulti.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/353-distinct-to-mapMulti.phr
@@ -1,0 +1,178 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 353-distinct-to-mapMulti
+#
+# Lowers Φ.hone.distinct (object Stream variant produced by 216) into:
+#   * Raw bytecode that allocates a fresh java/util/HashSet on the stack
+#     (new + dup + invokespecial HashSet.<init>)
+#   * A Φ.hone.lambda pragma that creates a BiConsumer capturing that
+#     HashSet, then calls Stream.mapMulti(BiConsumer)
+#   * A new synthetic private static wrapper method that implements
+#     distinct semantics: for every element, HashSet.add returns true
+#     iff the value has not been seen before, in which case the wrapper
+#     forwards it to the mapMulti Consumer; otherwise the element is
+#     swallowed.
+#
+# After this rule:
+#   * 701 picks up the Φ.hone.lambda and lowers it to invokedynamic +
+#     invokeinterface(mapMulti).
+#   * No user lambda is involved — the wrapper is self-contained.
+#
+# Mirror of 351 / 352 with two differences: the captured state is an
+# object reference (HashSet) rather than a boolean[1], and there is no
+# pre-existing predicate to dispatch to.
+name: distinct-to-mapMulti
+pattern: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    𝐵-class-head-before,
+    name ↦ 𝑒-class-name,
+    𝐵-class-head-after,
+    𝜏-caller ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      𝐵-caller-head,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-distinct ↦ ⟦
+          φ ↦ Φ.hone.distinct,
+          stream-class ↦ "java/util/stream/Stream"
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝐵-caller-tail
+    ⟧,
+    𝐵-class-tail,
+    ρ ↦ ∅
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    𝐵-class-head-before,
+    name ↦ 𝑒-class-name,
+    𝐵-class-head-after,
+    𝜏-caller ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      𝐵-caller-head,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-new ↦ ⟦
+          φ ↦ Φ.jeo.opcode.new,
+          i1 ↦ "java/util/HashSet"
+        ⟧,
+        𝜏-dup ↦ ⟦
+          φ ↦ Φ.jeo.opcode.dup
+        ⟧,
+        𝜏-init ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokespecial,
+          i2 ↦ "java/util/HashSet",
+          i3 ↦ "<init>",
+          i4 ↦ "()V",
+          i5 ↦ Φ.false
+        ⟧,
+        𝜏-lambda ↦ ⟦
+          φ ↦ Φ.hone.lambda,
+          class ↦ 𝑒-class-name,
+          method ↦ "accept",
+          interface ↦ "(Ljava/util/HashSet;)Ljava/util/function/BiConsumer;",
+          lambda-signature ↦ "(Ljava/lang/Object;Ljava/lang/Object;)V",
+          bridge-signature ↦ "(Ljava/lang/Object;Ljava/util/function/Consumer;)V",
+          static ↦ "true",
+          opcode ↦ "invokestatic",
+          target ↦ ⟦
+            handle ↦ 6,
+            class ↦ 𝑒-class-name,
+            method ↦ 𝑒-wrapper-method,
+            signature ↦ "(Ljava/util/HashSet;Ljava/lang/Object;Ljava/util/function/Consumer;)V",
+            is-interface ↦ Φ.false
+          ⟧,
+          stream ↦ ⟦
+            class ↦ "java/util/stream/Stream",
+            method ↦ "mapMulti",
+            signature ↦ "(Ljava/util/function/BiConsumer;)Ljava/util/stream/Stream;"
+          ⟧
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝐵-caller-tail
+    ⟧,
+    𝐵-class-tail,
+    𝜏-wrapper ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 4106,
+      descriptor ↦ "(Ljava/util/HashSet;Ljava/lang/Object;Ljava/util/function/Consumer;)V",
+      signature ↦ "",
+      maxs ↦ ⟦
+        φ ↦ Φ.jeo.maxs,
+        max-stack ↦ 2,
+        max-locals ↦ 3
+      ⟧,
+      params ↦ ⟦
+        φ ↦ Φ.jeo.params,
+        i1 ↦ ⟦ φ ↦ Φ.jeo.param, index ↦ 0, access ↦ 0, type ↦ "Ljava/util/HashSet;" ⟧,
+        i2 ↦ ⟦ φ ↦ Φ.jeo.param, index ↦ 1, access ↦ 0, type ↦ "Ljava/lang/Object;" ⟧,
+        i3 ↦ ⟦ φ ↦ Φ.jeo.param, index ↦ 2, access ↦ 0, type ↦ "Ljava/util/function/Consumer;" ⟧
+      ⟧,
+      body ↦ ⟦
+        φ ↦ Φ.jeo.seq.of,
+        w0 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 0 ⟧,
+        w1 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
+        w2 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokevirtual,
+          i2 ↦ "java/util/HashSet",
+          i3 ↦ "add",
+          i4 ↦ "(Ljava/lang/Object;)Z",
+          i5 ↦ Φ.false
+        ⟧,
+        w3 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.ifeq,
+          i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label-end ⟧
+        ⟧,
+        w4 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 2 ⟧,
+        w5 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
+        w6 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          i2 ↦ "java/util/function/Consumer",
+          i3 ↦ "accept",
+          i4 ↦ "(Ljava/lang/Object;)V",
+          i5 ↦ Φ.true
+        ⟧,
+        w7 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label-end ⟧,
+        w8 ↦ ⟦
+          φ ↦ Φ.jeo.frame,
+          type ↦ 3,
+          nlocal ↦ 0,
+          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+          nstack ↦ 0,
+          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
+        ⟧,
+        w9 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+        ρ ↦ ∅
+      ⟧,
+      name ↦ 𝑒-wrapper-method
+    ⟧,
+    ρ ↦ ∅
+  ⟧
+where:
+  - meta: 𝜏-new
+    function: random-tau
+    args: ['𝐵-body-head', '𝐵-body-tail']
+  - meta: 𝜏-dup
+    function: random-tau
+    args: ['𝐵-body-head', '𝐵-body-tail', '𝜏-new']
+  - meta: 𝜏-init
+    function: random-tau
+    args: ['𝐵-body-head', '𝐵-body-tail', '𝜏-new', '𝜏-dup']
+  - meta: 𝜏-lambda
+    function: random-tau
+    args: ['𝐵-body-head', '𝐵-body-tail', '𝜏-new', '𝜏-dup', '𝜏-init']
+  - meta: 𝑒-wrapper-method
+    function: random-string
+    args: ['"hone_distinct_%d"']
+  - meta: 𝜏-wrapper
+    function: random-tau
+    args: ['name', '𝐵-class-head-before', '𝐵-class-head-after', '𝐵-class-tail', '𝜏-caller']
+  - meta: 𝑒-label-end
+    function: random-string
+    args: ['"LdistinctEnd%d"']

--- a/src/main/resources/org/eolang/hone/rules/streams/730-distinct-to-invokeinterface.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/730-distinct-to-invokeinterface.phr
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Inverse of 216: lowers any Φ.hone.distinct pragma that was not
+# consumed by 353 back into the canonical `invokeinterface
+# java/util/stream/Stream.distinct:()Ljava/util/stream/Stream;` opcode.
+# This guarantees that any recognized `.distinct()` is always emitted
+# as valid bytecode by 7xx — even when the state-carrying mapMulti
+# fusion at 353 does not fire (e.g. when the class shape blocks the
+# class-level rewrite).
+name: distinct-to-invokeinterface
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-distinct ↦ ⟦
+      φ ↦ Φ.hone.distinct,
+      stream-class ↦ 𝑒-stream-class,
+      ρ ↦ ∅
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-invokeinterface ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      i2 ↦ 𝑒-stream-class,
+      i3 ↦ "distinct",
+      i4 ↦ "()Ljava/util/stream/Stream;",
+      i5 ↦ Φ.true
+    ⟧,
+    𝐵-after
+  ⟧
+where:
+  - meta: 𝜏-invokeinterface
+    function: random-tau
+    args: [ '𝐵-before', '𝐵-after' ]

--- a/src/test/phino/216-recognize-distinct.yml
+++ b/src/test/phino/216-recognize-distinct.yml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 216 recognizes the bare `invokeinterface java/util/stream/Stream.distinct:
+# ()Ljava/util/stream/Stream;` opcode (no preceding push, no lambda) and
+# folds it into a single Φ.hone.distinct block. This is the bytecode-
+# level entry point for the distinct recognizer; see issue #547. 353
+# folds the pragma into Stream.mapMulti with a captured HashSet; 730 is
+# the unrecognise fallback for pragmas not consumed by 353.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/216-recognize-distinct.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      i1 ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokeinterface,
+        v1 ↦ "java/util/stream/Stream",
+        v2 ↦ "distinct",
+        v3 ↦ "()Ljava/util/stream/Stream;",
+        v4 ↦ Φ.true
+      ⟧
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      𝐵-before,
+      𝜏-distinct ↦ ⟦
+        φ ↦ Φ.hone.distinct,
+        stream-class ↦ "java/util/stream/Stream"
+      ⟧,
+      𝐵-after
+    ⟧

--- a/src/test/phino/730-distinct-to-invokeinterface.yml
+++ b/src/test/phino/730-distinct-to-invokeinterface.yml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 730 is the unrecognise fallback for Φ.hone.distinct pragmas that were
+# not consumed by 353 — it lowers them back into a bare `invokeinterface
+# java/util/stream/Stream.distinct:()Ljava/util/stream/Stream;` opcode,
+# the same shape produced by javac and recognized by 216. See issue
+# #547. Mirror of 710 / 720 for skip.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/730-distinct-to-invokeinterface.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      a1 ↦ ⟦
+        φ ↦ Φ.hone.distinct,
+        stream-class ↦ "java/util/stream/Stream"
+      ⟧
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      𝐵-before,
+      𝜏-invokeinterface ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokeinterface,
+        i2 ↦ "java/util/stream/Stream",
+        i3 ↦ "distinct",
+        i4 ↦ "()Ljava/util/stream/Stream;",
+        i5 ↦ Φ.true
+      ⟧,
+      𝐵-after
+    ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams-all-ops.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-all-ops.yml
@@ -46,8 +46,8 @@ log:
   - "BUILD SUCCESS"
   - "The result is 54"
 opcodes:
-  invokespecial: 1
+  invokespecial: 2
   invokestatic: 25
-  invokevirtual: 11
-  invokedynamic: 15
-  return: 15
+  invokevirtual: 12
+  invokedynamic: 16
+  return: 16

--- a/src/test/resources/org/eolang/hone/optimize/streams-distinct.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-distinct.yml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Confirms that .distinct() on an object Stream is rewritten by rule 353
+# into a Stream.mapMulti() call with a captured java/util/HashSet
+# seen-set. See issue #547.
+#
+# The pipeline contains duplicates that distinct must remove while
+# preserving encounter order: [1, 2, 2, 3, 1, 3, 4] → [1, 2, 3, 4],
+# count() = 4. The .map(n -> n) is there only to satisfy the default
+# grep-in filter (which targets classes containing 'map' or 'filter');
+# it is a no-op semantically.
+#
+# Opcode counts pin down that the HashSet was allocated and consulted:
+# the single `new` is the HashSet allocation, and `invokevirtual` reaches
+# 2 because `HashSet.add` joins the existing `System.out.printf` call.
+java: |
+  package distinct;
+  import java.util.stream.*;
+  public class X {
+    public static void main(String[] a) {
+      long r = Stream.of(1, 2, 2, 3, 1, 3, 4)
+        .map(n -> n)
+        .distinct()
+        .count();
+      System.out.printf("The result is %d\n", r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 4"
+opcodes:
+  new: 1
+  invokevirtual: 2


### PR DESCRIPTION
Adds a recognition rule (216), a fold rule (353), and a fallback rule (730) for `Stream.distinct()` on object streams. The fold rewrites the call into `Stream.mapMulti(BiConsumer)` capturing a freshly allocated `java/util/HashSet`; the synthetic wrapper forwards an element to the downstream consumer only when `HashSet.add` returns true. The shape mirrors the takeWhile (#539) and dropWhile (#540) pipelines, with an object reference standing in for the boolean[1] guard those use.

Distinct is the canonical deduplication operation and shows up in essentially every introductory stream tutorial. Until now the call was opaque to the optimizer and acted as a barrier for adjacent fusions. The recognition + lowering infrastructure here gives later state-carrying-fusion work a pragma to plug into and, in the meantime, replaces the opaque invokeinterface with an explicit mapMulti that the runtime can JIT freely.

The streams-all-ops fixture exercises the new path together with the rest of the stream operators and its opcode counts move accordingly (+1 invokespecial, +1 invokevirtual, +1 invokedynamic, +1 return). A dedicated streams-distinct.yml pins the dedup semantics ([1,2,2,3,1,3,4].distinct().count() == 4), and phino unit tests cover 216 and 730 directly.

Closes #547