### PR TITLE
Pin coverage target repos to specific commits

### DIFF
--- a/.github/coverage.sh
+++ b/.github/coverage.sh
@@ -5,16 +5,16 @@
 set -e -u -o pipefail
 
 repos=(
-  "apache/commons-cli"
-  "apache/commons-csv"
-  "apache/commons-codec"
-  "apache/commons-text"
-  "apache/commons-io"
-  "apache/commons-validator"
-  "apache/commons-net"
-  "apache/commons-pool"
-  "apache/commons-email"
-  "jhy/jsoup"
+  "apache/commons-cli@17de58009bf9dada031a7b3891014c6de5a089bf"
+  "apache/commons-csv@6f93c7edfa0f758f757227b1d30588411fdbf669"
+  "apache/commons-codec@77fcf89711a0e20393105a1247c41968f6eb58d4"
+  "apache/commons-text@283eaf49586331a7adc0b28fdfa5e8f09df87123"
+  "apache/commons-io@5ea874ee07d081a69e4ff2971d3d8fc8cace9179"
+  "apache/commons-validator@a3e7627ffd1e633e93b45749650c5a6262da8e6c"
+  "apache/commons-net@ab2b19fee5e76984843fce6481f0c7724f629920"
+  "apache/commons-pool@6b9c542ac9746eeec00a497712e41b014d51fdb3"
+  "apache/commons-email@c300a6d66dcd5708b6bb5d1a1eb5f9f99f4d9090"
+  "jhy/jsoup@a7ec14364e2f9f84ecb795814b4fd05d028f709d"
 )
 
 root=$(pwd)
@@ -29,7 +29,16 @@ echo "hone-maven-plugin version: ${version}"
 mvn -B -q --batch-mode install -DskipTests -Dinvoker.skip
 echo "hone-maven-plugin installed into local Maven repository"
 
-printf 'repo;build_before;time_before;classes_modified;build_after;time_after\n' > "${csv}"
+printf 'repo;sha;build_before;time_before;classes_modified;build_after;time_after\n' > "${csv}"
+
+shallow_checkout() {
+  local repo=$1 sha=$2 dir=$3
+  mkdir -p "${dir}"
+  git -C "${dir}" init -q
+  git -C "${dir}" remote add origin "https://github.com/${repo}.git"
+  git -C "${dir}" fetch --depth 1 -q origin "${sha}"
+  git -C "${dir}" checkout -q FETCH_HEAD
+}
 
 snapshot_classes() {
   local base=$1 out=$2
@@ -57,14 +66,14 @@ count_modified() {
 }
 
 run_repo() {
-  local repo=$1
+  local repo=$1 sha=$2
   local name dir row start outcome seconds snap count
   name=$(basename "${repo}")
   dir="${work}/${name}"
-  printf '\n=== %s ===\n' "${repo}"
+  printf '\n=== %s @ %s ===\n' "${repo}" "${sha}"
   rm -rf "${dir}"
-  git clone --depth 1 "https://github.com/${repo}.git" "${dir}"
-  row="${repo}"
+  shallow_checkout "${repo}" "${sha}" "${dir}"
+  row="${repo};${sha}"
   start=$(date +%s)
   if (cd "${dir}" && mvn -B -q --batch-mode -Dlicense.skip -Drat.skip -Dspotbugs.skip -Dcheckstyle.skip -Dpmd.skip -Denforcer.skip clean test); then
     outcome="pass"
@@ -95,8 +104,8 @@ run_repo() {
   rm -rf "${dir}"
 }
 
-for repo in "${repos[@]}"; do
-  run_repo "${repo}"
+for entry in "${repos[@]}"; do
+  run_repo "${entry%@*}" "${entry#*@}"
 done
 
 echo ""
@@ -106,7 +115,10 @@ cat "${csv}"
 table=$(
   printf '| Repository | Build Before | Time Before (s) | Classes Modified | Build After | Time After (s) |\n'
   printf '|---|---|---|---|---|---|\n'
-  tail -n +2 "${csv}" | awk -F';' '{ printf "| [%s](https://github.com/%s) | %s | %s | %s | %s | %s |\n", $1, $1, $2, $3, $4, $5, $6 }'
+  tail -n +2 "${csv}" | awk -F';' '{
+    short = substr($2, 1, 7)
+    printf "| [%s@%s](https://github.com/%s/commit/%s) | %s | %s | %s | %s | %s |\n", $1, short, $1, $2, $3, $4, $5, $6, $7
+  }'
 )
 
 cpus=$(nproc --all 2>/dev/null || echo "?")

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,7 +7,7 @@ name: coverage
   push:
     branches:
       - master
-    paths-ignore: ['README.md', '.github']
+    paths-ignore: [ 'README.md', '.github' ]
 concurrency:
   group: coverage-${{ github.ref }}
   cancel-in-progress: true

--- a/README.md
+++ b/README.md
@@ -345,8 +345,10 @@ on Linux with 4 CPUs.
 ## Coverage
 
 Here is the result of running the plugin against a number of mid-size,
-mature open-source Java projects from GitHub. For each project, the
-workflow shallow-clones the repository, runs `mvn clean test` to record
+mature open-source Java projects from GitHub. Each project is pinned to
+a specific commit (rather than its moving `master` head) so that the
+table stays reproducible across runs. For each pinned commit, the
+workflow shallow-fetches that revision, runs `mvn clean test` to record
 a baseline, applies `hone-maven-plugin` to every `target/classes/`
 directory, and then re-runs the tests to check that the bytecode still
 passes the project's own test suite. The number of modified `.class`


### PR DESCRIPTION
Each of the ten target repositories in `.github/coverage.sh` is now pinned to a specific commit SHA in the `repos` array, instead of being cloned at whatever `master` happens to point to when the workflow runs. The clone step is replaced with a `git init` + `git fetch --depth 1 origin <sha>` + `git checkout FETCH_HEAD`, which is still a shallow fetch but always pulls the exact revision named in the array. A `sha` column is added to the CSV, and the rendered Markdown table links the repo title to that exact commit on GitHub.

The motivation is reproducibility: under the previous setup, the table was effectively a snapshot of whatever the upstream maintainers had merged that morning, so two runs of the workflow could disagree on baseline timings, test outcomes, or modified-class counts without `hone-maven-plugin` itself having changed. Pinning makes the workflow's output depend only on what is in this repository, which is what makes the table useful as a regression signal. When the pins drift far enough behind upstream to matter, the SHAs can be bumped in one place and the change shows up clearly in the diff.

No follow-up is needed; the workflow trigger and the rest of the script are unchanged.