### PR TITLE
ci(coverage): bump per-repo mvn timeout from 300s to 1200s

### DIFF
--- a/.github/hone-it.sh
+++ b/.github/hone-it.sh
@@ -70,7 +70,7 @@ build_outcome() {
   fi
 }
 
-budget=300
+budget=1200
 
 flags=(-ntp -B -q --batch-mode -Dlicense.skip -Drat.skip -Dspotbugs.skip -Dcheckstyle.skip -Dpmd.skip -Denforcer.skip)
 


### PR DESCRIPTION
The `budget` constant in `.github/hone-it.sh` capped every `timeout mvn ...` call at 300 seconds. That window is fine for the small repos at the top of the coverage list, but it gets uncomfortable as soon as the test suites grow — a single slow before/after phase loses the row for that repo.

Bumping the budget to 1200 seconds gives each mvn invocation up to 20 minutes, which fits inside the workflow's existing 90-minute job timeout and gives the bigger projects in `coverage.csv` (jackson, vavr, RxJava, byte-buddy) room to finish without changing anything else in the pipeline.

Repos that finish quickly are unaffected — the timeout is just an upper bound.