### PR TITLE
Add smoke workflow against one external Java repo

### DIFF
--- a/.github/smoke.sh
+++ b/.github/smoke.sh
@@ -12,11 +12,9 @@ work="${root}/target/smoke"
 mkdir -p "${work}"
 
 version=$(mvn -B -q -DforceStdout help:evaluate -Dexpression=project.version --batch-mode 2>/dev/null | tail -n 1)
-test -n "${version}" || { echo "Failed to read project version from pom.xml" >&2; exit 1; }
 echo "hone-maven-plugin version: ${version}"
 
 mvn -B -q --batch-mode install -DskipTests -Dinvoker.skip
-echo "hone-maven-plugin installed into local Maven repository"
 
 name=$(basename "${repo}")
 dir="${work}/${name}"
@@ -27,23 +25,16 @@ git -C "${dir}" fetch --depth 1 origin "${sha}"
 git -C "${dir}" checkout -q FETCH_HEAD
 echo "checked out ${repo} at ${sha}"
 
-printf '\n=== first run: tests of %s without hone ===\n' "${repo}"
-(cd "${dir}" && mvn -B --batch-mode -Dlicense.skip -Drat.skip -Dspotbugs.skip -Dcheckstyle.skip -Dpmd.skip -Denforcer.skip clean test) \
-  || { echo "tests of ${repo} failed before hone was applied" >&2; exit 1; }
+mvn_flags=(-B --batch-mode -Dlicense.skip -Drat.skip -Dspotbugs.skip -Dcheckstyle.skip -Dpmd.skip -Denforcer.skip)
 
-printf '\n=== applying hone to %s ===\n' "${repo}"
+(cd "${dir}" && mvn "${mvn_flags[@]}" clean test)
+
 while IFS= read -r -d '' cdir; do
   module=$(dirname "$(dirname "${cdir}")")
-  echo "applying hone in ${module}"
   (cd "${module}" && mvn -B --batch-mode \
     "org.eolang:hone-maven-plugin:${version}:build" \
     "org.eolang:hone-maven-plugin:${version}:optimize" \
     -Dhone.rules='streams/*')
 done < <(find "${dir}" -type d -path '*/target/classes' -print0)
 
-printf '\n=== second run: tests of %s after hone ===\n' "${repo}"
-(cd "${dir}" && mvn -B --batch-mode -Dlicense.skip -Drat.skip -Dspotbugs.skip -Dcheckstyle.skip -Dpmd.skip -Denforcer.skip surefire:test) \
-  || { echo "tests of ${repo} failed after hone was applied" >&2; exit 1; }
-
-echo ""
-echo "smoke test passed: ${repo} tests still pass after hone optimization"
+(cd "${dir}" && mvn "${mvn_flags[@]}" surefire:test)

--- a/.github/smoke.sh
+++ b/.github/smoke.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+
+set -e -u -o pipefail
+
+repo="apache/commons-cli"
+
+root=$(pwd)
+work="${root}/target/smoke"
+mkdir -p "${work}"
+
+version=$(mvn -B -q -DforceStdout help:evaluate -Dexpression=project.version --batch-mode 2>/dev/null | tail -n 1)
+test -n "${version}" || { echo "Failed to read project version from pom.xml" >&2; exit 1; }
+echo "hone-maven-plugin version: ${version}"
+
+mvn -B -q --batch-mode install -DskipTests -Dinvoker.skip
+echo "hone-maven-plugin installed into local Maven repository"
+
+name=$(basename "${repo}")
+dir="${work}/${name}"
+rm -rf "${dir}"
+git clone --depth 1 "https://github.com/${repo}.git" "${dir}"
+
+printf '\n=== first run: tests of %s without hone ===\n' "${repo}"
+(cd "${dir}" && mvn -B --batch-mode -Dlicense.skip -Drat.skip -Dspotbugs.skip -Dcheckstyle.skip -Dpmd.skip -Denforcer.skip clean test) \
+  || { echo "tests of ${repo} failed before hone was applied" >&2; exit 1; }
+
+printf '\n=== applying hone to %s ===\n' "${repo}"
+while IFS= read -r -d '' cdir; do
+  module=$(dirname "$(dirname "${cdir}")")
+  echo "applying hone in ${module}"
+  (cd "${module}" && mvn -B --batch-mode \
+    "org.eolang:hone-maven-plugin:${version}:build" \
+    "org.eolang:hone-maven-plugin:${version}:optimize" \
+    -Dhone.rules='streams/*')
+done < <(find "${dir}" -type d -path '*/target/classes' -print0)
+
+printf '\n=== second run: tests of %s after hone ===\n' "${repo}"
+(cd "${dir}" && mvn -B --batch-mode -Dlicense.skip -Drat.skip -Dspotbugs.skip -Dcheckstyle.skip -Dpmd.skip -Denforcer.skip surefire:test) \
+  || { echo "tests of ${repo} failed after hone was applied" >&2; exit 1; }
+
+echo ""
+echo "smoke test passed: ${repo} tests still pass after hone optimization"

--- a/.github/smoke.sh
+++ b/.github/smoke.sh
@@ -27,14 +27,14 @@ echo "checked out ${repo} at ${sha}"
 
 mvn_flags=(-B --batch-mode -Dlicense.skip -Drat.skip -Dspotbugs.skip -Dcheckstyle.skip -Dpmd.skip -Denforcer.skip)
 
-(cd "${dir}" && mvn "${mvn_flags[@]}" clean test)
+mvn -f "${dir}" "${mvn_flags[@]}" clean test
 
 while IFS= read -r -d '' cdir; do
   module=$(dirname "$(dirname "${cdir}")")
-  (cd "${module}" && mvn -B --batch-mode \
+  mvn -f "${module}" -B --batch-mode \
     "org.eolang:hone-maven-plugin:${version}:build" \
     "org.eolang:hone-maven-plugin:${version}:optimize" \
-    -Dhone.rules='streams/*')
+    -Dhone.rules='streams/*'
 done < <(find "${dir}" -type d -path '*/target/classes' -print0)
 
-(cd "${dir}" && mvn "${mvn_flags[@]}" surefire:test)
+mvn -f "${dir}" "${mvn_flags[@]}" surefire:test

--- a/.github/smoke.sh
+++ b/.github/smoke.sh
@@ -5,6 +5,7 @@
 set -e -u -o pipefail
 
 repo="apache/commons-cli"
+sha="17de58009bf9dada031a7b3891014c6de5a089bf"
 
 root=$(pwd)
 work="${root}/target/smoke"
@@ -20,7 +21,11 @@ echo "hone-maven-plugin installed into local Maven repository"
 name=$(basename "${repo}")
 dir="${work}/${name}"
 rm -rf "${dir}"
-git clone --depth 1 "https://github.com/${repo}.git" "${dir}"
+git init -q "${dir}"
+git -C "${dir}" remote add origin "https://github.com/${repo}.git"
+git -C "${dir}" fetch --depth 1 origin "${sha}"
+git -C "${dir}" checkout -q FETCH_HEAD
+echo "checked out ${repo} at ${sha}"
 
 printf '\n=== first run: tests of %s without hone ===\n' "${repo}"
 (cd "${dir}" && mvn -B --batch-mode -Dlicense.skip -Drat.skip -Dspotbugs.skip -Dcheckstyle.skip -Dpmd.skip -Denforcer.skip clean test) \

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+name: smoke
+'on':
+  push:
+    branches:
+      - master
+    paths-ignore: [ 'README.md', '.github' ]
+  pull_request:
+    branches:
+      - master
+    paths-ignore: [ 'README.md', '.github' ]
+concurrency:
+  group: smoke-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  smoke:
+    timeout-minutes: 30
+    runs-on: ubuntu-24.04
+    env:
+      LC_ALL: en_US.UTF-8
+      LANG: en_US.UTF-8
+      LANGUAGE: en_US.UTF-8
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: 21
+      - uses: actions/cache@v5
+        with:
+          path: ~/.m2/repository
+          key: ubuntu-jdk-21-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ubuntu-jdk-21-maven-
+      - run: |
+          sudo wget -q -O /usr/bin/phino http://phino.objectionary.com/releases/ubuntu-24.04/phino-latest
+          sudo chmod a+x /usr/bin/phino
+      - run: .github/smoke.sh


### PR DESCRIPTION
Adds a new `smoke.yml` CI workflow and a `.github/smoke.sh` script that clone one external Java project (apache/commons-cli), run its tests, install the current hone-maven-plugin into the local Maven repository, optimize the compiled classes with the `streams/*` rules, and run the tests again.

The job fails when the first test run fails, so a broken upstream is reported on its own and not mistaken for a hone regression. The second run is what guards against hone breaking otherwise-passing code. The workflow mirrors `coverage.yml` but drops the multi-repo loop, the CSV, and the README rewrite — a smoke test should be small and fast.

Closes #576