### PR TITLE
Warm up Maven cache before measuring the "before" time

### DIFF
--- a/.github/hone-it.sh
+++ b/.github/hone-it.sh
@@ -71,6 +71,8 @@ budget=300
 flags=(-ntp -B -q --batch-mode -Dlicense.skip -Drat.skip -Dspotbugs.skip -Dcheckstyle.skip -Dpmd.skip -Denforcer.skip)
 
 row="${repo};${sha}"
+echo "warming up Maven dependency cache for ${repo}"
+timeout "${budget}" mvn "${flags[@]}" -f "${dir}" test || true
 start=$(date +%s)
 rc=0
 timeout "${budget}" mvn "${flags[@]}" -f "${dir}" clean test || rc=$?


### PR DESCRIPTION
The `hone-it.sh` script that produces the coverage table now runs an
unmeasured `mvn test` against each downstream repository before it
starts the stopwatch. The exit code of that warm-up run is ignored.

Until now the "before" column timed `mvn clean test` on a fresh
checkout, so the very first run had to download the project's whole
dependency tree from Maven Central. That made the "before" number
systematically larger than the "after" number, which then ran on a
warm local repository. After this change both columns measure
compile-plus-test cost on a populated cache and are comparable.

No change to the surrounding pipeline or the CSV schema; the next
coverage run on `master` should already show the narrower gap.