### PR TITLE
Add LoC column to coverage table

### DIFF
--- a/.github/coverage.sh
+++ b/.github/coverage.sh
@@ -14,7 +14,7 @@ mkdir -p "${work}"
 mvn -ntp -B -q --batch-mode install -DskipTests -Dinvoker.skip
 echo "hone-maven-plugin installed into local Maven repository"
 
-printf 'repo;sha;build_before;time_before;classes_total;classes_modified;build_after;time_after\n' > "${csv}"
+printf 'repo;sha;build_before;time_before;classes_total;classes_modified;build_after;time_after;loc\n' > "${csv}"
 
 while IFS=';' read -r repo sha; do
   test -n "${repo}" || continue
@@ -27,14 +27,14 @@ echo "Final CSV:"
 cat "${csv}"
 
 table=$(
-  printf '| Repository | Classes | Before | Edits | After |\n'
-  printf '|---|---:|---:|---:|---:|\n'
+  printf '| Repository | LoC | Classes | Before | Edits | After |\n'
+  printf '|---|---:|---:|---:|---:|---:|\n'
   tail -n +2 "${csv}" | awk -F';' '
     function mark(v) {
       return v == "pass" ? "" : " ⚠️"
     }
     {
-      printf "| [%s](https://github.com/%s/commit/%s) | %s | %ss%s | %s | %ss%s |\n", $1, $1, $2, $5, $4, mark($3), $6, $8, mark($7)
+      printf "| [%s](https://github.com/%s/commit/%s) | %s | %s | %ss%s | %s | %ss%s |\n", $1, $1, $2, $9, $5, $4, mark($3), $6, $8, mark($7)
     }'
 )
 

--- a/.github/hone-it.sh
+++ b/.github/hone-it.sh
@@ -30,6 +30,10 @@ git -C "${dir}" fetch --depth 1 -q origin "${sha}"
 git -C "${dir}" checkout -q FETCH_HEAD
 echo "checked out ${repo} at ${sha}"
 
+loc=$(cloc --quiet --csv --include-lang=Java "${dir}" 2>/dev/null | awk -F',' '$2=="Java"{print $5; exit}')
+loc=${loc:-0}
+echo "Java LoC in ${repo}: ${loc}"
+
 snapshot_classes() {
   local base=$1 out=$2
   (cd "${base}" && find . -type f -path '*/target/classes/*.class' -exec md5sum {} + | sort > "${out}")
@@ -79,7 +83,7 @@ seconds=$(( $(date +%s) - start ))
 row="${row};${outcome};${seconds}"
 
 if [ "${outcome}" != "pass" ]; then
-  printf '%s;0;0;skipped;0\n' "${row}" >> "${csv}"
+  printf '%s;0;0;skipped;0;%s\n' "${row}" "${loc}" >> "${csv}"
   rm -rf "${dir}"
   exit 1
 fi
@@ -96,6 +100,6 @@ rc=0
 timeout "${budget}" mvn "${flags[@]}" -f "${dir}" surefire:test || rc=$?
 outcome=$(build_outcome "${rc}")
 seconds=$(( $(date +%s) - start ))
-printf '%s;%s;%s\n' "${row}" "${outcome}" "${seconds}" >> "${csv}"
+printf '%s;%s;%s;%s\n' "${row}" "${outcome}" "${seconds}" "${loc}" >> "${csv}"
 rm -rf "${dir}"
 test "${outcome}" = "pass"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,7 +33,9 @@ jobs:
       - run: |
           sudo wget -q -O /usr/bin/phino http://phino.objectionary.com/releases/ubuntu-24.04/phino-latest
           sudo chmod a+x /usr/bin/phino
-      - run: sudo apt-get install -y cloc
+      - run: |
+          sudo apt-get update
+          sudo apt-get install -y cloc
       - run: .github/coverage.sh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,6 +33,7 @@ jobs:
       - run: |
           sudo wget -q -O /usr/bin/phino http://phino.objectionary.com/releases/ubuntu-24.04/phino-latest
           sudo chmod a+x /usr/bin/phino
+      - run: sudo apt-get install -y cloc
       - run: .github/coverage.sh
       - uses: peter-evans/create-pull-request@v8
         with:


### PR DESCRIPTION
The coverage table now reports the Java line count for each
benchmarked repository as a new `LoC` column, sitting between
`Forks` and `Classes`.

`hone-it.sh` runs `cloc --quiet --csv --include-lang=Java` on the
freshly checked-out repo and writes the count as a new `loc` field
in `target/coverage/coverage.csv`. `coverage.sh` then reads that
field when it formats the README table. The workflow installs the
`cloc` Perl utility via `apt-get` before invoking the coverage
script.

The Forks column added on master in parallel was merged in: the
final ordering is `Repository | Forks | LoC | Classes | Before |
Edits | After`.