### PR TITLE
Pin heterogeneous mapMulti + mapToInt merge for #542

### DIFF
--- a/src/test/phino/pipeline-mapMulti-mapToInt-methodref.yml
+++ b/src/test/phino/pipeline-mapMulti-mapToInt-methodref.yml
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Pins the heterogeneous merge from issue #542. After the streams
+# pipeline reaches the 4xx/5xx phases, a .map().flatMap().map() chain
+# folds into a single Φ.hone.mapMulti(stream-class=Stream). The
+# downstream .mapToInt(Integer::intValue) is the method-reference
+# idiom that 111 never sees, so 112-methodref-to-lambda promotes it
+# to Φ.hone.lambda first, 141 supplies the missing opcode, and 205
+# recognises the .mapToInt shape as Φ.hone.unbox. Once the unbox is
+# adjacent to the upstream Φ.hone.mapMulti, 513 collapses both into a
+# single Φ.hone.lambda whose stream.method is mapMultiToInt, plus the
+# two synthesized merged + wrap-to-primitive methods that carry the
+# fused work. This is the canonical end-state that the optimised
+# bytecode of every `.map…mapToInt(Integer::intValue).sum()` chain
+# needs to reach in `main`, and the test asserts on each of the three
+# load-bearing shapes (fused lambda, merged method, wrap method).
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/112-methodref-to-lambda.phr
+  - src/main/resources/org/eolang/hone/rules/streams/141-set-opcode-in-lambda.phr
+  - src/main/resources/org/eolang/hone/rules/streams/205-lambda-to-unbox.phr
+  - src/main/resources/org/eolang/hone/rules/streams/513-merge-mapMulti-unbox.phr
+input: |
+  {⟦
+    φ ↦ Φ.jeo.class,
+    version ↦ 61,
+    access ↦ 33,
+    modifiers ↦ ⟦ φ ↦ Φ.jeo.modifiers, public ↦ Φ.true, static ↦ Φ.false ⟧,
+    name ↦ "Foo",
+    supername ↦ "java/lang/Object",
+    interfaces ↦ ⟦ φ ↦ Φ.jeo.interfaces ⟧,
+    jm$main ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 9,
+      modifiers ↦ ⟦ φ ↦ Φ.jeo.modifiers, public ↦ Φ.true, static ↦ Φ.true ⟧,
+      name ↦ "main",
+      descriptor ↦ "([Ljava/lang/String;)V",
+      signature ↦ "",
+      exceptions ↦ ⟦ φ ↦ Φ.jeo.exceptions ⟧,
+      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, max-stack ↦ 2, max-locals ↦ 2 ⟧,
+      params ↦ ⟦ φ ↦ Φ.jeo.params ⟧,
+      annotations ↦ ⟦ φ ↦ Φ.jeo.annotations ⟧,
+      body ↦ ⟦
+        i0 ↦ ⟦
+          φ ↦ Φ.hone.mapMulti,
+          class ↦ "Foo",
+          target-method ↦ "b1_target",
+          bridge-input ↦ "Ljava/lang/Integer;",
+          map-multi-consumer ↦ "Ljava/util/function/BiConsumer;",
+          lambda-signature ↦ "(Ljava/lang/Object;Ljava/lang/Object;)V",
+          consumer ↦ "Ljava/util/function/Consumer;",
+          stream-class ↦ "java/util/stream/Stream",
+          static ↦ "true",
+          is-interface ↦ Φ.false
+        ⟧,
+        i1 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokedynamic,
+          i2 ↦ "applyAsInt",
+          i3 ↦ "()Ljava/util/function/ToIntFunction;",
+          i4 ↦ ⟦
+            φ ↦ Φ.jeo.handle,
+            i1 ↦ 6,
+            i2 ↦ "java/lang/invoke/LambdaMetafactory",
+            i3 ↦ "metafactory",
+            i4 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+            i5 ↦ Φ.false
+          ⟧,
+          i5 ↦ ⟦ φ ↦ Φ.jeo.type, i1 ↦ "(Ljava/lang/Object;)I" ⟧,
+          i6 ↦ ⟦
+            φ ↦ Φ.jeo.handle,
+            i1 ↦ 5,
+            i2 ↦ "java/lang/Integer",
+            i3 ↦ "intValue",
+            i4 ↦ "()I",
+            i5 ↦ Φ.false
+          ⟧,
+          i7 ↦ ⟦ φ ↦ Φ.jeo.type, i1 ↦ "(Ljava/lang/Integer;)I" ⟧
+        ⟧,
+        i2 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          i2 ↦ "java/util/stream/Stream",
+          i3 ↦ "mapToInt",
+          i4 ↦ "(Ljava/util/function/ToIntFunction;)Ljava/util/stream/IntStream;",
+          i5 ↦ Φ.true
+        ⟧
+      ⟧,
+      trycatchblocks ↦ ⟦ φ ↦ Φ.jeo.trycatchblocks ⟧,
+      local-variable-table ↦ ⟦ φ ↦ Φ.jeo.local-variable-table ⟧
+    ⟧
+  ⟧}
+expected:
+  - |
+    ⟦
+      𝐵-class-pre,
+      𝜏-main ↦ ⟦
+        φ ↦ Φ.jeo.method,
+        𝐵-method-pre,
+        body ↦ ⟦
+          𝜏-only ↦ ⟦
+            φ ↦ Φ.hone.lambda,
+            𝐵-lambda-pre,
+            stream ↦ ⟦
+              𝐵-stream-pre,
+              method ↦ "mapMultiToInt",
+              𝐵-stream-post
+            ⟧,
+            𝐵-lambda-post
+          ⟧,
+          ρ ↦ ∅
+        ⟧,
+        𝐵-method-post
+      ⟧,
+      𝐵-class-post
+    ⟧
+  - |
+    ⟦
+      𝐵-pre,
+      𝜏-merged ↦ ⟦
+        φ ↦ Φ.jeo.method,
+        𝐵-pre-desc,
+        descriptor ↦ "(Ljava/lang/Integer;Ljava/util/function/IntConsumer;)V",
+        𝐵-post-desc
+      ⟧,
+      𝐵-post
+    ⟧
+  - |
+    ⟦
+      𝐵-pre,
+      𝜏-wrap ↦ ⟦
+        φ ↦ Φ.jeo.method,
+        𝐵-pre-desc,
+        descriptor ↦ "(Ljava/util/function/IntConsumer;Ljava/lang/Integer;)V",
+        𝐵-post-desc
+      ⟧,
+      𝐵-post
+    ⟧


### PR DESCRIPTION
Adds a phino-level integration test that pins the canonical end-state for issue #542. The test feeds an adjacent `Φ.hone.mapMulti(stream-class=Stream)` followed by the raw `invokedynamic + invokeinterface` pair that `.mapToInt(Integer::intValue)` lowers to, runs the chain 112 → 141 → 205 → 513, and asserts that the body collapses into a single `Φ.hone.lambda(stream.method=mapMultiToInt)` plus the two synthesised `merged` and wrap-to-primitive methods.

The underlying rule chain that makes this work was completed when PR #562 (issue #536) added `112-methodref-to-lambda` — until then `.mapToInt(Integer::intValue)` stayed as raw bytecode that 205 and 513 never saw. The fixtures `streams-flatmapped.yml`, `streams-mapped.yml`, and `streams-all-ops.yml` already exercise this end to end, but each of them spins up Docker and Maven; a regression in any of the four rules currently surfaces only after the slow optimise fixtures run. This test pins the same end-state at the phino layer so it fails fast.

Closes #542