### PR TITLE
fix(ci): unblock codecov by forcing Docker in BuildMojoTest and widening cold-build timeouts

### DIFF
--- a/src/test/java/org/eolang/hone/BuildMojoTest.java
+++ b/src/test/java/org/eolang/hone/BuildMojoTest.java
@@ -67,6 +67,7 @@ final class BuildMojoTest {
                     .phase("generate-resources")
                     .goals("build")
                     .configuration()
+                    .set("alwaysWithDocker", "true")
                     .set("image", image);
                 f.exec("generate-resources");
                 MatcherAssert.assertThat(
@@ -93,6 +94,7 @@ final class BuildMojoTest {
                     .phase("generate-resources")
                     .goals("build")
                     .configuration()
+                    .set("alwaysWithDocker", "true")
                     .set("image", image);
                 f.exec("generate-resources");
                 MatcherAssert.assertThat(

--- a/src/test/java/org/eolang/hone/OptimizeMojoTest.java
+++ b/src/test/java/org/eolang/hone/OptimizeMojoTest.java
@@ -290,7 +290,7 @@ final class OptimizeMojoTest {
     @Test
     @Tag("deep")
     @ExtendWith(MayBeSlow.class)
-    @Timeout(180L)
+    @Timeout(600L)
     @DisabledWithoutDocker
     void generatesStatisticsWithDocker(
         @Mktmp final Path home,
@@ -405,7 +405,7 @@ final class OptimizeMojoTest {
     @Test
     @Tag("deep")
     @ExtendWith(MayBeSlow.class)
-    @Timeout(180L)
+    @Timeout(600L)
     @DisabledWithoutDocker
     void optimizesSimpleApp(@Mktmp final Path home,
         @RandomImage final String image) throws Exception {


### PR DESCRIPTION
## Summary

The `codecov` workflow has failed on every push to `master` since `4a22a14`
("Bump default phino version to 0.0.0.68") with the same three test failures:

```
BuildMojoTest.buildsImageAndVerifiesFileStructure
  → docker: Error response from daemon: pull access denied for hone-test
OptimizeMojoTest.optimizesSimpleApp
  → java.util.concurrent.TimeoutException: timed out after 180 seconds
OptimizeMojoTest.generatesStatisticsWithDocker
  → java.util.concurrent.TimeoutException: timed out after 180 seconds
```

### Root cause

`codecov.yml` installs `phino-latest` on the runner. Before the bump, the
host phino (`0.0.0.68`) didn't match the expected version (`0.0.0.67`), so
`Phino.available()` returned `false` and `BuildMojo` always went through
Docker. After the bump, the versions match, and `BuildMojo` short-circuits
unless `alwaysWithDocker=true` is set explicitly.

This breaks codecov in two distinct ways:

1. **`BuildMojoTest.buildsImageAndVerifiesFileStructure`** asserts on a
   `docker run` against the just-built image, but it didn't ask for
   `alwaysWithDocker=true`. After the bump the image is never produced;
   the `docker run` falls through to a Docker Hub pull, and the daemon
   answers `pull access denied for hone-test`. Same logic for
   `buildsDockerImage`'s intent, fixed for consistency.

2. **`OptimizeMojoTest.{optimizesSimpleApp,generatesStatisticsWithDocker}`**
   both set `alwaysWithDocker=true` so they still build the image. With
   the parent POM's `<runOrder>random</runOrder>`, surefire sometimes
   schedules `OptimizeMojoTest` before `BuildMojoTest`. Previously this
   was harmless — `BuildMojoTest`'s ~10-minute deep run warmed the
   buildx layer cache before `OptimizeMojoTest` started. Now
   `BuildMojoTest` exits in 6 seconds, and whichever
   `alwaysWithDocker=true` test runs first must pay the cold buildx cost
   (~3–6 min) inside a 180s `@Timeout`. `optimizesJustOneLargeJnaClass`
   has no `@Timeout` and finishes in ~6.5 min on the same runner — the
   600s budget here matches that empirical envelope.

### Verification

- [ ] `mvn clean install -Pjacoco -Pdeep` on master re-runs the codecov job green
- [ ] `BuildMojoTest.buildsImageAndVerifiesFileStructure` actually builds the image (and asserts on its file structure)
- [ ] No regression in `mvn.yml` (the non-deep workflow skips these `@Tag("deep")` tests entirely)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WYfE6NMsYHEXfnPSUN8JKY)_