### PR TITLE
fix(coverage): run initialize phase so jackson-core's @{argLine} resolves

### DIFF
--- a/.github/hone-it.sh
+++ b/.github/hone-it.sh
@@ -99,7 +99,7 @@ count=$(count_modified "${snap}.before" "${snap}.after")
 row="${row};${total};${count}"
 start=$(date +%s)
 rc=0
-timeout "${budget}" mvn "${flags[@]}" -f "${dir}" surefire:test || rc=$?
+timeout "${budget}" mvn "${flags[@]}" -f "${dir}" initialize surefire:test || rc=$?
 outcome=$(build_outcome "${rc}")
 seconds=$(( $(date +%s) - start ))
 printf '%s;%s;%s;%s\n' "${row}" "${outcome}" "${seconds}" "${loc}" >> "${csv}"


### PR DESCRIPTION
## Summary

The `coverage` workflow flagged `FasterXML/jackson-core` as failing after HONE
optimization (`2s ⚠️` in the After column). The HONE-rewritten bytecode is
actually fine — the failure is in how `hone-it.sh` invokes Maven for the
post-optimization test run.

### Root cause

Jackson-core's `pom.xml` configures `maven-surefire-plugin` with

```xml
<argLine>@{argLine}
  --add-exports tools.jackson.core/tools.jackson.core.io.schubfach=…
  --add-opens   tools.jackson.core/tools.jackson.core.json=…
</argLine>
```

The `@{argLine}` is a *late-property reference* — Surefire substitutes it
from the `argLine` Maven property, which is populated by
`jacoco:prepare-agent` bound to the `initialize` phase.

`.github/hone-it.sh` runs `mvn surefire:test` directly (to avoid recompiling
the HONE'd classes). That skips the `initialize` phase, so `argLine` is
never set, and the JVM is launched with the literal token `@{argLine}` on
its command line:

```
Error: could not open `@{argLine}'
The forked VM terminated without properly saying goodbye.
```

Every test fork crashes on startup before any test class is loaded — hence
the ~2-second failure with zero tests executed.

### Fix

Invoke `mvn initialize surefire:test`. `initialize` runs `validate` +
`initialize` only (no `compile`, so the HONE'd `.class` files are preserved)
and triggers `jacoco:prepare-agent`, which sets `argLine` before Surefire
reads it. Projects without JaCoCo (the other 12 in `coverage.csv`) ignore
the phase and behave exactly as before.

### Verification

End-to-end run on the pinned `jackson-core` SHA:

```
FasterXML/jackson-core;3c0bcb749b…;pass;53;176;165;pass;46;86966
                                                  ^^^^ was: fail;2
```

A control run on `apache/commons-cli` (no JaCoCo) still passes unchanged.

## Test plan

- [x] `bash .github/hone-it.sh FasterXML/jackson-core 3c0bcb749b106d6b80cd1d1d133cf1c97b66e752 …` → `pass`
- [x] `bash .github/hone-it.sh apache/commons-cli  17de58009bf9dada031a7b3891014c6de5a089bf …` → `pass`
- [ ] Full `coverage.yml` re-run on master after merge regenerates the table without the ⚠️ on jackson-core


---
_Generated by [Claude Code](https://claude.ai/code/session_019zuHmnwD8aEcv3tFHKM2PF)_