### PR TITLE
Split opcodes into before+after in YAML test packs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,8 +178,11 @@ The output is the rewritten expression on stdout.
 5. **Add or update an end-to-end YAML** in
    `src/test/resources/org/eolang/hone/optimize/`. These specify the
    Java source to compile, the expected `log` lines, and the expected
-   `opcodes` count in the optimized class. Updating the opcodes counts
-   is normal when a rule changes how a stream pipeline is lowered.
+   opcode counts in the class — `before` for the bytecode produced by
+   `javac` and `after` for the bytecode produced by the optimizer.
+   A count of `0` asserts the opcode is absent at that stage. Updating
+   the `after` counts is normal when a rule changes how a stream
+   pipeline is lowered.
 6. **Bump the phino version** in `default-phino-version.txt` only if
    the rule depends on syntax or behavior that ships in a newer phino.
 

--- a/src/test/java/org/eolang/hone/OptimizeMojoTest.java
+++ b/src/test/java/org/eolang/hone/OptimizeMojoTest.java
@@ -92,8 +92,6 @@ final class OptimizeMojoTest {
         @RandomImage final String image) throws Exception {
         final Map<String, Object> pack = new Yaml().load(yaml);
         final String code = (String) pack.get("java");
-        final Map<String, Integer> before = (Map<String, Integer>) pack.get("before");
-        final Map<String, Integer> after = (Map<String, Integer>) pack.get("after");
         final Matcher pkg = Pattern.compile("package\\s+([\\w.]+)\\s*;").matcher(code);
         if (!pkg.find()) {
             throw new IllegalStateException(
@@ -106,21 +104,9 @@ final class OptimizeMojoTest {
                 String.format("YAML pack lacks 'class' declaration in 'java' field: %s", yaml)
             );
         }
-        final String path = String.format(
-            "src/main/java/%s/%s.java",
-            pkg.group(1).replace('.', '/'),
-            cls.group(1)
-        );
-        final String bytecode = String.format(
-            "target/classes/%s/%s.class",
-            pkg.group(1).replace('.', '/'),
-            cls.group(1)
-        );
-        final String original = String.format(
-            "target/classes-before-hone/%s/%s.class",
-            pkg.group(1).replace('.', '/'),
-            cls.group(1)
-        );
+        final String slashed = pkg.group(1).replace('.', '/');
+        final String klass = cls.group(1);
+        final String path = String.format("src/main/java/%s/%s.java", slashed, klass);
         new Farea(dir).together(
             f -> {
                 f.clean();
@@ -143,7 +129,7 @@ final class OptimizeMojoTest {
                     .phase("process-classes")
                     .goals("java")
                     .configuration()
-                    .set("mainClass", String.format("%s.%s", pkg.group(1), cls.group(1)));
+                    .set("mainClass", String.format("%s.%s", pkg.group(1), klass));
                 f.exec("process-classes");
                 MatcherAssert.assertThat(
                     String.format(
@@ -155,52 +141,69 @@ final class OptimizeMojoTest {
                         new Mapped<>(Matchers::containsString, (List<String>) pack.get("log"))
                     )
                 );
-                if (before != null) {
-                    final Map<String, Integer> actual = new ClassOpcodes(
-                        f.files().file(original).path()
-                    ).counts();
-                    final List<org.hamcrest.Matcher<? super Map<? extends String, ? extends Integer>>> checks =
-                        new ArrayList<>(before.size());
-                    for (final Map.Entry<String, Integer> entry : before.entrySet()) {
-                        if (entry.getValue() == 0) {
-                            checks.add(Matchers.not(Matchers.hasKey(entry.getKey())));
-                        } else {
-                            checks.add(Matchers.hasEntry(entry.getKey(), entry.getValue()));
-                        }
-                    }
-                    MatcherAssert.assertThat(
-                        String.format(
-                            "pre-optimization opcode counts in %s do not match YAML 'before' expectations, actual: %s",
-                            original, actual
-                        ),
-                        actual,
-                        Matchers.allOf(checks)
-                    );
-                }
-                if (after != null) {
-                    final Map<String, Integer> actual = new ClassOpcodes(
-                        f.files().file(bytecode).path()
-                    ).counts();
-                    final List<org.hamcrest.Matcher<? super Map<? extends String, ? extends Integer>>> checks =
-                        new ArrayList<>(after.size());
-                    for (final Map.Entry<String, Integer> entry : after.entrySet()) {
-                        if (entry.getValue() == 0) {
-                            checks.add(Matchers.not(Matchers.hasKey(entry.getKey())));
-                        } else {
-                            checks.add(Matchers.hasEntry(entry.getKey(), entry.getValue()));
-                        }
-                    }
-                    MatcherAssert.assertThat(
-                        String.format(
-                            "post-optimization opcode counts in %s do not match YAML 'after' expectations, actual: %s",
-                            bytecode, actual
-                        ),
-                        actual,
-                        Matchers.allOf(checks)
-                    );
-                }
+                OptimizeMojoTest.assertOpcodes(
+                    f.files().file(
+                        String.format("target/classes-before-hone/%s/%s.class", slashed, klass)
+                    ).path(),
+                    (Map<String, Integer>) pack.get("before"),
+                    "before"
+                );
+                OptimizeMojoTest.assertOpcodes(
+                    f.files().file(
+                        String.format("target/classes/%s/%s.class", slashed, klass)
+                    ).path(),
+                    (Map<String, Integer>) pack.get("after"),
+                    "after"
+                );
             }
         );
+    }
+
+    /**
+     * Assert that opcode counts in a compiled class match the YAML
+     * expectations. A zero value asserts the opcode is absent.
+     * @param klass Path to the .class file
+     * @param expected Expected opcode → count map, or null to skip
+     * @param stage Either "before" or "after" — used in the failure message
+     * @throws IOException If the class file cannot be read
+     */
+    private static void assertOpcodes(final Path klass,
+        final Map<String, Integer> expected, final String stage) throws IOException {
+        if (expected == null) {
+            return;
+        }
+        final Map<String, Integer> actual = new ClassOpcodes(klass).counts();
+        final List<org.hamcrest.Matcher<? super Map<? extends String, ? extends Integer>>> checks =
+            new ArrayList<>(expected.size());
+        for (final Map.Entry<String, Integer> entry : expected.entrySet()) {
+            checks.add(OptimizeMojoTest.opcodeMatcher(entry.getKey(), entry.getValue()));
+        }
+        MatcherAssert.assertThat(
+            String.format(
+                "%s-stage opcode counts in %s do not match YAML '%s' expectations, actual: %s",
+                stage, klass, stage, actual
+            ),
+            actual,
+            Matchers.allOf(checks)
+        );
+    }
+
+    /**
+     * Build a single opcode matcher: presence with an exact count when
+     * the expected value is positive, absence when it is zero.
+     * @param opcode Opcode mnemonic
+     * @param count Expected occurrences (zero asserts absence)
+     * @return A Hamcrest matcher over the opcode tally
+     */
+    private static org.hamcrest.Matcher<? super Map<? extends String, ? extends Integer>>
+        opcodeMatcher(final String opcode, final Integer count) {
+        final org.hamcrest.Matcher<? super Map<? extends String, ? extends Integer>> ret;
+        if (count == 0) {
+            ret = Matchers.not(Matchers.hasKey(opcode));
+        } else {
+            ret = Matchers.hasEntry(opcode, count);
+        }
+        return ret;
     }
 
     @Test

--- a/src/test/java/org/eolang/hone/OptimizeMojoTest.java
+++ b/src/test/java/org/eolang/hone/OptimizeMojoTest.java
@@ -92,7 +92,8 @@ final class OptimizeMojoTest {
         @RandomImage final String image) throws Exception {
         final Map<String, Object> pack = new Yaml().load(yaml);
         final String code = (String) pack.get("java");
-        final Map<String, Integer> opcodes = (Map<String, Integer>) pack.get("opcodes");
+        final Map<String, Integer> before = (Map<String, Integer>) pack.get("before");
+        final Map<String, Integer> after = (Map<String, Integer>) pack.get("after");
         final Matcher pkg = Pattern.compile("package\\s+([\\w.]+)\\s*;").matcher(code);
         if (!pkg.find()) {
             throw new IllegalStateException(
@@ -112,6 +113,11 @@ final class OptimizeMojoTest {
         );
         final String bytecode = String.format(
             "target/classes/%s/%s.class",
+            pkg.group(1).replace('.', '/'),
+            cls.group(1)
+        );
+        final String original = String.format(
+            "target/classes-before-hone/%s/%s.class",
             pkg.group(1).replace('.', '/'),
             cls.group(1)
         );
@@ -149,18 +155,44 @@ final class OptimizeMojoTest {
                         new Mapped<>(Matchers::containsString, (List<String>) pack.get("log"))
                     )
                 );
-                if (opcodes != null) {
+                if (before != null) {
+                    final Map<String, Integer> actual = new ClassOpcodes(
+                        f.files().file(original).path()
+                    ).counts();
+                    final List<org.hamcrest.Matcher<? super Map<? extends String, ? extends Integer>>> checks =
+                        new ArrayList<>(before.size());
+                    for (final Map.Entry<String, Integer> entry : before.entrySet()) {
+                        if (entry.getValue() == 0) {
+                            checks.add(Matchers.not(Matchers.hasKey(entry.getKey())));
+                        } else {
+                            checks.add(Matchers.hasEntry(entry.getKey(), entry.getValue()));
+                        }
+                    }
+                    MatcherAssert.assertThat(
+                        String.format(
+                            "pre-optimization opcode counts in %s do not match YAML 'before' expectations, actual: %s",
+                            original, actual
+                        ),
+                        actual,
+                        Matchers.allOf(checks)
+                    );
+                }
+                if (after != null) {
                     final Map<String, Integer> actual = new ClassOpcodes(
                         f.files().file(bytecode).path()
                     ).counts();
                     final List<org.hamcrest.Matcher<? super Map<? extends String, ? extends Integer>>> checks =
-                        new ArrayList<>(opcodes.size());
-                    for (final Map.Entry<String, Integer> entry : opcodes.entrySet()) {
-                        checks.add(Matchers.hasEntry(entry.getKey(), entry.getValue()));
+                        new ArrayList<>(after.size());
+                    for (final Map.Entry<String, Integer> entry : after.entrySet()) {
+                        if (entry.getValue() == 0) {
+                            checks.add(Matchers.not(Matchers.hasKey(entry.getKey())));
+                        } else {
+                            checks.add(Matchers.hasEntry(entry.getKey(), entry.getValue()));
+                        }
                     }
                     MatcherAssert.assertThat(
                         String.format(
-                            "opcode counts in %s do not match YAML expectations, actual: %s",
+                            "post-optimization opcode counts in %s do not match YAML 'after' expectations, actual: %s",
                             bytecode, actual
                         ),
                         actual,

--- a/src/test/resources/org/eolang/hone/optimize/streams-all-ops.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-all-ops.yml
@@ -45,7 +45,13 @@ log:
   - "Finished rewriting 1 file"
   - "BUILD SUCCESS"
   - "The result is 54"
-opcodes:
+before:
+  invokespecial: 1
+  invokestatic: 17
+  invokevirtual: 11
+  invokedynamic: 17
+  return: 7
+after:
   invokespecial: 2
   invokestatic: 26
   invokevirtual: 13

--- a/src/test/resources/org/eolang/hone/optimize/streams-distinct.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-distinct.yml
@@ -31,6 +31,9 @@ log:
   - "Finished rewriting 1 file"
   - "BUILD SUCCESS"
   - "The result is 4"
-opcodes:
+before:
+  new: 0
+  invokevirtual: 1
+after:
   new: 1
   invokevirtual: 2

--- a/src/test/resources/org/eolang/hone/optimize/streams-drop-while.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-drop-while.yml
@@ -32,7 +32,11 @@ log:
   - "Finished rewriting 1 file"
   - "BUILD SUCCESS"
   - "The result is 5"
-opcodes:
+before:
+  newarray: 0
+  baload: 0
+  bastore: 0
+after:
   newarray: 1
   baload: 1
   bastore: 1

--- a/src/test/resources/org/eolang/hone/optimize/streams-flatmapped.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-flatmapped.yml
@@ -21,7 +21,13 @@ log:
   - "Finished rewriting 1 file"
   - "BUILD SUCCESS"
   - "The result is 87"
-opcodes:
+before:
+  invokespecial: 1
+  invokestatic: 9
+  invokevirtual: 4
+  invokedynamic: 4
+  return: 2
+after:
   invokespecial: 1
   invokestatic: 17
   invokevirtual: 5

--- a/src/test/resources/org/eolang/hone/optimize/streams-full-non-terminal.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-full-non-terminal.yml
@@ -74,5 +74,7 @@ log:
   - "Finished rewriting 1 file"
   - "BUILD SUCCESS"
   - "The result is 54"
-opcodes:
+before:
+  invokedynamic: 23
+after:
   invokedynamic: 19

--- a/src/test/resources/org/eolang/hone/optimize/streams-mapped.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-mapped.yml
@@ -22,7 +22,13 @@ log:
   - "Finished rewriting 1 file"
   - "BUILD SUCCESS"
   - "The result is 32"
-opcodes:
+before:
+  invokespecial: 1
+  invokestatic: 9
+  invokevirtual: 5
+  invokedynamic: 5
+  return: 2
+after:
   invokespecial: 1
   invokestatic: 14
   invokevirtual: 6

--- a/src/test/resources/org/eolang/hone/optimize/streams-peeked.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-peeked.yml
@@ -25,5 +25,7 @@ log:
   - "Finished rewriting 1 file"
   - "BUILD SUCCESS"
   - "The result is 5"
-opcodes:
+before:
+  invokedynamic: 2
+after:
   invokedynamic: 1

--- a/src/test/resources/org/eolang/hone/optimize/streams-rand.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-rand.yml
@@ -15,7 +15,13 @@ log:
   - "Finished rewriting 1 file"
   - "BUILD SUCCESS"
   - "Dont optimize me, pls"
-opcodes:
+before:
+  invokespecial: 1
+  invokevirtual: 1
+  getstatic: 1
+  ldc: 1
+  return: 2
+after:
   invokespecial: 1
   invokevirtual: 1
   getstatic: 1

--- a/src/test/resources/org/eolang/hone/optimize/streams-skipped-non-zero.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-skipped-non-zero.yml
@@ -23,5 +23,7 @@ log:
   - "Finished rewriting 1 file"
   - "BUILD SUCCESS"
   - "The result is 3"
-opcodes:
+before:
+  invokeinterface: 2
+after:
   invokeinterface: 2

--- a/src/test/resources/org/eolang/hone/optimize/streams-skipped-primitive.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-skipped-primitive.yml
@@ -28,5 +28,7 @@ log:
   - "Finished rewriting 1 file"
   - "BUILD SUCCESS"
   - "Sums are 15 70 7.5"
-opcodes:
+before:
+  invokeinterface: 6
+after:
   invokeinterface: 4

--- a/src/test/resources/org/eolang/hone/optimize/streams-skipped.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-skipped.yml
@@ -23,5 +23,7 @@ log:
   - "Finished rewriting 1 file"
   - "BUILD SUCCESS"
   - "The result is 5"
-opcodes:
+before:
+  invokeinterface: 2
+after:
   invokeinterface: 1

--- a/src/test/resources/org/eolang/hone/optimize/streams-take-while.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-take-while.yml
@@ -31,7 +31,11 @@ log:
   - "Finished rewriting 1 file"
   - "BUILD SUCCESS"
   - "The result is 3"
-opcodes:
+before:
+  newarray: 0
+  baload: 0
+  bastore: 0
+after:
   newarray: 1
   baload: 1
   bastore: 1


### PR DESCRIPTION
Every YAML pack under src/test/resources/org/eolang/hone/optimize/
used to carry a single `opcodes` block that listed how many of each
JVM opcode were expected after the rewrite ran. This change splits
that block in two: `before` (counts in the bytecode that javac just
emitted) and `after` (counts in the bytecode after phino is done).
OptimizeMojoTest reads target/classes-before-hone/ for `before` and
target/classes/ for `after`. A zero value now means the opcode must
be absent at that stage.

The motivation is the request in #564: with the two blocks side by
side the optimization effect is immediately visible in the fixture
(for example, streams-mapped jumps from invokedynamic=5 down to
invokedynamic=2, and streams-take-while shows the boolean[1] guard
appearing as newarray=0 -> newarray=1).

Closes #564