### PR TITLE
Add Forks column to coverage table

### DIFF
--- a/.github/coverage.sh
+++ b/.github/coverage.sh
@@ -28,7 +28,7 @@ cat "${csv}"
 
 table=$(
   printf '| Repository | Forks | Classes | Before | Edits | After |\n'
-  printf '|---|---:|---:|---:|---:|---:|\n'
+  printf '| --- | ---: | ---: | ---: | ---: | ---: |\n'
   while IFS=';' read -r repo sha bbuild btime total modified abuild atime; do
     forks=$(gh api "repos/${repo}" --jq '.forks_count' 2>/dev/null || echo '?')
     bmark=""

--- a/.github/coverage.sh
+++ b/.github/coverage.sh
@@ -27,15 +27,17 @@ echo "Final CSV:"
 cat "${csv}"
 
 table=$(
-  printf '| Repository | Classes | Before | Edits | After |\n'
-  printf '|---|---:|---:|---:|---:|\n'
-  tail -n +2 "${csv}" | awk -F';' '
-    function mark(v) {
-      return v == "pass" ? "" : " ⚠️"
-    }
-    {
-      printf "| [%s](https://github.com/%s/commit/%s) | %s | %ss%s | %s | %ss%s |\n", $1, $1, $2, $5, $4, mark($3), $6, $8, mark($7)
-    }'
+  printf '| Repository | Forks | Classes | Before | Edits | After |\n'
+  printf '|---|---:|---:|---:|---:|---:|\n'
+  while IFS=';' read -r repo sha bbuild btime total modified abuild atime; do
+    forks=$(gh api "repos/${repo}" --jq '.forks_count' 2>/dev/null || echo '?')
+    bmark=""
+    amark=""
+    [ "${bbuild}" = "pass" ] || bmark=" ⚠️"
+    [ "${abuild}" = "pass" ] || amark=" ⚠️"
+    printf '| [%s](https://github.com/%s/commit/%s) | %s | %s | %ss%s | %s | %ss%s |\n' \
+      "${repo}" "${repo}" "${sha}" "${forks}" "${total}" "${btime}" "${bmark}" "${modified}" "${atime}" "${amark}"
+  done < <(tail -n +2 "${csv}")
 )
 
 cpus=$(nproc --all 2>/dev/null || echo "?")

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,6 +34,8 @@ jobs:
           sudo wget -q -O /usr/bin/phino http://phino.objectionary.com/releases/ubuntu-24.04/phino-latest
           sudo chmod a+x /usr/bin/phino
       - run: .github/coverage.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: peter-evans/create-pull-request@v8
         with:
           sign-commits: true

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ files is computed by comparing MD5 checksums before and after.
 
 <!-- coverage_begin -->
 | Repository | Classes | Before | Edits | After |
-|---|---:|---:|---:|---:|
+| --- | ---: | ---: | ---: | ---: |
 | [apache/commons-cli](https://github.com/apache/commons-cli/commit/17de58009bf9dada031a7b3891014c6de5a089bf) | 56 | 28s | 54 | 6s |
 | [jhy/jsoup](https://github.com/jhy/jsoup/commit/a7ec14364e2f9f84ecb795814b4fd05d028f709d) | 317 | 24s | 317 | 15s |
 | [FasterXML/jackson-core](https://github.com/FasterXML/jackson-core/commit/3c0bcb749b106d6b80cd1d1d133cf1c97b66e752) | 176 | 40s | 165 | 3s ⚠️ |


### PR DESCRIPTION
The coverage table in the README now shows a Forks column with the
current GitHub fork count for each repository, fetched per row from
the GitHub API via `gh api`.

It is handy to see how widely-used each tested repository is right
next to its coverage numbers, so a quick glance tells you whether
the benchmark is exercising a popular library or a niche one. The
coverage workflow exports `GH_TOKEN` so the API call is
authenticated and not rate-limited on every run.

If the API call fails for a row, the cell falls back to `?` so the
table still renders.