### PR TITLE
Add coverage workflow that runs hone against open-source Java repos

### DIFF
--- a/.github/coverage.sh
+++ b/.github/coverage.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+
+set -u -o pipefail
+
+repos=(
+  "apache/commons-cli"
+  "apache/commons-csv"
+  "apache/commons-codec"
+  "apache/commons-text"
+  "apache/commons-io"
+  "apache/commons-validator"
+  "apache/commons-net"
+  "apache/commons-pool"
+  "apache/commons-email"
+  "jhy/jsoup"
+)
+
+root=$(pwd)
+work="${root}/target/coverage"
+csv="${work}/coverage.csv"
+mkdir -p "${work}"
+
+version=$(mvn -B -q -DforceStdout help:evaluate -Dexpression=project.version --batch-mode 2>/dev/null | tail -n 1)
+test -n "${version}" || { echo "Failed to read project version from pom.xml" >&2; exit 1; }
+echo "hone-maven-plugin version: ${version}"
+
+mvn -B -q --batch-mode install -DskipTests -Dinvoker.skip
+echo "hone-maven-plugin installed into local Maven repository"
+
+printf 'repo;build_before;time_before;classes_modified;build_after;time_after\n' > "${csv}"
+
+snapshot_classes() {
+  local base=$1 out=$2
+  (cd "${base}" && find . -type f -path '*/target/classes/*.class' -print0 \
+    | xargs -0 md5sum 2>/dev/null \
+    | sort > "${out}") || true
+}
+
+apply_hone() {
+  local base=$1
+  local rc=0
+  (cd "${base}" && find . -type d -path '*/target/classes' -print0 \
+    | while IFS= read -r -d '' cdir; do
+    module=$(dirname "$(dirname "${cdir}")")
+    echo "applying hone in ${module}"
+    if ! (cd "${module}" && mvn -B -q --batch-mode \
+        "org.eolang:hone-maven-plugin:${version}:build" \
+        "org.eolang:hone-maven-plugin:${version}:optimize" \
+        -Dhone.rules='streams/*'); then
+      echo "hone failed in ${module}" >&2
+      rc=1
+    fi
+  done) || rc=1
+  return "${rc}"
+}
+
+count_modified() {
+  local before=$1 after=$2
+  awk '/^[<>]/ {print $NF}' < <(diff "${before}" "${after}" 2>/dev/null) \
+    | sort -u | wc -l | tr -d ' '
+}
+
+run_repo() {
+  local repo=$1
+  local name
+  name=$(basename "${repo}")
+  local repo_dir="${work}/${name}"
+  printf '\n=== %s ===\n' "${repo}"
+  rm -rf "${repo_dir}"
+  if ! git clone --depth 1 "https://github.com/${repo}.git" "${repo_dir}"; then
+    printf '%s;clone_failed;0;0;skipped;0\n' "${repo}" >> "${csv}"
+    return 0
+  fi
+  local before_start before_end time_before build_before
+  before_start=$(date +%s)
+  if (cd "${repo_dir}" && mvn -B -q --batch-mode -Dlicense.skip -Drat.skip -Dspotbugs.skip -Dcheckstyle.skip -Dpmd.skip -Denforcer.skip clean test); then
+    build_before="pass"
+  else
+    build_before="fail"
+  fi
+  before_end=$(date +%s)
+  time_before=$((before_end - before_start))
+  if [ "${build_before}" != "pass" ]; then
+    printf '%s;fail;%s;0;skipped;0\n' "${repo}" "${time_before}" >> "${csv}"
+    return 0
+  fi
+  local snap_before="${repo_dir}/.cov-before" snap_after="${repo_dir}/.cov-after"
+  snapshot_classes "${repo_dir}" "${snap_before}"
+  local hone_ok="yes"
+  apply_hone "${repo_dir}" || hone_ok="no"
+  snapshot_classes "${repo_dir}" "${snap_after}"
+  local modified=0
+  if [ -s "${snap_before}" ] && [ -s "${snap_after}" ]; then
+    modified=$(count_modified "${snap_before}" "${snap_after}")
+  fi
+  local after_start after_end time_after build_after
+  after_start=$(date +%s)
+  if [ "${hone_ok}" != "yes" ]; then
+    build_after="hone_failed"
+    time_after=0
+  else
+    if (cd "${repo_dir}" && mvn -B -q --batch-mode -Dlicense.skip -Drat.skip -Dspotbugs.skip -Dcheckstyle.skip -Dpmd.skip -Denforcer.skip surefire:test); then
+      build_after="pass"
+    else
+      build_after="fail"
+    fi
+    after_end=$(date +%s)
+    time_after=$((after_end - after_start))
+  fi
+  printf '%s;%s;%s;%s;%s;%s\n' "${repo}" "${build_before}" "${time_before}" "${modified}" "${build_after}" "${time_after}" >> "${csv}"
+  rm -rf "${repo_dir}"
+}
+
+for repo in "${repos[@]}"; do
+  run_repo "${repo}" || true
+done
+
+echo ""
+echo "Final CSV:"
+cat "${csv}"
+
+table=$(
+  printf '| Repository | Build Before | Time Before (s) | Classes Modified | Build After | Time After (s) |\n'
+  printf '|---|---|---|---|---|---|\n'
+  tail -n +2 "${csv}" | while IFS=';' read -r row_repo before_status before_time changed after_status after_time; do
+    printf '| [%s](https://github.com/%s) | %s | %s | %s | %s | %s |\n' \
+      "${row_repo}" "${row_repo}" "${before_status}" "${before_time}" "${changed}" "${after_status}" "${after_time}"
+  done
+)
+
+sum=$(
+  printf '%s\n\n' "${table}"
+  printf 'The results were calculated in [this GHA job][coverage-gha]\n'
+  printf 'on %s at %s,\n' "$(date +'%Y-%m-%d')" "$(date +'%H:%M')"
+  printf 'on %s with %s CPUs.\n' "$(uname)" "$(nproc --all)"
+)
+export sum
+perl -i -0777 -pe 's/(?<=<!-- coverage_begin -->).*(?=<!-- coverage_end -->)/\n$ENV{sum}\n/gs;' README.md
+
+if [ -n "${GITHUB_RUN_ID:-}" ]; then
+  url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+  export url
+  perl -i -0777 -pe 's/(?<=\[coverage-gha\]: )[^\n]+(?=\n)/$ENV{url}/gs;' README.md
+fi

--- a/.github/coverage.sh
+++ b/.github/coverage.sh
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 
-set -u -o pipefail
+set -e -u -o pipefail
 
 repos=(
   "apache/commons-cli"
@@ -26,56 +26,44 @@ version=$(mvn -B -q -DforceStdout help:evaluate -Dexpression=project.version --b
 test -n "${version}" || { echo "Failed to read project version from pom.xml" >&2; exit 1; }
 echo "hone-maven-plugin version: ${version}"
 
-if ! mvn -B -q --batch-mode install -DskipTests -Dinvoker.skip; then
-  echo "Failed to install hone-maven-plugin into local Maven repository" >&2
-  exit 1
-fi
+mvn -B -q --batch-mode install -DskipTests -Dinvoker.skip
 echo "hone-maven-plugin installed into local Maven repository"
 
 printf 'repo;build_before;time_before;classes_modified;build_after;time_after\n' > "${csv}"
 
 snapshot_classes() {
   local base=$1 out=$2
-  (cd "${base}" && find . -type f -path '*/target/classes/*.class' -print0 \
-    | xargs -0 md5sum 2>/dev/null \
-    | sort > "${out}") || true
+  (cd "${base}" && find . -type f -path '*/target/classes/*.class' -exec md5sum {} + | sort > "${out}")
 }
 
 apply_hone() {
   local base=$1
-  local rc=0
   local cdir module
   while IFS= read -r -d '' cdir; do
     module=$(dirname "$(dirname "${cdir}")")
     echo "applying hone in ${module}"
-    if ! (cd "${module}" && mvn -B -q --batch-mode \
-        "org.eolang:hone-maven-plugin:${version}:build" \
-        "org.eolang:hone-maven-plugin:${version}:optimize" \
-        -Dhone.rules='streams/*'); then
-      echo "hone failed in ${module}" >&2
-      rc=1
-    fi
+    (cd "${module}" && mvn -B -q --batch-mode \
+      "org.eolang:hone-maven-plugin:${version}:build" \
+      "org.eolang:hone-maven-plugin:${version}:optimize" \
+      -Dhone.rules='streams/*')
   done < <(find "${base}" -type d -path '*/target/classes' -print0)
-  return "${rc}"
 }
 
 count_modified() {
   local before=$1 after=$2
-  awk '/^[<>]/ {print $NF}' < <(diff "${before}" "${after}" 2>/dev/null) \
+  { diff "${before}" "${after}" || true; } \
+    | awk '/^[<>]/ {print $NF}' \
     | sort -u | wc -l | tr -d ' '
 }
 
 run_repo() {
   local repo=$1
-  local name dir row start outcome seconds snap count hone
+  local name dir row start outcome seconds snap count
   name=$(basename "${repo}")
   dir="${work}/${name}"
   printf '\n=== %s ===\n' "${repo}"
   rm -rf "${dir}"
-  if ! git clone --depth 1 "https://github.com/${repo}.git" "${dir}"; then
-    printf '%s;clone_failed;0;0;skipped;0\n' "${repo}" >> "${csv}"
-    return 0
-  fi
+  git clone --depth 1 "https://github.com/${repo}.git" "${dir}"
   row="${repo}"
   start=$(date +%s)
   if (cd "${dir}" && mvn -B -q --batch-mode -Dlicense.skip -Drat.skip -Dspotbugs.skip -Dcheckstyle.skip -Dpmd.skip -Denforcer.skip clean test); then
@@ -87,22 +75,15 @@ run_repo() {
   row="${row};${outcome};${seconds}"
   if [ "${outcome}" != "pass" ]; then
     printf '%s;0;skipped;0\n' "${row}" >> "${csv}"
+    rm -rf "${dir}"
     return 0
   fi
   snap="${dir}/.snap"
   snapshot_classes "${dir}" "${snap}.before"
-  hone="yes"
-  apply_hone "${dir}" || hone="no"
+  apply_hone "${dir}"
   snapshot_classes "${dir}" "${snap}.after"
-  count=0
-  if [ -s "${snap}.before" ] && [ -s "${snap}.after" ]; then
-    count=$(count_modified "${snap}.before" "${snap}.after")
-  fi
+  count=$(count_modified "${snap}.before" "${snap}.after")
   row="${row};${count}"
-  if [ "${hone}" != "yes" ]; then
-    printf '%s;hone_failed;0\n' "${row}" >> "${csv}"
-    return 0
-  fi
   start=$(date +%s)
   if (cd "${dir}" && mvn -B -q --batch-mode -Dlicense.skip -Drat.skip -Dspotbugs.skip -Dcheckstyle.skip -Dpmd.skip -Denforcer.skip surefire:test); then
     outcome="pass"
@@ -115,7 +96,7 @@ run_repo() {
 }
 
 for repo in "${repos[@]}"; do
-  run_repo "${repo}" || true
+  run_repo "${repo}"
 done
 
 echo ""
@@ -128,11 +109,12 @@ table=$(
   tail -n +2 "${csv}" | awk -F';' '{ printf "| [%s](https://github.com/%s) | %s | %s | %s | %s | %s |\n", $1, $1, $2, $3, $4, $5, $6 }'
 )
 
+cpus=$(nproc --all 2>/dev/null || echo "?")
 sum=$(
   printf '%s\n\n' "${table}"
   printf 'The results were calculated in [this GHA job][coverage-gha]\n'
   printf 'on %s at %s,\n' "$(date +'%Y-%m-%d')" "$(date +'%H:%M')"
-  printf 'on %s with %s CPUs.\n' "$(uname)" "$(nproc --all)"
+  printf 'on %s with %s CPUs.\n' "$(uname)" "${cpus}"
 )
 export sum
 perl -i -0777 -pe 's/(?<=<!-- coverage_begin -->).*(?=<!-- coverage_end -->)/\n$ENV{sum}\n/gs;' README.md

--- a/.github/coverage.sh
+++ b/.github/coverage.sh
@@ -26,7 +26,10 @@ version=$(mvn -B -q -DforceStdout help:evaluate -Dexpression=project.version --b
 test -n "${version}" || { echo "Failed to read project version from pom.xml" >&2; exit 1; }
 echo "hone-maven-plugin version: ${version}"
 
-mvn -B -q --batch-mode install -DskipTests -Dinvoker.skip
+if ! mvn -B -q --batch-mode install -DskipTests -Dinvoker.skip; then
+  echo "Failed to install hone-maven-plugin into local Maven repository" >&2
+  exit 1
+fi
 echo "hone-maven-plugin installed into local Maven repository"
 
 printf 'repo;build_before;time_before;classes_modified;build_after;time_after\n' > "${csv}"
@@ -41,8 +44,8 @@ snapshot_classes() {
 apply_hone() {
   local base=$1
   local rc=0
-  (cd "${base}" && find . -type d -path '*/target/classes' -print0 \
-    | while IFS= read -r -d '' cdir; do
+  local cdir module
+  while IFS= read -r -d '' cdir; do
     module=$(dirname "$(dirname "${cdir}")")
     echo "applying hone in ${module}"
     if ! (cd "${module}" && mvn -B -q --batch-mode \
@@ -52,7 +55,7 @@ apply_hone() {
       echo "hone failed in ${module}" >&2
       rc=1
     fi
-  done) || rc=1
+  done < <(find "${base}" -type d -path '*/target/classes' -print0)
   return "${rc}"
 }
 
@@ -64,53 +67,51 @@ count_modified() {
 
 run_repo() {
   local repo=$1
-  local name
+  local name dir row start outcome seconds snap count hone
   name=$(basename "${repo}")
-  local repo_dir="${work}/${name}"
+  dir="${work}/${name}"
   printf '\n=== %s ===\n' "${repo}"
-  rm -rf "${repo_dir}"
-  if ! git clone --depth 1 "https://github.com/${repo}.git" "${repo_dir}"; then
+  rm -rf "${dir}"
+  if ! git clone --depth 1 "https://github.com/${repo}.git" "${dir}"; then
     printf '%s;clone_failed;0;0;skipped;0\n' "${repo}" >> "${csv}"
     return 0
   fi
-  local before_start before_end time_before build_before
-  before_start=$(date +%s)
-  if (cd "${repo_dir}" && mvn -B -q --batch-mode -Dlicense.skip -Drat.skip -Dspotbugs.skip -Dcheckstyle.skip -Dpmd.skip -Denforcer.skip clean test); then
-    build_before="pass"
+  row="${repo}"
+  start=$(date +%s)
+  if (cd "${dir}" && mvn -B -q --batch-mode -Dlicense.skip -Drat.skip -Dspotbugs.skip -Dcheckstyle.skip -Dpmd.skip -Denforcer.skip clean test); then
+    outcome="pass"
   else
-    build_before="fail"
+    outcome="fail"
   fi
-  before_end=$(date +%s)
-  time_before=$((before_end - before_start))
-  if [ "${build_before}" != "pass" ]; then
-    printf '%s;fail;%s;0;skipped;0\n' "${repo}" "${time_before}" >> "${csv}"
+  seconds=$(( $(date +%s) - start ))
+  row="${row};${outcome};${seconds}"
+  if [ "${outcome}" != "pass" ]; then
+    printf '%s;0;skipped;0\n' "${row}" >> "${csv}"
     return 0
   fi
-  local snap_before="${repo_dir}/.cov-before" snap_after="${repo_dir}/.cov-after"
-  snapshot_classes "${repo_dir}" "${snap_before}"
-  local hone_ok="yes"
-  apply_hone "${repo_dir}" || hone_ok="no"
-  snapshot_classes "${repo_dir}" "${snap_after}"
-  local modified=0
-  if [ -s "${snap_before}" ] && [ -s "${snap_after}" ]; then
-    modified=$(count_modified "${snap_before}" "${snap_after}")
+  snap="${dir}/.snap"
+  snapshot_classes "${dir}" "${snap}.before"
+  hone="yes"
+  apply_hone "${dir}" || hone="no"
+  snapshot_classes "${dir}" "${snap}.after"
+  count=0
+  if [ -s "${snap}.before" ] && [ -s "${snap}.after" ]; then
+    count=$(count_modified "${snap}.before" "${snap}.after")
   fi
-  local after_start after_end time_after build_after
-  after_start=$(date +%s)
-  if [ "${hone_ok}" != "yes" ]; then
-    build_after="hone_failed"
-    time_after=0
+  row="${row};${count}"
+  if [ "${hone}" != "yes" ]; then
+    printf '%s;hone_failed;0\n' "${row}" >> "${csv}"
+    return 0
+  fi
+  start=$(date +%s)
+  if (cd "${dir}" && mvn -B -q --batch-mode -Dlicense.skip -Drat.skip -Dspotbugs.skip -Dcheckstyle.skip -Dpmd.skip -Denforcer.skip surefire:test); then
+    outcome="pass"
   else
-    if (cd "${repo_dir}" && mvn -B -q --batch-mode -Dlicense.skip -Drat.skip -Dspotbugs.skip -Dcheckstyle.skip -Dpmd.skip -Denforcer.skip surefire:test); then
-      build_after="pass"
-    else
-      build_after="fail"
-    fi
-    after_end=$(date +%s)
-    time_after=$((after_end - after_start))
+    outcome="fail"
   fi
-  printf '%s;%s;%s;%s;%s;%s\n' "${repo}" "${build_before}" "${time_before}" "${modified}" "${build_after}" "${time_after}" >> "${csv}"
-  rm -rf "${repo_dir}"
+  seconds=$(( $(date +%s) - start ))
+  printf '%s;%s;%s\n' "${row}" "${outcome}" "${seconds}" >> "${csv}"
+  rm -rf "${dir}"
 }
 
 for repo in "${repos[@]}"; do
@@ -124,10 +125,7 @@ cat "${csv}"
 table=$(
   printf '| Repository | Build Before | Time Before (s) | Classes Modified | Build After | Time After (s) |\n'
   printf '|---|---|---|---|---|---|\n'
-  tail -n +2 "${csv}" | while IFS=';' read -r row_repo before_status before_time changed after_status after_time; do
-    printf '| [%s](https://github.com/%s) | %s | %s | %s | %s | %s |\n' \
-      "${row_repo}" "${row_repo}" "${before_status}" "${before_time}" "${changed}" "${after_status}" "${after_time}"
-  done
+  tail -n +2 "${csv}" | awk -F';' '{ printf "| [%s](https://github.com/%s) | %s | %s | %s | %s | %s |\n", $1, $1, $2, $3, $4, $5, $6 }'
 )
 
 sum=$(

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,9 +4,10 @@
 # yamllint disable rule:line-length
 name: coverage
 'on':
-  schedule:
-    - cron: '0 5 * * 1'
-  workflow_dispatch:
+  push:
+    branches:
+      - master
+    paths-ignore: ['README.md', '.github']
 concurrency:
   group: coverage-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+name: coverage
+'on':
+  schedule:
+    - cron: '0 5 * * 1'
+  workflow_dispatch:
+concurrency:
+  group: coverage-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  coverage:
+    timeout-minutes: 120
+    runs-on: ubuntu-24.04
+    env:
+      LC_ALL: en_US.UTF-8
+      LANG: en_US.UTF-8
+      LANGUAGE: en_US.UTF-8
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: 21
+      - uses: actions/cache@v5
+        with:
+          path: ~/.m2/repository
+          key: ubuntu-jdk-21-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ubuntu-jdk-21-maven-
+      - run: |
+          sudo wget -q -O /usr/bin/phino http://phino.objectionary.com/releases/ubuntu-24.04/phino-latest
+          sudo chmod a+x /usr/bin/phino
+      - run: .github/coverage.sh
+      - uses: peter-evans/create-pull-request@v8
+        with:
+          sign-commits: true
+          branch: coverage
+          commit-message: 'new coverage results'
+          delete-branch: true
+          title: 'New coverage results'
+          assignees: yegor256
+          base: master

--- a/README.md
+++ b/README.md
@@ -342,6 +342,24 @@ on 2026-05-19 at 05:44,
 on Linux with 4 CPUs.
 <!-- benchmark_end -->
 
+## Coverage
+
+Here is the result of running the plugin against a number of mid-size,
+mature open-source Java projects from GitHub. For each project, the
+workflow shallow-clones the repository, runs `mvn clean test` to record
+a baseline, applies `hone-maven-plugin` to every `target/classes/`
+directory, and then re-runs the tests to check that the bytecode still
+passes the project's own test suite. The number of modified `.class`
+files is computed by comparing MD5 checksums before and after.
+
+<!-- coverage_begin -->
+The coverage report has not been generated yet. Once the `coverage`
+GitHub Actions workflow runs for the first time, a table with results
+will appear here.
+
+The results are calculated in [this GHA job][coverage-gha].
+<!-- coverage_end -->
+
 ## How to Contribute
 
 Fork repository, make changes, then send us a [pull request][guidelines].
@@ -362,6 +380,7 @@ that we use, are defined in the `pom.xml` file.
 
 [EO]: https://github.com/objectionary/eo
 [benchmark-gha]: https://github.com/objectionary/hone-maven-plugin/actions/runs/26078355752
+[coverage-gha]: https://github.com/objectionary/hone-maven-plugin/actions/workflows/coverage.yml
 [bytecode]: https://en.wikipedia.org/wiki/Java_bytecode
 [guidelines]: https://www.yegor256.com/2014/04/15/github-guidelines.html
 [Maven]: https://maven.apache.org/


### PR DESCRIPTION
This adds a new `coverage` GitHub Actions workflow alongside a `.github/coverage.sh` script that exercises the plugin against ten mid-size, mature open-source Java projects: the bulk of the Apache Commons family (`cli`, `csv`, `codec`, `text`, `io`, `validator`, `net`, `pool`, `email`) plus `jhy/jsoup`. Each one is shallow-cloned, built with `mvn clean test` as a baseline, then `hone-maven-plugin` is applied to every `target/classes/` directory in the project, and the test suite is rerun. The script records build status, build timings, and the number of `.class` files modified by hone into a CSV, then renders that CSV as a Markdown table and injects it into a new `<!-- coverage_begin -->...<!-- coverage_end -->` block in the README, the same way `benchmark.yml` updates the benchmark block today.

The motivation is to give us a regularly-refreshed signal across real-world projects of how often the plugin keeps the test suite green and how often it actually changes any bytecode. The workflow runs weekly on a cron and on `workflow_dispatch`, and it opens a `coverage` PR with the updated README, mirroring the benchmark workflow's pattern.

Closes #571