### PR TITLE
Recognize method references in 112-methodref-to-lambda

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/112-methodref-to-lambda.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/112-methodref-to-lambda.phr
@@ -13,6 +13,17 @@
 # them too. The promotion is reversible: if no later rule fires on the
 # resulting Φ.hone.lambda, 701 lowers it back to the original
 # invokedynamic + invokeinterface pair with no bytecode change.
+#
+# Restricted to target handle kinds 5 (REF_invokeVirtual) and 6
+# (REF_invokeStatic). Kinds 7/8/9 (REF_invokeSpecial,
+# REF_newInvokeSpecial, REF_invokeInterface) are deliberately
+# excluded: 141-set-opcode-in-lambda derives the call opcode from
+# the target signature alone, which can only produce invokevirtual
+# or invokestatic, and downstream wrap-method synthesis (e.g. 513)
+# would emit the wrong bytecode for constructor references
+# (Foo::new needs new/dup/invokespecial) and interface method
+# references (need invokeinterface). Widening the gate has to wait
+# until 141 (or its consumers) learn those shapes.
 name: methodref-to-lambda
 pattern: |
   ⟦
@@ -157,6 +168,9 @@ when:
         matches:
           - 'lambda\$.+'
           - 𝑒-target-method
+    - or:
+        - eq: [𝑒-target-handle, '5']
+        - eq: [𝑒-target-handle, '6']
 where:
   - meta: 𝜏-lambda
     function: random-tau

--- a/src/main/resources/org/eolang/hone/rules/streams/112-methodref-to-lambda.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/112-methodref-to-lambda.phr
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Mirrors 111-invokedynamic-to-lambda but for method references rather
+# than for compiler-synthesized lambda$N bridge methods. A method
+# reference like Integer::intValue or X::isOdd lowers to an
+# invokedynamic whose target handle points directly at the referenced
+# method instead of a lambda$N synthetic. 111 explicitly excludes
+# those by requiring the target method name to match 'lambda$.+';
+# this rule covers the complement so the rest of the streams/ pipeline
+# (filter/map/unbox/peek recognition, fusion, mapMulti lowering) sees
+# them too. The promotion is reversible: if no later rule fires on the
+# resulting Φ.hone.lambda, 701 lowers it back to the original
+# invokedynamic + invokeinterface pair with no bytecode change.
+name: methodref-to-lambda
+pattern: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    version ↦ 𝑒-class-version,
+    access ↦ 𝑒-class-access,
+    modifiers ↦ 𝑒-class-modifiers,
+    name ↦ 𝑒-class,
+    supername ↦ 𝑒-class-supername,
+    interfaces ↦ 𝑒-class-interfaces,
+    𝐵-class-body-head,
+    𝜏-function ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 𝑒-method-access,
+      modifiers ↦ ⟦
+        𝐵-modifiers-before,
+        static ↦ Φ.true,
+        𝐵-modifiers-after
+      ⟧,
+      name ↦ 𝑒-function,
+      descriptor ↦ 𝑒-method-descriptor,
+      signature ↦ 𝑒-method-signature,
+      exceptions ↦ 𝑒-method-exceptions,
+      maxs ↦ 𝑒-method-maxs,
+      params ↦ 𝑒-method-params,
+      annotations ↦ 𝑒-annotations,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-invokedynamic ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokedynamic,
+          𝜏3 ↦ 𝑒-method,
+          𝜏4 ↦ 𝑒-interface,
+          𝜏5 ↦ ⟦
+            φ ↦ Φ.jeo.handle,
+            𝜏6 ↦ 6,
+            𝜏7 ↦ "java/lang/invoke/LambdaMetafactory",
+            𝜏8 ↦ "metafactory",
+            𝜏9 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+            𝜏10 ↦ Φ.false,
+            ρ ↦ ∅
+          ⟧,
+          𝜏11 ↦ ⟦
+            φ ↦ Φ.jeo.type,
+            𝜏12 ↦ 𝑒-lambda-signature,
+            ρ ↦ ∅
+          ⟧,
+          𝜏13 ↦ ⟦
+            φ ↦ Φ.jeo.handle,
+            𝜏14 ↦ 𝑒-target-handle,
+            𝜏15 ↦ 𝑒-target-class,
+            𝜏16 ↦ 𝑒-target-method,
+            𝜏17 ↦ 𝑒-target-signature,
+            𝜏18 ↦ 𝑒-target-is-interface,
+            ρ ↦ ∅
+          ⟧,
+          𝜏19 ↦ ⟦
+            φ ↦ Φ.jeo.type,
+            𝜏21 ↦ 𝑒-bridge-signature,
+            ρ ↦ ∅
+          ⟧,
+          ρ ↦ ∅
+        ⟧,
+        𝜏-invokeinterface ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          𝜏24 ↦ 𝑒-stream-class,
+          𝜏25 ↦ 𝑒-stream-method,
+          𝜏26 ↦ 𝑒-stream-signature,
+          𝜏27 ↦ Φ.true,
+          ρ ↦ ∅
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝜏-trycatchblocks ↦ 𝑒-trycatchblocks,
+      local-variable-table ↦ 𝑒-lvt,
+      ρ ↦ ∅
+    ⟧,
+    𝐵-class-body-tail
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    version ↦ 𝑒-class-version,
+    access ↦ 𝑒-class-access,
+    modifiers ↦ 𝑒-class-modifiers,
+    name ↦ 𝑒-class,
+    supername ↦ 𝑒-class-supername,
+    interfaces ↦ 𝑒-class-interfaces,
+    𝐵-class-body-head,
+    𝜏-function ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 𝑒-method-access,
+      modifiers ↦ ⟦
+        𝐵-modifiers-before,
+        static ↦ Φ.true,
+        𝐵-modifiers-after
+      ⟧,
+      name ↦ 𝑒-function,
+      descriptor ↦ 𝑒-method-descriptor,
+      signature ↦ 𝑒-method-signature,
+      exceptions ↦ 𝑒-method-exceptions,
+      maxs ↦ 𝑒-method-maxs,
+      params ↦ 𝑒-method-params,
+      annotations ↦ 𝑒-annotations,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-lambda ↦ ⟦
+          φ ↦ Φ.hone.lambda,
+          class ↦ 𝑒-class,
+          method ↦ 𝑒-method,
+          interface ↦ 𝑒-interface,
+          lambda-signature ↦ 𝑒-lambda-signature,
+          bridge-signature ↦ 𝑒-bridge-signature,
+          static ↦ "true",
+          opcode ↦ "",
+          target ↦ ⟦
+            handle ↦ 𝑒-target-handle,
+            class ↦ 𝑒-target-class,
+            method ↦ 𝑒-target-method,
+            signature ↦ 𝑒-target-signature,
+            is-interface ↦ 𝑒-target-is-interface
+          ⟧,
+          stream ↦ ⟦
+            class ↦ 𝑒-stream-class,
+            method ↦ 𝑒-stream-method,
+            signature ↦ 𝑒-stream-signature
+          ⟧
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝜏-trycatchblocks ↦ 𝑒-trycatchblocks,
+      local-variable-table ↦ 𝑒-lvt,
+      ρ ↦ ∅
+    ⟧,
+    𝐵-class-body-tail
+  ⟧
+when:
+  and:
+    - matches:
+        - '\(\).+'
+        - 𝑒-interface
+    - not:
+        matches:
+          - 'lambda\$.+'
+          - 𝑒-target-method
+where:
+  - meta: 𝜏-lambda
+    function: random-tau
+    args: ['𝐵-body-head', '𝐵-body-tail', '𝜏-invokeinterface', '𝜏-invokedynamic']

--- a/src/test/phino/112-methodref-to-lambda.yml
+++ b/src/test/phino/112-methodref-to-lambda.yml
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 112 mirrors 111 but for method references (Integer::intValue,
+# X::isOdd, ...) instead of compiler-synthesized lambda$N bridges.
+# The target-method must not match 'lambda$.+'; everything else
+# matches the same shape, and the result is a Φ.hone.lambda that the
+# rest of the streams/ pipeline can consume.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/112-methodref-to-lambda.phr
+input: |
+  {⟦
+    j$Foo ↦ ⟦
+      φ ↦ Φ.jeo.class,
+      version ↦ 66,
+      access ↦ 33,
+      modifiers ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      name ↦ "Foo",
+      supername ↦ "java/lang/Object",
+      interfaces ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      j$main ↦ ⟦
+        φ ↦ Φ.jeo.method,
+        access ↦ 4096,
+        modifiers ↦ ⟦ static ↦ Φ.true ⟧,
+        name ↦ "main",
+        descriptor ↦ "()V",
+        signature ↦ "",
+        exceptions ↦ "Exceptions",
+        maxs ↦ ⟦ φ ↦ Φ.jeo.seq.of2, v1 ↦ 5, v2 ↦ 5 ⟧,
+        params ↦ ⟦ φ ↦ Φ.jeo.seq.of2 ⟧,
+        annotations ↦ ⟦ φ ↦ Φ.jeo.seq.of2 ⟧,
+        body ↦ ⟦
+          φ ↦ Φ.jeo.seq.of2,
+          i2186 ↦ ⟦
+            φ ↦ Φ.jeo.opcode.invokedynamic,
+            v2194 ↦ "applyAsInt",
+            v2196 ↦ "()Ljava/util/function/ToIntFunction;",
+            h2198 ↦ ⟦
+              φ ↦ Φ.jeo.handle,
+              v2199 ↦ 6,
+              v2201 ↦ "java/lang/invoke/LambdaMetafactory",
+              v2202 ↦ "metafactory",
+              v2203 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+              v2204 ↦ Φ.false
+            ⟧,
+            t2214 ↦ ⟦
+              φ ↦ Φ.jeo.type,
+              v2215 ↦ "(Ljava/lang/Object;)I"
+            ⟧,
+            h2246 ↦ ⟦
+              φ ↦ Φ.jeo.handle,
+              v2249 ↦ 5,
+              v2250 ↦ "java/lang/Integer",
+              v2251 ↦ "intValue",
+              v2252 ↦ "()I",
+              v2254 ↦ Φ.false
+            ⟧,
+            t2271 ↦ ⟦
+              φ ↦ Φ.jeo.type,
+              v2272 ↦ "(Ljava/lang/Integer;)I"
+            ⟧
+          ⟧,
+          i2362 ↦ ⟦
+            φ ↦ Φ.jeo.opcode.invokeinterface,
+            v2369 ↦ "java/util/stream/Stream",
+            v2371 ↦ "mapToInt",
+            v2372 ↦ "(Ljava/util/function/ToIntFunction;)Ljava/util/stream/IntStream;",
+            v2376 ↦ Φ.true
+          ⟧
+        ⟧,
+        trycatchblocks ↦ ⟦⟧,
+        local-variable-table ↦ ⟦⟧
+      ⟧,
+      signature ↦ ""
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      φ ↦ Φ.hone.lambda,
+      class ↦ "Foo",
+      method ↦ "applyAsInt",
+      interface ↦ "()Ljava/util/function/ToIntFunction;",
+      𝐵-lambda-middle,
+      target ↦ ⟦
+        handle ↦ 5,
+        class ↦ "java/lang/Integer",
+        method ↦ "intValue",
+        signature ↦ "()I",
+        is-interface ↦ Φ.false
+      ⟧,
+      𝐵-lambda-post
+    ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams-all-ops.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-all-ops.yml
@@ -47,7 +47,7 @@ log:
   - "The result is 54"
 opcodes:
   invokespecial: 2
-  invokestatic: 25
-  invokevirtual: 12
+  invokestatic: 26
+  invokevirtual: 13
   invokedynamic: 16
-  return: 16
+  return: 18

--- a/src/test/resources/org/eolang/hone/optimize/streams-flatmapped.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-flatmapped.yml
@@ -23,7 +23,7 @@ log:
   - "The result is 87"
 opcodes:
   invokespecial: 1
-  invokestatic: 16
-  invokevirtual: 4
+  invokestatic: 17
+  invokevirtual: 5
   invokedynamic: 4
-  return: 9
+  return: 11

--- a/src/test/resources/org/eolang/hone/optimize/streams-mapped.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-mapped.yml
@@ -24,7 +24,7 @@ log:
   - "The result is 32"
 opcodes:
   invokespecial: 1
-  invokestatic: 13
-  invokevirtual: 5
+  invokestatic: 14
+  invokevirtual: 6
   invokedynamic: 2
-  return: 4
+  return: 6


### PR DESCRIPTION
This adds a new rule `112-methodref-to-lambda.phr` next to `111-invokedynamic-to-lambda.phr`. The two share the same shape, but `111` only fires when the target method name matches `lambda$.+`, which excludes every method reference. `112` covers the complement, so pipelines that use forms like `.mapToInt(Integer::intValue)` or `.filter(X::isOdd)` now reach the recognition, fusion, and mapMulti lowering rules.

The promotion is reversible. If no later rule fires, `701` lowers the Φ.hone.lambda back to the same invokedynamic + invokeinterface it came from. When `513` does fire (mapMulti followed by an unbox-shaped method ref), the synthesized wrap method materializes the dispatch that LambdaMetafactory used to hide; the opcode expectations in `streams-mapped`, `streams-flatmapped`, and `streams-all-ops` are updated by +1 invokevirtual, +1 invokestatic, and +2 return per class to reflect that.

A phino unit test under `src/test/phino/112-methodref-to-lambda.yml` exercises the `Integer::intValue` form end-to-end and checks the resulting Φ.hone.lambda carries the right target. The opcode count adjustments are the issue author's measured deltas; CI will verify them on the deep yaml-pack tests.

Closes #536