### PR TITLE
#546: Fold Stream.skip(1L) into mapMulti with long[1] counter

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/354-skip-one-to-mapMulti.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/354-skip-one-to-mapMulti.phr
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 354-skip-one-to-mapMulti
+#
+# Sibling of 353-skip-to-mapMulti.phr for the `.skip(1L)` shape.
+# Recognises Φ.hone.skip with count="1" (the string-typed form
+# produced by 212 when javac emitted `lconst_1` for the count) and
+# lowers it into the same state-carrying mapMulti BiConsumer the
+# generic ldc case uses, with `lconst_1` in the counter-init instead
+# of `ldc Φ.jeo.long(N)`. Wrapper body is identical to 353's.
+#
+# See 353 for the full design notes (counter cell semantics, known
+# adjacency limitation of the counter-init bytecode w.r.t. 512, and
+# the negative-count gap — none of which apply to count="1" since 1
+# is a positive constant).
+name: skip-one-to-mapMulti
+pattern: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    𝐵-class-head-before,
+    name ↦ 𝑒-class-name,
+    𝐵-class-head-after,
+    𝜏-caller ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      𝐵-caller-head,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-skip ↦ ⟦
+          φ ↦ Φ.hone.skip,
+          stream-class ↦ "java/util/stream/Stream",
+          count ↦ "1"
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝐵-caller-tail
+    ⟧,
+    𝐵-class-tail,
+    ρ ↦ ∅
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    𝐵-class-head-before,
+    name ↦ 𝑒-class-name,
+    𝐵-class-head-after,
+    𝜏-caller ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      𝐵-caller-head,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-iconst-1 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.iconst_1
+        ⟧,
+        𝜏-newarray ↦ ⟦
+          φ ↦ Φ.jeo.opcode.newarray,
+          i1 ↦ 11
+        ⟧,
+        𝜏-dup ↦ ⟦
+          φ ↦ Φ.jeo.opcode.dup
+        ⟧,
+        𝜏-iconst-0 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.iconst_0
+        ⟧,
+        𝜏-lconst-1 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.lconst_1
+        ⟧,
+        𝜏-lastore ↦ ⟦
+          φ ↦ Φ.jeo.opcode.lastore
+        ⟧,
+        𝜏-lambda ↦ ⟦
+          φ ↦ Φ.hone.lambda,
+          class ↦ 𝑒-class-name,
+          method ↦ "accept",
+          interface ↦ "([J)Ljava/util/function/BiConsumer;",
+          lambda-signature ↦ "(Ljava/lang/Object;Ljava/lang/Object;)V",
+          bridge-signature ↦ "(Ljava/lang/Object;Ljava/util/function/Consumer;)V",
+          static ↦ "true",
+          opcode ↦ "invokestatic",
+          target ↦ ⟦
+            handle ↦ 6,
+            class ↦ 𝑒-class-name,
+            method ↦ 𝑒-wrapper-method,
+            signature ↦ 𝑒-wrapper-signature,
+            is-interface ↦ Φ.false
+          ⟧,
+          stream ↦ ⟦
+            class ↦ "java/util/stream/Stream",
+            method ↦ "mapMulti",
+            signature ↦ "(Ljava/util/function/BiConsumer;)Ljava/util/stream/Stream;"
+          ⟧
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝐵-caller-tail
+    ⟧,
+    𝐵-class-tail,
+    𝜏-wrapper ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 4106,
+      descriptor ↦ 𝑒-wrapper-signature,
+      signature ↦ "",
+      maxs ↦ ⟦
+        φ ↦ Φ.jeo.maxs,
+        max-stack ↦ 6,
+        max-locals ↦ 3
+      ⟧,
+      params ↦ ⟦
+        φ ↦ Φ.jeo.params,
+        i1 ↦ ⟦ φ ↦ Φ.jeo.param, index ↦ 0, access ↦ 0, type ↦ "[J" ⟧,
+        i2 ↦ ⟦ φ ↦ Φ.jeo.param, index ↦ 1, access ↦ 0, type ↦ "Ljava/lang/Object;" ⟧,
+        i3 ↦ ⟦ φ ↦ Φ.jeo.param, index ↦ 2, access ↦ 0, type ↦ "Ljava/util/function/Consumer;" ⟧
+      ⟧,
+      body ↦ ⟦
+        φ ↦ Φ.jeo.seq.of,
+        w0 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 0 ⟧,
+        w1 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+        w2 ↦ ⟦ φ ↦ Φ.jeo.opcode.laload ⟧,
+        w3 ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_0 ⟧,
+        w4 ↦ ⟦ φ ↦ Φ.jeo.opcode.lcmp ⟧,
+        w5 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.ifle,
+          i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label-accept ⟧
+        ⟧,
+        w6 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 0 ⟧,
+        w7 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+        w8 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 0 ⟧,
+        w9 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+        w10 ↦ ⟦ φ ↦ Φ.jeo.opcode.laload ⟧,
+        w11 ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_1 ⟧,
+        w12 ↦ ⟦ φ ↦ Φ.jeo.opcode.lsub ⟧,
+        w13 ↦ ⟦ φ ↦ Φ.jeo.opcode.lastore ⟧,
+        w14 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+        w15 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label-accept ⟧,
+        w16 ↦ ⟦
+          φ ↦ Φ.jeo.frame,
+          type ↦ 3,
+          nlocal ↦ 0,
+          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+          nstack ↦ 0,
+          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
+        ⟧,
+        w17 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 2 ⟧,
+        w18 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
+        w19 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          i2 ↦ "java/util/function/Consumer",
+          i3 ↦ "accept",
+          i4 ↦ "(Ljava/lang/Object;)V",
+          i5 ↦ Φ.true
+        ⟧,
+        w20 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+        ρ ↦ ∅
+      ⟧,
+      name ↦ 𝑒-wrapper-method
+    ⟧,
+    ρ ↦ ∅
+  ⟧
+where:
+  - meta: 𝜏-iconst-1
+    function: random-tau
+    args: [ '𝐵-body-head', '𝐵-body-tail' ]
+  - meta: 𝜏-newarray
+    function: random-tau
+    args: [ '𝐵-body-head', '𝐵-body-tail', '𝜏-iconst-1' ]
+  - meta: 𝜏-dup
+    function: random-tau
+    args: [ '𝐵-body-head', '𝐵-body-tail', '𝜏-iconst-1', '𝜏-newarray' ]
+  - meta: 𝜏-iconst-0
+    function: random-tau
+    args: [ '𝐵-body-head', '𝐵-body-tail', '𝜏-iconst-1', '𝜏-newarray', '𝜏-dup' ]
+  - meta: 𝜏-lconst-1
+    function: random-tau
+    args: [ '𝐵-body-head', '𝐵-body-tail', '𝜏-iconst-1', '𝜏-newarray', '𝜏-dup', '𝜏-iconst-0' ]
+  - meta: 𝜏-lastore
+    function: random-tau
+    args: [ '𝐵-body-head', '𝐵-body-tail', '𝜏-iconst-1', '𝜏-newarray', '𝜏-dup', '𝜏-iconst-0', '𝜏-lconst-1' ]
+  - meta: 𝜏-lambda
+    function: random-tau
+    args: [ '𝐵-body-head', '𝐵-body-tail', '𝜏-iconst-1', '𝜏-newarray', '𝜏-dup', '𝜏-iconst-0', '𝜏-lconst-1', '𝜏-lastore' ]
+  - meta: 𝑒-wrapper-method
+    function: random-string
+    args: [ '"hone_skip_%d"' ]
+  - meta: 𝜏-wrapper
+    function: random-tau
+    args: [ 'name', '𝐵-class-head-before', '𝐵-class-head-after', '𝐵-class-tail', '𝜏-caller' ]
+  - meta: 𝑒-wrapper-signature
+    function: concat
+    args: [ '"([JLjava/lang/Object;Ljava/util/function/Consumer;)V"' ]
+  - meta: 𝑒-label-accept
+    function: random-string
+    args: [ '"LskipAccept%d"' ]

--- a/src/test/phino/354-skip-one-to-mapMulti.yml
+++ b/src/test/phino/354-skip-one-to-mapMulti.yml
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 354 is the .skip(1L) sibling of 353: Φ.hone.skip with count="1"
+# (the string-typed form produced by 212 when javac emitted lconst_1)
+# is lowered into the same state-carrying mapMulti shape — long[1]
+# counter array + captured BiConsumer + synthetic wrapper — but with
+# lconst_1 in the counter-init instead of ldc Φ.jeo.long(N).
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/354-skip-one-to-mapMulti.phr
+input: |
+  {⟦
+    φ ↦ Φ.jeo.class,
+    version ↦ 66,
+    access ↦ 33,
+    name ↦ "Foo",
+    supername ↦ "java/lang/Object",
+    main ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 4096,
+      name ↦ "main",
+      descriptor ↦ "()V",
+      body ↦ ⟦
+        i1 ↦ ⟦
+          φ ↦ Φ.hone.skip,
+          stream-class ↦ "java/util/stream/Stream",
+          count ↦ "1"
+        ⟧
+      ⟧
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      φ ↦ Φ.jeo.class,
+      𝐵-rest
+    ⟧
+  - |
+    ⟦
+      φ ↦ Φ.hone.lambda,
+      class ↦ "Foo",
+      method ↦ "accept",
+      interface ↦ "([J)Ljava/util/function/BiConsumer;",
+      lambda-signature ↦ "(Ljava/lang/Object;Ljava/lang/Object;)V",
+      𝐵-lambda-tail
+    ⟧
+  - |
+    ⟦
+      φ ↦ Φ.jeo.opcode.newarray,
+      i1 ↦ 11
+    ⟧
+  - |
+    ⟦
+      φ ↦ Φ.jeo.opcode.lconst_1
+    ⟧
+  - |
+    ⟦
+      φ ↦ Φ.jeo.opcode.lcmp
+    ⟧
+  - |
+    ⟦
+      φ ↦ Φ.jeo.opcode.lsub
+    ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams-skipped-one-fused.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-skipped-one-fused.yml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Asserts that `.skip(1L)` is folded into the same state-carrying
+# mapMulti shape that 353 emits for .skip(N>1), with `lconst_1` in
+# the counter-init. The assertion is the sum of the remaining
+# elements so an off-by-one or a non-prefix discard would produce a
+# different number: dropping element 2 from (2, 3, 4, 5, 6) and
+# summing the rest gives 3 + 4 + 5 + 6 = 18.
+java: |
+  package skippedonefused;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      int r = Stream.of(1, 2, 3, 4, 5)
+        .map(n -> n + 1)
+        .skip(1L)
+        .mapToInt(Integer::intValue)
+        .sum();
+      System.out.printf("The result is %d\n", r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 18"


### PR DESCRIPTION
## Summary

Continues #546 from [#560](https://github.com/objectionary/hone-maven-plugin/pull/560) by closing the remaining gap in the state-carrying fold for object Stream: `.skip(1L)`.

`353-skip-to-mapMulti.phr`'s `when:` clause excludes string-typed `count="0"` and `count="1"` — the two forms produced by `210` and `212` when javac picked `lconst_0` / `lconst_1` for the constant. `count="0"` is correctly handled by `311 → nop` (real optimization). `count="1"` was round-tripping through `710` back to `lconst_1 + invokeinterface Stream.skip(J)` and bypassing the state-carrying fold entirely.

`354-skip-one-to-mapMulti.phr` plugs that hole. Same mapMulti shape as `353` — `long[1]` counter array, captured `BiConsumer`, synthetic wrapper method with the decrement-or-forward logic — only the counter-init opcode differs (`lconst_1` instead of `ldc Φ.jeo.long(N)`). Wrapper body is byte-identical to `353`'s.

After `354` fires, `701` lowers the new `Φ.hone.lambda` to `invokedynamic + invokeinterface(mapMulti)` exactly as it does for `353`'s output.

## Test plan

- [x] `bash src/test/phino/run.sh` — 38 phino tests pass (37 existing + 1 new).
- [x] `yamllint` clean on all new files.
- [x] Manually verified that `354` + `710` together fire `354` first when given a `Φ.hone.skip(count="1")` block (skip becomes mapMulti, not raw bytecode).
- [ ] CI runs the Docker-backed end-to-end pack `streams-skipped-one-fused.yml` — `Stream.of(1..5).map(n -> n+1).skip(1L).mapToInt(...).sum()` should print `The result is 18` (3 + 4 + 5 + 6 = 18, proving the first element was discarded as a prefix).

## What's still open from #546

- Primitive-stream folds for `Φ.hone.primitive-skip(N)` — IntStream/LongStream/DoubleStream each need their own mapMulti variant (`mapMultiToInt` / `mapMultiToLong` / `mapMultiToDouble`).
- Cross-stage fusion across the counter-init bytecode (so `.map().skip(N)` actually collapses into one mapMulti via `512`).
- Negative-count safety (silently forwards instead of throwing `IllegalArgumentException`).
- `.skip(K).limit(N)` pagination fusion — `.limit` recognition just landed in master via #548; the cross-op fusion rule is the remaining piece.