### PR TITLE
ci(coverage): render every repo from coverage.csv in the README table

### DIFF
--- a/.github/coverage.sh
+++ b/.github/coverage.sh
@@ -29,15 +29,23 @@ cat "${csv}"
 table=$(
   printf '| Repository | Forks | LoC | Classes | Before | Edits | After |\n'
   printf '| --- | ---: | ---: | ---: | ---: | ---: | ---: |\n'
-  while IFS=',' read -r repo sha bbuild btime total modified abuild atime loc; do
+  while IFS=',' read -r repo sha; do
+    test -n "${repo}" || continue
     forks=$(gh api "repos/${repo}" --jq '.forks_count' 2>/dev/null || echo '?')
-    bmark=""
-    amark=""
-    [ "${bbuild}" = "pass" ] || bmark=" ⚠️"
-    [ "${abuild}" = "pass" ] || amark=" ⚠️"
-    printf '| [%s](https://github.com/%s/commit/%s) | %s | %s | %s | %ss%s | %s | %ss%s |\n' \
-      "${repo}" "${repo}" "${sha}" "${forks}" "${loc}" "${total}" "${btime}" "${bmark}" "${modified}" "${atime}" "${amark}"
-  done < <(tail -n +2 "${csv}")
+    row=$(grep -F "${repo},${sha}," "${csv}" || true)
+    if [ -n "${row}" ]; then
+      IFS=',' read -r _ _ bbuild btime total modified abuild atime loc <<< "${row}"
+      bmark=""
+      amark=""
+      [ "${bbuild}" = "pass" ] || bmark=" ⚠️"
+      [ "${abuild}" = "pass" ] || amark=" ⚠️"
+      printf '| [%s](https://github.com/%s/commit/%s) | %s | %s | %s | %ss%s | %s | %ss%s |\n' \
+        "${repo}" "${repo}" "${sha}" "${forks}" "${loc}" "${total}" "${btime}" "${bmark}" "${modified}" "${atime}" "${amark}"
+    else
+      printf '| [%s](https://github.com/%s/commit/%s) | %s | ? | ? | ? ⚠️ | ? | ? ⚠️ |\n' \
+        "${repo}" "${repo}" "${sha}" "${forks}"
+    fi
+  done < <(tail -n +2 "${repos}")
 )
 
 cpus=$(nproc --all 2>/dev/null || echo "?")

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   coverage:
-    timeout-minutes: 30
+    timeout-minutes: 90
     runs-on: ubuntu-24.04
     env:
       LC_ALL: en_US.UTF-8


### PR DESCRIPTION
## Summary

PR #597 only had 9 of the 15 repos listed in `.github/coverage.csv` —
`ronmamo/reflections`, `junit-team/junit4`, `redis/jedis`,
`raphw/byte-buddy`, `mockito/mockito`, and `ReactiveX/RxJava` were
missing from the markdown table.

Two reasons:

- The job's `timeout-minutes: 30` was tight enough that processing
  stopped before the last 6 repos finished (mockito + RxJava had only
  just been added in #593, growing the list from 13 to 15).
- The table loop in `.github/coverage.sh` iterated over the *results*
  CSV in `target/coverage/`, so any repo whose row hadn't been written
  was silently dropped from the rendered table.

## Changes

- `.github/coverage.sh`: drive the table from the input `coverage.csv`
  instead of the per-run results file. Look up each repo's row in the
  results; render a placeholder row with `?` and ⚠️ markers when no
  result exists, so an unfinished or failed run is visible in the
  README rather than silently omitted.
- `.github/workflows/coverage.yml`: bump `timeout-minutes` from 30 to
  90 so the workflow has enough headroom to actually process all 15
  repos.

## Test plan

- [ ] Coverage workflow runs on master after merge and produces a
      README table with every repo from `.github/coverage.csv`, with
      real data for repos that finish and `?` ⚠️ rows for any that
      don't.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JyW9bzDpf4f7TPkXCGZzz9)_