### PR TITLE
ci(coverage): stop mvn from eating the repo-loop input via stdin

### DIFF
--- a/.github/coverage.sh
+++ b/.github/coverage.sh
@@ -16,11 +16,11 @@ echo "hone-maven-plugin installed into local Maven repository"
 
 printf 'repo,sha,build_before,time_before,classes_total,classes_modified,build_after,time_after,loc\n' > "${csv}"
 
-while IFS=',' read -r repo sha; do
+while IFS=',' read -r -u 3 repo sha; do
   test -n "${repo}" || continue
   printf '\n=== %s @ %s ===\n' "${repo}" "${sha}"
-  "${root}/.github/hone-it.sh" "${repo}" "${sha}" "${csv}" || true
-done < <(tail -n +2 "${repos}")
+  "${root}/.github/hone-it.sh" "${repo}" "${sha}" "${csv}" </dev/null || true
+done 3< <(tail -n +2 "${repos}")
 
 echo ""
 echo "Final CSV:"


### PR DESCRIPTION
Run 26145676127 of the `coverage` workflow processed only 9 of the 15 repos listed in `.github/coverage.csv` and then exited cleanly, well under the 30-minute job timeout, with no error in the log. The loop in `.github/coverage.sh` reads the repo list from a process substitution into the shell's stdin, and during each iteration that stdin is inherited by `hone-it.sh` and the many `mvn` invocations it triggers. Maven (or one of its plugins) silently consumed lines from that input, so by the time control returned to the loop the remaining six repos had been read away and `read` saw EOF.

The fix moves the loop's read to file descriptor 3 and feeds `hone-it.sh` from `/dev/null`. No child process can then reach the loop's input, regardless of what mvn or any of its plugins decide to do with stdin. The second loop in the same file only calls `gh api` and rendered all 15 rows correctly in the buggy run, so it is left untouched.

A small bash reproducer with `cat > /dev/null` inside the loop body confirms both the failure and the fix.