### PR TITLE
ci(coverage): measure and report hone-maven-plugin runtime

### DIFF
--- a/.github/coverage.sh
+++ b/.github/coverage.sh
@@ -14,7 +14,7 @@ mkdir -p "${work}"
 mvn -ntp -B -q --batch-mode install -DskipTests -Dinvoker.skip
 echo "hone-maven-plugin installed into local Maven repository"
 
-printf 'repo,sha,build_before,time_before,classes_total,classes_modified,build_after,time_after,loc\n' > "${csv}"
+printf 'repo,sha,build_before,time_before,classes_total,classes_modified,time_hone,build_after,time_after,loc\n' > "${csv}"
 
 while IFS=',' read -r -u 3 repo sha; do
   test -n "${repo}" || continue
@@ -27,22 +27,22 @@ echo "Final CSV:"
 cat "${csv}"
 
 table=$(
-  printf '| Repository | Forks | LoC | Classes | Before | Edits | After |\n'
-  printf '| --- | ---: | ---: | ---: | ---: | ---: | ---: |\n'
+  printf '| Repository | Forks | LoC | Classes | Before | Edits | Hone | After |\n'
+  printf '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n'
   while IFS=',' read -r repo sha; do
     test -n "${repo}" || continue
     forks=$(gh api "repos/${repo}" --jq '.forks_count' 2>/dev/null || echo '?')
     row=$(grep -F "${repo},${sha}," "${csv}" || true)
     if [ -n "${row}" ]; then
-      IFS=',' read -r _ _ bbuild btime total modified abuild atime loc <<< "${row}"
+      IFS=',' read -r _ _ bbuild btime total modified htime abuild atime loc <<< "${row}"
       bmark=""
       amark=""
       [ "${bbuild}" = "pass" ] || bmark=" ⚠️"
       [ "${abuild}" = "pass" ] || amark=" ⚠️"
-      printf '| [%s](https://github.com/%s/commit/%s) | %s | %s | %s | %ss%s | %s | %ss%s |\n' \
-        "${repo}" "${repo}" "${sha}" "${forks}" "${loc}" "${total}" "${btime}" "${bmark}" "${modified}" "${atime}" "${amark}"
+      printf '| [%s](https://github.com/%s/commit/%s) | %s | %s | %s | %ss%s | %s | %ss | %ss%s |\n' \
+        "${repo}" "${repo}" "${sha}" "${forks}" "${loc}" "${total}" "${btime}" "${bmark}" "${modified}" "${htime}" "${atime}" "${amark}"
     else
-      printf '| [%s](https://github.com/%s/commit/%s) | %s | ? | ? | ? ⚠️ | ? | ? ⚠️ |\n' \
+      printf '| [%s](https://github.com/%s/commit/%s) | %s | ? | ? | ? ⚠️ | ? | ? | ? ⚠️ |\n' \
         "${repo}" "${repo}" "${sha}" "${forks}"
     fi
   done < <(tail -n +2 "${repos}")

--- a/.github/hone-it.sh
+++ b/.github/hone-it.sh
@@ -85,7 +85,7 @@ seconds=$(( $(date +%s) - start ))
 row="${row},${outcome},${seconds}"
 
 if [ "${outcome}" != "pass" ]; then
-  printf '%s,0,0,skipped,0,%s\n' "${row}" "${loc}" >> "${csv}"
+  printf '%s,0,0,0,skipped,0,%s\n' "${row}" "${loc}" >> "${csv}"
   rm -rf "${dir}"
   exit 1
 fi
@@ -93,10 +93,12 @@ fi
 snap="${dir}/.snap"
 snapshot_classes "${dir}" "${snap}.before"
 total=$(wc -l < "${snap}.before" | tr -d ' ')
+hstart=$(date +%s)
 apply_hone "${dir}"
+hone_seconds=$(( $(date +%s) - hstart ))
 snapshot_classes "${dir}" "${snap}.after"
 count=$(count_modified "${snap}.before" "${snap}.after")
-row="${row},${total},${count}"
+row="${row},${total},${count},${hone_seconds}"
 start=$(date +%s)
 rc=0
 timeout "${budget}" mvn "${flags[@]}" -f "${dir}" initialize surefire:test || rc=$?


### PR DESCRIPTION
## Summary

- Times the `apply_hone` invocation in `.github/hone-it.sh` and adds a new `time_hone` column to `coverage.csv`.
- Adds a `Hone` column to the README coverage table generated by `.github/coverage.sh`, showing how long `hone-maven-plugin` itself took to run on each repository.

## Test plan

- [ ] Run the coverage workflow and verify the CSV has the new `time_hone` column populated.
- [ ] Verify the rendered README table shows the new `Hone` column with `Ns` values between `Edits` and `After`.
- [ ] Verify rows for repos that failed the baseline build still emit a `0` for `time_hone` and the markdown row renders correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Akv9e8JMV5Ut4GDYeAVUCT)_