### PR TITLE
Recognize mapToObj on primitive streams

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/205-lambda-to-box.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/205-lambda-to-box.phr
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+name: lambda-to-box
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.lambda,
+    class ↦ 𝑒-class,
+    method ↦ 𝑒-method,
+    interface ↦ 𝑒-interface,
+    lambda-signature ↦ 𝑒-lambda-signature,
+    bridge-signature ↦ 𝑒-bridge-signature,
+    static ↦ 𝑒-static,
+    opcode ↦ 𝑒-opcode,
+    target ↦ ⟦
+      𝐵-target-before,
+      signature ↦ 𝑒-target-signature,
+      𝐵-target-after
+    ⟧,
+    stream ↦ ⟦
+      class ↦ 𝑒-stream-class,
+      method ↦ 𝑒-stream-method,
+      signature ↦ 𝑒-stream-signature
+    ⟧
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.box,
+    opcode ↦ 𝑒-opcode,
+    class ↦ 𝑒-class,
+    stream-class ↦ 𝑒-stream-class,
+    bridge-signature ↦ 𝑒-bridge-signature,
+    static ↦ 𝑒-static,
+    target ↦ ⟦
+      𝐵-target-before,
+      signature ↦ 𝑒-target-signature,
+      𝐵-target-after
+    ⟧
+  ⟧
+when:
+  or:
+    - and:
+        - eq: [𝑒-method, '"apply"']
+        - matches: ['\(\)Ljava/util/function/IntFunction;', 𝑒-interface]
+        - eq: [𝑒-lambda-signature, '"(I)Ljava/lang/Object;"']
+        - eq: [𝑒-stream-class, '"java/util/stream/IntStream"']
+        - eq: [𝑒-stream-method, '"mapToObj"']
+        - eq: [𝑒-stream-signature, '"(Ljava/util/function/IntFunction;)Ljava/util/stream/Stream;"']
+        - matches: ['\(I\)L.+;', 𝑒-bridge-signature]
+    - and:
+        - eq: [𝑒-method, '"apply"']
+        - matches: ['\(\)Ljava/util/function/LongFunction;', 𝑒-interface]
+        - eq: [𝑒-lambda-signature, '"(J)Ljava/lang/Object;"']
+        - eq: [𝑒-stream-class, '"java/util/stream/LongStream"']
+        - eq: [𝑒-stream-method, '"mapToObj"']
+        - eq: [𝑒-stream-signature, '"(Ljava/util/function/LongFunction;)Ljava/util/stream/Stream;"']
+        - matches: ['\(J\)L.+;', 𝑒-bridge-signature]
+    - and:
+        - eq: [𝑒-method, '"apply"']
+        - matches: ['\(\)Ljava/util/function/DoubleFunction;', 𝑒-interface]
+        - eq: [𝑒-lambda-signature, '"(D)Ljava/lang/Object;"']
+        - eq: [𝑒-stream-class, '"java/util/stream/DoubleStream"']
+        - eq: [𝑒-stream-method, '"mapToObj"']
+        - eq: [𝑒-stream-signature, '"(Ljava/util/function/DoubleFunction;)Ljava/util/stream/Stream;"']
+        - matches: ['\(D\)L.+;', 𝑒-bridge-signature]

--- a/src/main/resources/org/eolang/hone/rules/streams/603-box-to-lambda.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/603-box-to-lambda.phr
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+name: box-to-lambda
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.box,
+    opcode ↦ 𝑒-opcode,
+    class ↦ 𝑒-class,
+    stream-class ↦ 𝑒-stream-class,
+    bridge-signature ↦ 𝑒-bridge-signature,
+    static ↦ 𝑒-static,
+    target ↦ 𝑒-target
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.lambda,
+    class ↦ 𝑒-class,
+    method ↦ "apply",
+    interface ↦ 𝑒-interface,
+    lambda-signature ↦ 𝑒-lambda-signature,
+    bridge-signature ↦ 𝑒-bridge-signature,
+    static ↦ 𝑒-static,
+    opcode ↦ 𝑒-opcode,
+    target ↦ 𝑒-target,
+    stream ↦ ⟦
+      class ↦ 𝑒-stream-class,
+      method ↦ "mapToObj",
+      signature ↦ 𝑒-stream-signature
+    ⟧
+  ⟧
+where:
+  - meta: 𝑒-bridge-input
+    function: sed
+    args:
+      - 𝑒-bridge-signature
+      - '"s/\\((.)\\)L.+;/$1/g"'
+  - meta: 𝑒-input-class-simple-name
+    function: sed
+    args:
+      - 𝑒-bridge-input
+      - '"s/I/Int/g"'
+      - '"s/J/Long/g"'
+      - '"s/D/Double/g"'
+  - meta: 𝑒-interface
+    function: concat
+    args: ['"()Ljava/util/function/"', 𝑒-input-class-simple-name, '"Function;"']
+  - meta: 𝑒-lambda-signature
+    function: concat
+    args: ['"("', 𝑒-bridge-input, '")Ljava/lang/Object;"']
+  - meta: 𝑒-stream-signature
+    function: concat
+    args:
+      - '"(Ljava/util/function/"'
+      - 𝑒-input-class-simple-name
+      - '"Function;)Ljava/util/stream/Stream;"'

--- a/src/test/phino/205-lambda-to-box-double.yml
+++ b/src/test/phino/205-lambda-to-box-double.yml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 205 recognizes a Φ.hone.lambda whose stream call is
+# DoubleStream.mapToObj(DoubleFunction<R>) and rewrites it into a rich
+# Φ.hone.box pragma. See issue #538.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/205-lambda-to-box.phr
+input: |
+  {⟦
+    φ ↦ Φ.hone.lambda,
+    class ↦ "Foo",
+    method ↦ "apply",
+    interface ↦ "()Ljava/util/function/DoubleFunction;",
+    lambda-signature ↦ "(D)Ljava/lang/Object;",
+    bridge-signature ↦ "(D)Ljava/lang/Double;",
+    static ↦ "true",
+    opcode ↦ "invokestatic",
+    target ↦ ⟦
+      handle ↦ 6,
+      class ↦ "Foo",
+      method ↦ "lambda$main$0",
+      signature ↦ "(D)Ljava/lang/Double;",
+      is-interface ↦ Φ.false
+    ⟧,
+    stream ↦ ⟦
+      class ↦ "java/util/stream/DoubleStream",
+      method ↦ "mapToObj",
+      signature ↦ "(Ljava/util/function/DoubleFunction;)Ljava/util/stream/Stream;"
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      φ ↦ Φ.hone.box,
+      opcode ↦ "invokestatic",
+      class ↦ "Foo",
+      stream-class ↦ "java/util/stream/DoubleStream",
+      bridge-signature ↦ "(D)Ljava/lang/Double;",
+      static ↦ "true",
+      target ↦ ⟦
+        handle ↦ 6,
+        class ↦ "Foo",
+        method ↦ "lambda$main$0",
+        signature ↦ "(D)Ljava/lang/Double;",
+        is-interface ↦ Φ.false
+      ⟧
+    ⟧

--- a/src/test/phino/205-lambda-to-box-int.yml
+++ b/src/test/phino/205-lambda-to-box-int.yml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 205 recognizes a Φ.hone.lambda whose stream call is
+# IntStream.mapToObj(IntFunction<R>) and rewrites it into a rich
+# Φ.hone.box pragma. Mirror of 205-lambda-to-unbox; see issue #538.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/205-lambda-to-box.phr
+input: |
+  {⟦
+    φ ↦ Φ.hone.lambda,
+    class ↦ "Foo",
+    method ↦ "apply",
+    interface ↦ "()Ljava/util/function/IntFunction;",
+    lambda-signature ↦ "(I)Ljava/lang/Object;",
+    bridge-signature ↦ "(I)Ljava/lang/String;",
+    static ↦ "true",
+    opcode ↦ "invokestatic",
+    target ↦ ⟦
+      handle ↦ 6,
+      class ↦ "Foo",
+      method ↦ "lambda$main$0",
+      signature ↦ "(I)Ljava/lang/String;",
+      is-interface ↦ Φ.false
+    ⟧,
+    stream ↦ ⟦
+      class ↦ "java/util/stream/IntStream",
+      method ↦ "mapToObj",
+      signature ↦ "(Ljava/util/function/IntFunction;)Ljava/util/stream/Stream;"
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      φ ↦ Φ.hone.box,
+      opcode ↦ "invokestatic",
+      class ↦ "Foo",
+      stream-class ↦ "java/util/stream/IntStream",
+      bridge-signature ↦ "(I)Ljava/lang/String;",
+      static ↦ "true",
+      target ↦ ⟦
+        handle ↦ 6,
+        class ↦ "Foo",
+        method ↦ "lambda$main$0",
+        signature ↦ "(I)Ljava/lang/String;",
+        is-interface ↦ Φ.false
+      ⟧
+    ⟧

--- a/src/test/phino/205-lambda-to-box-long.yml
+++ b/src/test/phino/205-lambda-to-box-long.yml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 205 recognizes a Φ.hone.lambda whose stream call is
+# LongStream.mapToObj(LongFunction<R>) and rewrites it into a rich
+# Φ.hone.box pragma. See issue #538.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/205-lambda-to-box.phr
+input: |
+  {⟦
+    φ ↦ Φ.hone.lambda,
+    class ↦ "Foo",
+    method ↦ "apply",
+    interface ↦ "()Ljava/util/function/LongFunction;",
+    lambda-signature ↦ "(J)Ljava/lang/Object;",
+    bridge-signature ↦ "(J)Ljava/lang/Long;",
+    static ↦ "true",
+    opcode ↦ "invokestatic",
+    target ↦ ⟦
+      handle ↦ 6,
+      class ↦ "Foo",
+      method ↦ "lambda$main$0",
+      signature ↦ "(J)Ljava/lang/Long;",
+      is-interface ↦ Φ.false
+    ⟧,
+    stream ↦ ⟦
+      class ↦ "java/util/stream/LongStream",
+      method ↦ "mapToObj",
+      signature ↦ "(Ljava/util/function/LongFunction;)Ljava/util/stream/Stream;"
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      φ ↦ Φ.hone.box,
+      opcode ↦ "invokestatic",
+      class ↦ "Foo",
+      stream-class ↦ "java/util/stream/LongStream",
+      bridge-signature ↦ "(J)Ljava/lang/Long;",
+      static ↦ "true",
+      target ↦ ⟦
+        handle ↦ 6,
+        class ↦ "Foo",
+        method ↦ "lambda$main$0",
+        signature ↦ "(J)Ljava/lang/Long;",
+        is-interface ↦ Φ.false
+      ⟧
+    ⟧

--- a/src/test/phino/603-box-to-lambda-double.yml
+++ b/src/test/phino/603-box-to-lambda-double.yml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 603 unrecognises a rich Φ.hone.box pragma derived from
+# DoubleStream.mapToObj back into a Φ.hone.lambda call. See issue #538.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/603-box-to-lambda.phr
+input: |
+  {⟦
+    φ ↦ Φ.hone.box,
+    opcode ↦ "invokestatic",
+    class ↦ "Foo",
+    stream-class ↦ "java/util/stream/DoubleStream",
+    bridge-signature ↦ "(D)Ljava/lang/Double;",
+    static ↦ "true",
+    target ↦ ⟦
+      handle ↦ 6,
+      class ↦ "Foo",
+      method ↦ "lambda$main$0",
+      signature ↦ "(D)Ljava/lang/Double;",
+      is-interface ↦ Φ.false
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      φ ↦ Φ.hone.lambda,
+      class ↦ "Foo",
+      method ↦ "apply",
+      interface ↦ "()Ljava/util/function/DoubleFunction;",
+      lambda-signature ↦ "(D)Ljava/lang/Object;",
+      bridge-signature ↦ "(D)Ljava/lang/Double;",
+      static ↦ "true",
+      opcode ↦ "invokestatic",
+      target ↦ ⟦
+        handle ↦ 6,
+        class ↦ "Foo",
+        method ↦ "lambda$main$0",
+        signature ↦ "(D)Ljava/lang/Double;",
+        is-interface ↦ Φ.false
+      ⟧,
+      stream ↦ ⟦
+        class ↦ "java/util/stream/DoubleStream",
+        method ↦ "mapToObj",
+        signature ↦ "(Ljava/util/function/DoubleFunction;)Ljava/util/stream/Stream;"
+      ⟧
+    ⟧

--- a/src/test/phino/603-box-to-lambda-int.yml
+++ b/src/test/phino/603-box-to-lambda-int.yml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 603 unrecognises a rich Φ.hone.box pragma (the form emitted by 205
+# for IntStream.mapToObj) back into a Φ.hone.lambda with the original
+# IntStream.mapToObj invokeinterface call, so the 7xx phase can lower
+# it back to invokedynamic + invokeinterface. See issue #538.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/603-box-to-lambda.phr
+input: |
+  {⟦
+    φ ↦ Φ.hone.box,
+    opcode ↦ "invokestatic",
+    class ↦ "Foo",
+    stream-class ↦ "java/util/stream/IntStream",
+    bridge-signature ↦ "(I)Ljava/lang/String;",
+    static ↦ "true",
+    target ↦ ⟦
+      handle ↦ 6,
+      class ↦ "Foo",
+      method ↦ "lambda$main$0",
+      signature ↦ "(I)Ljava/lang/String;",
+      is-interface ↦ Φ.false
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      φ ↦ Φ.hone.lambda,
+      class ↦ "Foo",
+      method ↦ "apply",
+      interface ↦ "()Ljava/util/function/IntFunction;",
+      lambda-signature ↦ "(I)Ljava/lang/Object;",
+      bridge-signature ↦ "(I)Ljava/lang/String;",
+      static ↦ "true",
+      opcode ↦ "invokestatic",
+      target ↦ ⟦
+        handle ↦ 6,
+        class ↦ "Foo",
+        method ↦ "lambda$main$0",
+        signature ↦ "(I)Ljava/lang/String;",
+        is-interface ↦ Φ.false
+      ⟧,
+      stream ↦ ⟦
+        class ↦ "java/util/stream/IntStream",
+        method ↦ "mapToObj",
+        signature ↦ "(Ljava/util/function/IntFunction;)Ljava/util/stream/Stream;"
+      ⟧
+    ⟧

--- a/src/test/phino/603-box-to-lambda-long.yml
+++ b/src/test/phino/603-box-to-lambda-long.yml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 603 unrecognises a rich Φ.hone.box pragma derived from
+# LongStream.mapToObj back into a Φ.hone.lambda call. See issue #538.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/603-box-to-lambda.phr
+input: |
+  {⟦
+    φ ↦ Φ.hone.box,
+    opcode ↦ "invokestatic",
+    class ↦ "Foo",
+    stream-class ↦ "java/util/stream/LongStream",
+    bridge-signature ↦ "(J)Ljava/lang/Long;",
+    static ↦ "true",
+    target ↦ ⟦
+      handle ↦ 6,
+      class ↦ "Foo",
+      method ↦ "lambda$main$0",
+      signature ↦ "(J)Ljava/lang/Long;",
+      is-interface ↦ Φ.false
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      φ ↦ Φ.hone.lambda,
+      class ↦ "Foo",
+      method ↦ "apply",
+      interface ↦ "()Ljava/util/function/LongFunction;",
+      lambda-signature ↦ "(J)Ljava/lang/Object;",
+      bridge-signature ↦ "(J)Ljava/lang/Long;",
+      static ↦ "true",
+      opcode ↦ "invokestatic",
+      target ↦ ⟦
+        handle ↦ 6,
+        class ↦ "Foo",
+        method ↦ "lambda$main$0",
+        signature ↦ "(J)Ljava/lang/Long;",
+        is-interface ↦ Φ.false
+      ⟧,
+      stream ↦ ⟦
+        class ↦ "java/util/stream/LongStream",
+        method ↦ "mapToObj",
+        signature ↦ "(Ljava/util/function/LongFunction;)Ljava/util/stream/Stream;"
+      ⟧
+    ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams-map-to-obj.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-map-to-obj.yml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Drives an IntStream pipeline through mapToObj to confirm that the
+# 2xx recognition rule for mapToObj (lambda-to-box) and the 6xx
+# reverse rule (box-to-lambda) round-trip without changing the
+# observable result. The lambda boxes int values into Strings, then
+# joins them; sum-of-lengths is asserted to keep the check stable
+# across JDK implementations of Integer.toString.
+java: |
+  package maptoobj;
+  import java.util.stream.IntStream;
+  import java.util.stream.Collectors;
+  public class X {
+    public static void main(String[] a) {
+      String r = IntStream.range(0, 5)
+        .mapToObj(i -> "n" + i)
+        .collect(Collectors.joining("-"));
+      System.out.printf("The result is %s\n", r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is n0-n1-n2-n3-n4"

--- a/src/test/resources/org/eolang/hone/optimize/streams-map-to-obj.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-map-to-obj.yml
@@ -4,9 +4,8 @@
 # Drives an IntStream pipeline through mapToObj to confirm that the
 # 2xx recognition rule for mapToObj (lambda-to-box) and the 6xx
 # reverse rule (box-to-lambda) round-trip without changing the
-# observable result. The lambda boxes int values into Strings, then
-# joins them; sum-of-lengths is asserted to keep the check stable
-# across JDK implementations of Integer.toString.
+# observable result. The lambda boxes int values into Strings, which
+# are then joined with a dash separator and printed verbatim.
 java: |
   package maptoobj;
   import java.util.stream.IntStream;


### PR DESCRIPTION
Adds two phino rules so that `IntStream.mapToObj`, `LongStream.mapToObj`,
and `DoubleStream.mapToObj` are no longer a fusion barrier. The new
`205-lambda-to-box.phr` lifts a `Φ.hone.lambda` whose `stream.method` is
`mapToObj` into a `Φ.hone.box` pragma with the same rich shape as
`Φ.hone.unbox` (the mirror form emitted by `205-lambda-to-unbox.phr`).
The new `603-box-to-lambda.phr` reverses that lifting before the 7xx
invokedynamic phase so the round-trip is bytecode-equivalent.

Before this change, `Φ.hone.lambda{stream.method = "mapToObj"}` was left
untouched by the 2xx recognition pass, which blocked any later fold from
collapsing the conversion across adjacent distills. The existing simple
`Φ.hone.box{stream-class}` pragma emitted by `boxed()` keeps working
because phino's matcher distinguishes the two shapes — `602-box-to-boxed`
and `411-box-distill-unbox-to-primitive-distill` both expect the simple
shape and ignore the new rich one.

A focused `streams-map-to-obj.yml` drives an `IntStream.range(...)
.mapToObj(i -> "n" + i)` pipeline end-to-end and asserts the joined
result, so the round-trip is exercised on real bytecode. A follow-up
fold rule (mirror of `411-...`) that actually fuses
`unbox → primitive-distill → box` is left for a later PR.

Closes #538