### PR TITLE
#546: Fold primitive .skip(N) into mapMulti

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/355-primitive-skip-to-mapMulti.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/355-primitive-skip-to-mapMulti.phr
@@ -1,0 +1,317 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 355-primitive-skip-to-mapMulti
+#
+# Primitive-stream counterpart of 353. Lowers Φ.hone.primitive-skip
+# (produced by 226 for the ldc form on IntStream / LongStream /
+# DoubleStream) into:
+#   * Raw bytecode that allocates a long[1] counter array on the stack
+#     (iconst_1 + newarray long + dup + iconst_0 + ldc Φ.jeo.long(N) +
+#     lastore)
+#   * A Φ.hone.lambda pragma that creates a primitive MapMultiConsumer
+#     capturing that counter, then calls
+#     IntStream.mapMulti(IntMapMultiConsumer) (or the Long / Double
+#     equivalent).
+#   * A new synthetic private static wrapper method that implements
+#     skip semantics: while counter[0] > 0 it decrements and drops the
+#     element, otherwise it forwards the primitive value to the
+#     downstream primitive Consumer.
+#
+# All three primitive stream classes are dispatched through a single
+# rule via sed substitution on 𝑒-primitive (I / J / D), producing the
+# correct lambda interface, bridge / lambda signatures, wrapper
+# signature, wrapper bytecode (iload / lload / dload, aload index,
+# max-locals) and invokeinterface signature.
+#
+# Fires only when count was captured as a Φ.number (the ldc form). The
+# string-typed count="0" / count="1" cases stay on the 313 / 356 paths.
+#
+# Same known limitations as 353 (counter-init bytecode placement w.r.t.
+# 512 cross-stage fusion; no eager negative-count check).
+name: primitive-skip-to-mapMulti
+pattern: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    𝐵-class-head-before,
+    name ↦ 𝑒-class-name,
+    𝐵-class-head-after,
+    𝜏-caller ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      𝐵-caller-head,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-skip ↦ ⟦
+          φ ↦ Φ.hone.primitive-skip,
+          stream-class ↦ 𝑒-stream-class,
+          stream-signature ↦ 𝑒-stream-signature,
+          count ↦ 𝑒-count
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝐵-caller-tail
+    ⟧,
+    𝐵-class-tail,
+    ρ ↦ ∅
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    𝐵-class-head-before,
+    name ↦ 𝑒-class-name,
+    𝐵-class-head-after,
+    𝜏-caller ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      𝐵-caller-head,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-iconst-1 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.iconst_1
+        ⟧,
+        𝜏-newarray ↦ ⟦
+          φ ↦ Φ.jeo.opcode.newarray,
+          i1 ↦ 11
+        ⟧,
+        𝜏-dup ↦ ⟦
+          φ ↦ Φ.jeo.opcode.dup
+        ⟧,
+        𝜏-iconst-0 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.iconst_0
+        ⟧,
+        𝜏-ldc ↦ ⟦
+          φ ↦ Φ.jeo.opcode.ldc,
+          i1 ↦ ⟦
+            φ ↦ Φ.jeo.long,
+            i1 ↦ 𝑒-count
+          ⟧
+        ⟧,
+        𝜏-lastore ↦ ⟦
+          φ ↦ Φ.jeo.opcode.lastore
+        ⟧,
+        𝜏-lambda ↦ ⟦
+          φ ↦ Φ.hone.lambda,
+          class ↦ 𝑒-class-name,
+          method ↦ "accept",
+          interface ↦ 𝑒-interface,
+          lambda-signature ↦ 𝑒-lambda-signature,
+          bridge-signature ↦ 𝑒-lambda-signature,
+          static ↦ "true",
+          opcode ↦ "invokestatic",
+          target ↦ ⟦
+            handle ↦ 6,
+            class ↦ 𝑒-class-name,
+            method ↦ 𝑒-wrapper-method,
+            signature ↦ 𝑒-wrapper-signature,
+            is-interface ↦ Φ.false
+          ⟧,
+          stream ↦ ⟦
+            class ↦ 𝑒-stream-class,
+            method ↦ "mapMulti",
+            signature ↦ 𝑒-stream-mapMulti-signature
+          ⟧
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝐵-caller-tail
+    ⟧,
+    𝐵-class-tail,
+    𝜏-wrapper ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 4106,
+      descriptor ↦ 𝑒-wrapper-signature,
+      signature ↦ "",
+      maxs ↦ ⟦
+        φ ↦ Φ.jeo.maxs,
+        max-stack ↦ 6,
+        max-locals ↦ 𝑒-max-locals
+      ⟧,
+      params ↦ ⟦
+        φ ↦ Φ.jeo.params,
+        i1 ↦ ⟦ φ ↦ Φ.jeo.param, index ↦ 0, access ↦ 0, type ↦ "[J" ⟧,
+        i2 ↦ ⟦ φ ↦ Φ.jeo.param, index ↦ 1, access ↦ 0, type ↦ 𝑒-primitive-type ⟧,
+        i3 ↦ ⟦ φ ↦ Φ.jeo.param, index ↦ 𝑒-consumer-index, access ↦ 0, type ↦ 𝑒-consumer-type ⟧
+      ⟧,
+      body ↦ ⟦
+        φ ↦ Φ.jeo.seq.of,
+        w0 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 0 ⟧,
+        w1 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+        w2 ↦ ⟦ φ ↦ Φ.jeo.opcode.laload ⟧,
+        w3 ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_0 ⟧,
+        w4 ↦ ⟦ φ ↦ Φ.jeo.opcode.lcmp ⟧,
+        w5 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.ifle,
+          i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label-accept ⟧
+        ⟧,
+        w6 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 0 ⟧,
+        w7 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+        w8 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 0 ⟧,
+        w9 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+        w10 ↦ ⟦ φ ↦ Φ.jeo.opcode.laload ⟧,
+        w11 ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_1 ⟧,
+        w12 ↦ ⟦ φ ↦ Φ.jeo.opcode.lsub ⟧,
+        w13 ↦ ⟦ φ ↦ Φ.jeo.opcode.lastore ⟧,
+        w14 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+        w15 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label-accept ⟧,
+        w16 ↦ ⟦
+          φ ↦ Φ.jeo.frame,
+          type ↦ 3,
+          nlocal ↦ 0,
+          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+          nstack ↦ 0,
+          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
+        ⟧,
+        w17 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 𝑒-consumer-index ⟧,
+        w18 ↦ ⟦ φ ↦ Φ.jeo.opcode.𝜏-value-load, i1 ↦ 1 ⟧,
+        w19 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          i2 ↦ 𝑒-consumer-class,
+          i3 ↦ "accept",
+          i4 ↦ 𝑒-consumer-accept-sig,
+          i5 ↦ Φ.true
+        ⟧,
+        w20 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+        ρ ↦ ∅
+      ⟧,
+      name ↦ 𝑒-wrapper-method
+    ⟧,
+    ρ ↦ ∅
+  ⟧
+when:
+  and:
+    - not:
+        eq: [ 𝑒-count, '"0"' ]
+    - not:
+        eq: [ 𝑒-count, '"1"' ]
+    - or:
+        - and:
+            - eq: [ 𝑒-stream-class, '"java/util/stream/IntStream"' ]
+            - eq: [ 𝑒-stream-signature, '"(J)Ljava/util/stream/IntStream;"' ]
+        - and:
+            - eq: [ 𝑒-stream-class, '"java/util/stream/LongStream"' ]
+            - eq: [ 𝑒-stream-signature, '"(J)Ljava/util/stream/LongStream;"' ]
+        - and:
+            - eq: [ 𝑒-stream-class, '"java/util/stream/DoubleStream"' ]
+            - eq: [ 𝑒-stream-signature, '"(J)Ljava/util/stream/DoubleStream;"' ]
+where:
+  - meta: 𝑒-primitive
+    function: sed
+    args:
+      - 𝑒-stream-class
+      - '"s/^java\\/util\\/stream\\/IntStream$/I/g"'
+      - '"s/^java\\/util\\/stream\\/LongStream$/J/g"'
+      - '"s/^java\\/util\\/stream\\/DoubleStream$/D/g"'
+  - meta: 𝑒-primitive-type
+    function: sed
+    args:
+      - 𝑒-primitive
+      - '"s/^I$/I/g"'
+      - '"s/^J$/J/g"'
+      - '"s/^D$/D/g"'
+  - meta: 𝑒-consumer-type
+    function: sed
+    args:
+      - 𝑒-primitive
+      - '"s/^I$/Ljava\\/util\\/function\\/IntConsumer;/g"'
+      - '"s/^J$/Ljava\\/util\\/function\\/LongConsumer;/g"'
+      - '"s/^D$/Ljava\\/util\\/function\\/DoubleConsumer;/g"'
+  - meta: 𝑒-consumer-class
+    function: sed
+    args:
+      - 𝑒-primitive
+      - '"s/^I$/java\\/util\\/function\\/IntConsumer/g"'
+      - '"s/^J$/java\\/util\\/function\\/LongConsumer/g"'
+      - '"s/^D$/java\\/util\\/function\\/DoubleConsumer/g"'
+  - meta: 𝑒-consumer-accept-sig
+    function: sed
+    args:
+      - 𝑒-primitive
+      - '"s/^I$/(I)V/g"'
+      - '"s/^J$/(J)V/g"'
+      - '"s/^D$/(D)V/g"'
+  - meta: 𝑒-consumer-index-str
+    function: sed
+    args:
+      - 𝑒-primitive
+      - '"s/^I$/2/g"'
+      - '"s/^J$/3/g"'
+      - '"s/^D$/3/g"'
+  - meta: 𝑒-consumer-index
+    function: number
+    args: [𝑒-consumer-index-str]
+  - meta: 𝑒-max-locals-str
+    function: sed
+    args:
+      - 𝑒-primitive
+      - '"s/^I$/3/g"'
+      - '"s/^J$/4/g"'
+      - '"s/^D$/4/g"'
+  - meta: 𝑒-max-locals
+    function: number
+    args: [𝑒-max-locals-str]
+  - meta: 𝑒-value-load-opcode-str
+    function: sed
+    args:
+      - 𝑒-primitive
+      - '"s/^I$/iload/g"'
+      - '"s/^J$/lload/g"'
+      - '"s/^D$/dload/g"'
+  - meta: 𝜏-value-load
+    function: tau
+    args: [𝑒-value-load-opcode-str]
+  - meta: 𝑒-sam-class
+    function: sed
+    args:
+      - 𝑒-primitive
+      - '"s/^I$/Ljava\\/util\\/stream\\/IntStream$IntMapMultiConsumer;/g"'
+      - '"s/^J$/Ljava\\/util\\/stream\\/LongStream$LongMapMultiConsumer;/g"'
+      - '"s/^D$/Ljava\\/util\\/stream\\/DoubleStream$DoubleMapMultiConsumer;/g"'
+  - meta: 𝑒-interface
+    function: concat
+    args: [ '"([J)"', 𝑒-sam-class ]
+  - meta: 𝑒-output-stream-type
+    function: sed
+    args:
+      - 𝑒-primitive
+      - '"s/^I$/Ljava\\/util\\/stream\\/IntStream;/g"'
+      - '"s/^J$/Ljava\\/util\\/stream\\/LongStream;/g"'
+      - '"s/^D$/Ljava\\/util\\/stream\\/DoubleStream;/g"'
+  - meta: 𝑒-stream-mapMulti-signature
+    function: concat
+    args: [ '"("', 𝑒-sam-class, '")"', 𝑒-output-stream-type ]
+  - meta: 𝑒-lambda-signature
+    function: concat
+    args: [ '"("', 𝑒-primitive-type, 𝑒-consumer-type, '")V"' ]
+  - meta: 𝑒-wrapper-signature
+    function: concat
+    args: [ '"([J"', 𝑒-primitive-type, 𝑒-consumer-type, '")V"' ]
+  - meta: 𝜏-iconst-1
+    function: random-tau
+    args: [ '𝐵-body-head', '𝐵-body-tail' ]
+  - meta: 𝜏-newarray
+    function: random-tau
+    args: [ '𝐵-body-head', '𝐵-body-tail', '𝜏-iconst-1' ]
+  - meta: 𝜏-dup
+    function: random-tau
+    args: [ '𝐵-body-head', '𝐵-body-tail', '𝜏-iconst-1', '𝜏-newarray' ]
+  - meta: 𝜏-iconst-0
+    function: random-tau
+    args: [ '𝐵-body-head', '𝐵-body-tail', '𝜏-iconst-1', '𝜏-newarray', '𝜏-dup' ]
+  - meta: 𝜏-ldc
+    function: random-tau
+    args: [ '𝐵-body-head', '𝐵-body-tail', '𝜏-iconst-1', '𝜏-newarray', '𝜏-dup', '𝜏-iconst-0' ]
+  - meta: 𝜏-lastore
+    function: random-tau
+    args: [ '𝐵-body-head', '𝐵-body-tail', '𝜏-iconst-1', '𝜏-newarray', '𝜏-dup', '𝜏-iconst-0', '𝜏-ldc' ]
+  - meta: 𝜏-lambda
+    function: random-tau
+    args: [ '𝐵-body-head', '𝐵-body-tail', '𝜏-iconst-1', '𝜏-newarray', '𝜏-dup', '𝜏-iconst-0', '𝜏-ldc', '𝜏-lastore' ]
+  - meta: 𝑒-wrapper-method
+    function: random-string
+    args: [ '"hone_primitive_skip_%d"' ]
+  - meta: 𝜏-wrapper
+    function: random-tau
+    args: [ 'name', '𝐵-class-head-before', '𝐵-class-head-after', '𝐵-class-tail', '𝜏-caller' ]
+  - meta: 𝑒-label-accept
+    function: random-string
+    args: [ '"LprimitiveSkipAccept%d"' ]

--- a/src/main/resources/org/eolang/hone/rules/streams/356-primitive-skip-one-to-mapMulti.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/356-primitive-skip-one-to-mapMulti.phr
@@ -1,0 +1,292 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 356-primitive-skip-one-to-mapMulti
+#
+# Sibling of 355 for the `.skip(1L)` shape on primitive streams.
+# Recognises Φ.hone.primitive-skip with count="1" (the string-typed
+# form produced by 224 when javac emitted `lconst_1` for the count)
+# and lowers it into the same state-carrying mapMulti shape 355
+# emits for the ldc case, with `lconst_1` in the counter-init instead
+# of `ldc Φ.jeo.long(N)`. Wrapper body is identical to 355's.
+#
+# See 355 for the full design notes (per-primitive sed dispatch,
+# wrapper local layout, known adjacency limitation w.r.t. 512 and
+# negative-count gap — the latter does not apply to count="1").
+name: primitive-skip-one-to-mapMulti
+pattern: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    𝐵-class-head-before,
+    name ↦ 𝑒-class-name,
+    𝐵-class-head-after,
+    𝜏-caller ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      𝐵-caller-head,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-skip ↦ ⟦
+          φ ↦ Φ.hone.primitive-skip,
+          stream-class ↦ 𝑒-stream-class,
+          stream-signature ↦ 𝑒-stream-signature,
+          count ↦ "1"
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝐵-caller-tail
+    ⟧,
+    𝐵-class-tail,
+    ρ ↦ ∅
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    𝐵-class-head-before,
+    name ↦ 𝑒-class-name,
+    𝐵-class-head-after,
+    𝜏-caller ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      𝐵-caller-head,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-iconst-1 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.iconst_1
+        ⟧,
+        𝜏-newarray ↦ ⟦
+          φ ↦ Φ.jeo.opcode.newarray,
+          i1 ↦ 11
+        ⟧,
+        𝜏-dup ↦ ⟦
+          φ ↦ Φ.jeo.opcode.dup
+        ⟧,
+        𝜏-iconst-0 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.iconst_0
+        ⟧,
+        𝜏-lconst-1 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.lconst_1
+        ⟧,
+        𝜏-lastore ↦ ⟦
+          φ ↦ Φ.jeo.opcode.lastore
+        ⟧,
+        𝜏-lambda ↦ ⟦
+          φ ↦ Φ.hone.lambda,
+          class ↦ 𝑒-class-name,
+          method ↦ "accept",
+          interface ↦ 𝑒-interface,
+          lambda-signature ↦ 𝑒-lambda-signature,
+          bridge-signature ↦ 𝑒-lambda-signature,
+          static ↦ "true",
+          opcode ↦ "invokestatic",
+          target ↦ ⟦
+            handle ↦ 6,
+            class ↦ 𝑒-class-name,
+            method ↦ 𝑒-wrapper-method,
+            signature ↦ 𝑒-wrapper-signature,
+            is-interface ↦ Φ.false
+          ⟧,
+          stream ↦ ⟦
+            class ↦ 𝑒-stream-class,
+            method ↦ "mapMulti",
+            signature ↦ 𝑒-stream-mapMulti-signature
+          ⟧
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝐵-caller-tail
+    ⟧,
+    𝐵-class-tail,
+    𝜏-wrapper ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 4106,
+      descriptor ↦ 𝑒-wrapper-signature,
+      signature ↦ "",
+      maxs ↦ ⟦
+        φ ↦ Φ.jeo.maxs,
+        max-stack ↦ 6,
+        max-locals ↦ 𝑒-max-locals
+      ⟧,
+      params ↦ ⟦
+        φ ↦ Φ.jeo.params,
+        i1 ↦ ⟦ φ ↦ Φ.jeo.param, index ↦ 0, access ↦ 0, type ↦ "[J" ⟧,
+        i2 ↦ ⟦ φ ↦ Φ.jeo.param, index ↦ 1, access ↦ 0, type ↦ 𝑒-primitive-type ⟧,
+        i3 ↦ ⟦ φ ↦ Φ.jeo.param, index ↦ 𝑒-consumer-index, access ↦ 0, type ↦ 𝑒-consumer-type ⟧
+      ⟧,
+      body ↦ ⟦
+        φ ↦ Φ.jeo.seq.of,
+        w0 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 0 ⟧,
+        w1 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+        w2 ↦ ⟦ φ ↦ Φ.jeo.opcode.laload ⟧,
+        w3 ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_0 ⟧,
+        w4 ↦ ⟦ φ ↦ Φ.jeo.opcode.lcmp ⟧,
+        w5 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.ifle,
+          i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label-accept ⟧
+        ⟧,
+        w6 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 0 ⟧,
+        w7 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+        w8 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 0 ⟧,
+        w9 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+        w10 ↦ ⟦ φ ↦ Φ.jeo.opcode.laload ⟧,
+        w11 ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_1 ⟧,
+        w12 ↦ ⟦ φ ↦ Φ.jeo.opcode.lsub ⟧,
+        w13 ↦ ⟦ φ ↦ Φ.jeo.opcode.lastore ⟧,
+        w14 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+        w15 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label-accept ⟧,
+        w16 ↦ ⟦
+          φ ↦ Φ.jeo.frame,
+          type ↦ 3,
+          nlocal ↦ 0,
+          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+          nstack ↦ 0,
+          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
+        ⟧,
+        w17 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 𝑒-consumer-index ⟧,
+        w18 ↦ ⟦ φ ↦ Φ.jeo.opcode.𝜏-value-load, i1 ↦ 1 ⟧,
+        w19 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          i2 ↦ 𝑒-consumer-class,
+          i3 ↦ "accept",
+          i4 ↦ 𝑒-consumer-accept-sig,
+          i5 ↦ Φ.true
+        ⟧,
+        w20 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+        ρ ↦ ∅
+      ⟧,
+      name ↦ 𝑒-wrapper-method
+    ⟧,
+    ρ ↦ ∅
+  ⟧
+when:
+  or:
+    - and:
+        - eq: [ 𝑒-stream-class, '"java/util/stream/IntStream"' ]
+        - eq: [ 𝑒-stream-signature, '"(J)Ljava/util/stream/IntStream;"' ]
+    - and:
+        - eq: [ 𝑒-stream-class, '"java/util/stream/LongStream"' ]
+        - eq: [ 𝑒-stream-signature, '"(J)Ljava/util/stream/LongStream;"' ]
+    - and:
+        - eq: [ 𝑒-stream-class, '"java/util/stream/DoubleStream"' ]
+        - eq: [ 𝑒-stream-signature, '"(J)Ljava/util/stream/DoubleStream;"' ]
+where:
+  - meta: 𝑒-primitive
+    function: sed
+    args:
+      - 𝑒-stream-class
+      - '"s/^java\\/util\\/stream\\/IntStream$/I/g"'
+      - '"s/^java\\/util\\/stream\\/LongStream$/J/g"'
+      - '"s/^java\\/util\\/stream\\/DoubleStream$/D/g"'
+  - meta: 𝑒-primitive-type
+    function: sed
+    args:
+      - 𝑒-primitive
+      - '"s/^I$/I/g"'
+      - '"s/^J$/J/g"'
+      - '"s/^D$/D/g"'
+  - meta: 𝑒-consumer-type
+    function: sed
+    args:
+      - 𝑒-primitive
+      - '"s/^I$/Ljava\\/util\\/function\\/IntConsumer;/g"'
+      - '"s/^J$/Ljava\\/util\\/function\\/LongConsumer;/g"'
+      - '"s/^D$/Ljava\\/util\\/function\\/DoubleConsumer;/g"'
+  - meta: 𝑒-consumer-class
+    function: sed
+    args:
+      - 𝑒-primitive
+      - '"s/^I$/java\\/util\\/function\\/IntConsumer/g"'
+      - '"s/^J$/java\\/util\\/function\\/LongConsumer/g"'
+      - '"s/^D$/java\\/util\\/function\\/DoubleConsumer/g"'
+  - meta: 𝑒-consumer-accept-sig
+    function: sed
+    args:
+      - 𝑒-primitive
+      - '"s/^I$/(I)V/g"'
+      - '"s/^J$/(J)V/g"'
+      - '"s/^D$/(D)V/g"'
+  - meta: 𝑒-consumer-index-str
+    function: sed
+    args:
+      - 𝑒-primitive
+      - '"s/^I$/2/g"'
+      - '"s/^J$/3/g"'
+      - '"s/^D$/3/g"'
+  - meta: 𝑒-consumer-index
+    function: number
+    args: [𝑒-consumer-index-str]
+  - meta: 𝑒-max-locals-str
+    function: sed
+    args:
+      - 𝑒-primitive
+      - '"s/^I$/3/g"'
+      - '"s/^J$/4/g"'
+      - '"s/^D$/4/g"'
+  - meta: 𝑒-max-locals
+    function: number
+    args: [𝑒-max-locals-str]
+  - meta: 𝑒-value-load-opcode-str
+    function: sed
+    args:
+      - 𝑒-primitive
+      - '"s/^I$/iload/g"'
+      - '"s/^J$/lload/g"'
+      - '"s/^D$/dload/g"'
+  - meta: 𝜏-value-load
+    function: tau
+    args: [𝑒-value-load-opcode-str]
+  - meta: 𝑒-sam-class
+    function: sed
+    args:
+      - 𝑒-primitive
+      - '"s/^I$/Ljava\\/util\\/stream\\/IntStream$IntMapMultiConsumer;/g"'
+      - '"s/^J$/Ljava\\/util\\/stream\\/LongStream$LongMapMultiConsumer;/g"'
+      - '"s/^D$/Ljava\\/util\\/stream\\/DoubleStream$DoubleMapMultiConsumer;/g"'
+  - meta: 𝑒-interface
+    function: concat
+    args: [ '"([J)"', 𝑒-sam-class ]
+  - meta: 𝑒-output-stream-type
+    function: sed
+    args:
+      - 𝑒-primitive
+      - '"s/^I$/Ljava\\/util\\/stream\\/IntStream;/g"'
+      - '"s/^J$/Ljava\\/util\\/stream\\/LongStream;/g"'
+      - '"s/^D$/Ljava\\/util\\/stream\\/DoubleStream;/g"'
+  - meta: 𝑒-stream-mapMulti-signature
+    function: concat
+    args: [ '"("', 𝑒-sam-class, '")"', 𝑒-output-stream-type ]
+  - meta: 𝑒-lambda-signature
+    function: concat
+    args: [ '"("', 𝑒-primitive-type, 𝑒-consumer-type, '")V"' ]
+  - meta: 𝑒-wrapper-signature
+    function: concat
+    args: [ '"([J"', 𝑒-primitive-type, 𝑒-consumer-type, '")V"' ]
+  - meta: 𝜏-iconst-1
+    function: random-tau
+    args: [ '𝐵-body-head', '𝐵-body-tail' ]
+  - meta: 𝜏-newarray
+    function: random-tau
+    args: [ '𝐵-body-head', '𝐵-body-tail', '𝜏-iconst-1' ]
+  - meta: 𝜏-dup
+    function: random-tau
+    args: [ '𝐵-body-head', '𝐵-body-tail', '𝜏-iconst-1', '𝜏-newarray' ]
+  - meta: 𝜏-iconst-0
+    function: random-tau
+    args: [ '𝐵-body-head', '𝐵-body-tail', '𝜏-iconst-1', '𝜏-newarray', '𝜏-dup' ]
+  - meta: 𝜏-lconst-1
+    function: random-tau
+    args: [ '𝐵-body-head', '𝐵-body-tail', '𝜏-iconst-1', '𝜏-newarray', '𝜏-dup', '𝜏-iconst-0' ]
+  - meta: 𝜏-lastore
+    function: random-tau
+    args: [ '𝐵-body-head', '𝐵-body-tail', '𝜏-iconst-1', '𝜏-newarray', '𝜏-dup', '𝜏-iconst-0', '𝜏-lconst-1' ]
+  - meta: 𝜏-lambda
+    function: random-tau
+    args: [ '𝐵-body-head', '𝐵-body-tail', '𝜏-iconst-1', '𝜏-newarray', '𝜏-dup', '𝜏-iconst-0', '𝜏-lconst-1', '𝜏-lastore' ]
+  - meta: 𝑒-wrapper-method
+    function: random-string
+    args: [ '"hone_primitive_skip_%d"' ]
+  - meta: 𝜏-wrapper
+    function: random-tau
+    args: [ 'name', '𝐵-class-head-before', '𝐵-class-head-after', '𝐵-class-tail', '𝜏-caller' ]
+  - meta: 𝑒-label-accept
+    function: random-string
+    args: [ '"LprimitiveSkipAccept%d"' ]

--- a/src/test/phino/355-primitive-skip-to-mapMulti-double.yml
+++ b/src/test/phino/355-primitive-skip-to-mapMulti-double.yml
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# DoubleStream variant of 355: same fold but capturing primitive double
+# values through a DoubleMapMultiConsumer and forwarding to a
+# DoubleConsumer. Wrapper local layout matches the long case
+# (max-locals=4, consumer at index 3).
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/355-primitive-skip-to-mapMulti.phr
+input: |
+  {⟦
+    φ ↦ Φ.jeo.class,
+    version ↦ 66,
+    access ↦ 33,
+    name ↦ "Foo",
+    supername ↦ "java/lang/Object",
+    main ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 4096,
+      name ↦ "main",
+      descriptor ↦ "()V",
+      body ↦ ⟦
+        i1 ↦ ⟦
+          φ ↦ Φ.hone.primitive-skip,
+          stream-class ↦ "java/util/stream/DoubleStream",
+          stream-signature ↦ "(J)Ljava/util/stream/DoubleStream;",
+          count ↦ 3
+        ⟧
+      ⟧
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      φ ↦ Φ.hone.lambda,
+      class ↦ "Foo",
+      method ↦ "accept",
+      interface ↦ "([J)Ljava/util/stream/DoubleStream$DoubleMapMultiConsumer;",
+      lambda-signature ↦ "(DLjava/util/function/DoubleConsumer;)V",
+      𝐵-lambda-tail
+    ⟧
+  - |
+    ⟦
+      φ ↦ Φ.jeo.opcode.ldc,
+      i1 ↦ ⟦
+        φ ↦ Φ.jeo.long,
+        i1 ↦ 3
+      ⟧
+    ⟧
+  - |
+    ⟦
+      φ ↦ Φ.jeo.opcode.dload,
+      i1 ↦ 1
+    ⟧
+  - |
+    ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      i2 ↦ "java/util/function/DoubleConsumer",
+      i3 ↦ "accept",
+      i4 ↦ "(D)V",
+      i5 ↦ Φ.true
+    ⟧

--- a/src/test/phino/355-primitive-skip-to-mapMulti-long.yml
+++ b/src/test/phino/355-primitive-skip-to-mapMulti-long.yml
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# LongStream variant of 355: same fold but capturing primitive long
+# values through a LongMapMultiConsumer and forwarding to a
+# LongConsumer. The wrapper local layout shifts to max-locals=4
+# because the long value occupies slots 1+2, putting the consumer at
+# index 3.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/355-primitive-skip-to-mapMulti.phr
+input: |
+  {⟦
+    φ ↦ Φ.jeo.class,
+    version ↦ 66,
+    access ↦ 33,
+    name ↦ "Foo",
+    supername ↦ "java/lang/Object",
+    main ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 4096,
+      name ↦ "main",
+      descriptor ↦ "()V",
+      body ↦ ⟦
+        i1 ↦ ⟦
+          φ ↦ Φ.hone.primitive-skip,
+          stream-class ↦ "java/util/stream/LongStream",
+          stream-signature ↦ "(J)Ljava/util/stream/LongStream;",
+          count ↦ 7
+        ⟧
+      ⟧
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      φ ↦ Φ.hone.lambda,
+      class ↦ "Foo",
+      method ↦ "accept",
+      interface ↦ "([J)Ljava/util/stream/LongStream$LongMapMultiConsumer;",
+      lambda-signature ↦ "(JLjava/util/function/LongConsumer;)V",
+      𝐵-lambda-tail
+    ⟧
+  - |
+    ⟦
+      φ ↦ Φ.jeo.opcode.ldc,
+      i1 ↦ ⟦
+        φ ↦ Φ.jeo.long,
+        i1 ↦ 7
+      ⟧
+    ⟧
+  - |
+    ⟦
+      φ ↦ Φ.jeo.opcode.lload,
+      i1 ↦ 1
+    ⟧
+  - |
+    ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      i2 ↦ "java/util/function/LongConsumer",
+      i3 ↦ "accept",
+      i4 ↦ "(J)V",
+      i5 ↦ Φ.true
+    ⟧

--- a/src/test/phino/355-primitive-skip-to-mapMulti.yml
+++ b/src/test/phino/355-primitive-skip-to-mapMulti.yml
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 355 is the primitive-stream counterpart of 353: Φ.hone.primitive-skip
+# with a Φ.number count (the ldc form on IntStream / LongStream /
+# DoubleStream) is lowered into the same state-carrying mapMulti shape
+# as the object Stream variant — long[1] counter array, captured
+# primitive MapMultiConsumer, synthetic wrapper — but using the
+# stream's primitive consumer type. Tested here on IntStream.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/355-primitive-skip-to-mapMulti.phr
+input: |
+  {⟦
+    φ ↦ Φ.jeo.class,
+    version ↦ 66,
+    access ↦ 33,
+    name ↦ "Foo",
+    supername ↦ "java/lang/Object",
+    main ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 4096,
+      name ↦ "main",
+      descriptor ↦ "()V",
+      body ↦ ⟦
+        i1 ↦ ⟦
+          φ ↦ Φ.hone.primitive-skip,
+          stream-class ↦ "java/util/stream/IntStream",
+          stream-signature ↦ "(J)Ljava/util/stream/IntStream;",
+          count ↦ 5
+        ⟧
+      ⟧
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      φ ↦ Φ.jeo.class,
+      𝐵-rest
+    ⟧
+  - |
+    ⟦
+      φ ↦ Φ.hone.lambda,
+      class ↦ "Foo",
+      method ↦ "accept",
+      interface ↦ "([J)Ljava/util/stream/IntStream$IntMapMultiConsumer;",
+      lambda-signature ↦ "(ILjava/util/function/IntConsumer;)V",
+      𝐵-lambda-tail
+    ⟧
+  - |
+    ⟦
+      φ ↦ Φ.jeo.opcode.newarray,
+      i1 ↦ 11
+    ⟧
+  - |
+    ⟦
+      φ ↦ Φ.jeo.opcode.ldc,
+      i1 ↦ ⟦
+        φ ↦ Φ.jeo.long,
+        i1 ↦ 5
+      ⟧
+    ⟧
+  - |
+    ⟦
+      φ ↦ Φ.jeo.opcode.lcmp
+    ⟧
+  - |
+    ⟦
+      φ ↦ Φ.jeo.opcode.lsub
+    ⟧
+  - |
+    ⟦
+      φ ↦ Φ.jeo.opcode.iload,
+      i1 ↦ 1
+    ⟧

--- a/src/test/phino/356-primitive-skip-one-to-mapMulti.yml
+++ b/src/test/phino/356-primitive-skip-one-to-mapMulti.yml
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 356 is the .skip(1L) sibling of 355 for primitive streams.
+# Φ.hone.primitive-skip with count="1" (the string-typed form produced
+# by 224 when javac emitted lconst_1 for the count) is lowered into the
+# same state-carrying mapMulti shape 355 emits for the ldc case, with
+# lconst_1 in the counter-init instead of ldc Φ.jeo.long(N). Tested
+# here on IntStream.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/356-primitive-skip-one-to-mapMulti.phr
+input: |
+  {⟦
+    φ ↦ Φ.jeo.class,
+    version ↦ 66,
+    access ↦ 33,
+    name ↦ "Foo",
+    supername ↦ "java/lang/Object",
+    main ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 4096,
+      name ↦ "main",
+      descriptor ↦ "()V",
+      body ↦ ⟦
+        i1 ↦ ⟦
+          φ ↦ Φ.hone.primitive-skip,
+          stream-class ↦ "java/util/stream/IntStream",
+          stream-signature ↦ "(J)Ljava/util/stream/IntStream;",
+          count ↦ "1"
+        ⟧
+      ⟧
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      φ ↦ Φ.hone.lambda,
+      class ↦ "Foo",
+      method ↦ "accept",
+      interface ↦ "([J)Ljava/util/stream/IntStream$IntMapMultiConsumer;",
+      lambda-signature ↦ "(ILjava/util/function/IntConsumer;)V",
+      𝐵-lambda-tail
+    ⟧
+  - |
+    ⟦
+      φ ↦ Φ.jeo.opcode.lconst_1
+    ⟧
+  - |
+    ⟦
+      φ ↦ Φ.jeo.opcode.iload,
+      i1 ↦ 1
+    ⟧
+  - |
+    ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      i2 ↦ "java/util/function/IntConsumer",
+      i3 ↦ "accept",
+      i4 ↦ "(I)V",
+      i5 ↦ Φ.true
+    ⟧

--- a/src/test/phino/356-primitive-skip-one-to-mapMulti.yml
+++ b/src/test/phino/356-primitive-skip-one-to-mapMulti.yml
@@ -44,7 +44,14 @@ expected:
     ⟧
   - |
     ⟦
-      φ ↦ Φ.jeo.opcode.lconst_1
+      𝐵-init-head,
+      𝜏-lconst-1 ↦ ⟦
+        φ ↦ Φ.jeo.opcode.lconst_1
+      ⟧,
+      𝜏-lastore ↦ ⟦
+        φ ↦ Φ.jeo.opcode.lastore
+      ⟧,
+      𝐵-init-tail
     ⟧
   - |
     ⟦

--- a/src/test/resources/org/eolang/hone/optimize/streams-skipped-primitive-fused.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-skipped-primitive-fused.yml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Asserts that .skip(N) on IntStream / LongStream / DoubleStream is
+# folded into the state-carrying mapMulti shape by 355 / 356, and
+# that the resulting bytecode still produces the same numeric outputs
+# as the original .skip() chain. Each primitive stream gets a
+# different non-zero skip count and a downstream operation that is
+# order-sensitive (sum after a prefix discard) so that an off-by-one
+# or a non-prefix discard would surface as a wrong number:
+#   * IntStream  : (1,2,3,4,5).map(n+1).skip(2).sum() = 4+5+6 = 15
+#   * LongStream : (10,20,30,40).skip(1).sum()       = 20+30+40 = 90
+#   * DoubleStream: (1.5,2.5,3.5).skip(1).sum()      = 2.5+3.5 = 6.0
+java: |
+  package skippedprimitivefused;
+  import java.util.stream.IntStream;
+  import java.util.stream.LongStream;
+  import java.util.stream.DoubleStream;
+  public class X {
+    public static void main(String[] a) {
+      int i = IntStream.of(1, 2, 3, 4, 5).map(n -> n + 1).skip(2L).sum();
+      long l = LongStream.of(10L, 20L, 30L, 40L).skip(1L).sum();
+      double d = DoubleStream.of(1.5, 2.5, 3.5).skip(1L).sum();
+      System.out.printf("Sums are %d %d %.1f\n", i, l, d);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "Sums are 15 90 6.0"


### PR DESCRIPTION
Extends the 353/354 state-carrying mapMulti fold to the primitive
streams. Each primitive `.skip(N)` is lowered into the same shape
as the object Stream variant — a `long[1]` counter array captured
by a synthetic primitive `MapMultiConsumer`, with a new
private-static wrapper method per call site that decrements the
counter while it is positive and forwards the value otherwise.

Two rules carry the lowering: 355 for the `ldc Φ.jeo.long(N)`
form, and 356 for the `lconst_1` form that 224 produces when
javac picked the one-byte opcode for `1L`. Both dispatch across
`IntStream` / `LongStream` / `DoubleStream` through a single
`sed` substitution on `stream-class`, producing the right
lambda interface (`IntMapMultiConsumer` / `LongMapMultiConsumer`
/ `DoubleMapMultiConsumer`), wrapper signature, wrapper bytecode
(`iload` / `lload` / `dload`, consumer at `aload 2` for `int` and
`aload 3` for `long` / `double`, `max-locals` 3 or 4) and the
matching `mapMulti` invokeinterface descriptor.

There are phino unit tests covering all three primitive variants
of 355 plus the lconst_1 form of 356, and a Docker integration
test (`streams-skipped-primitive-fused`) that exercises
`.map().skip(2).sum()` on `IntStream` and `.skip(1).sum()` on
`LongStream` / `DoubleStream` end-to-end. The same adjacency and
negative-count caveats noted on 353 carry over here.