### PR TITLE
#622: Map object Stream.skip(long) to distill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,9 +132,9 @@ body                 the opcode formation spliced between item-load and emit
 The body is one-in-one-out (auto-style): phino feeds it a single item
 and it produces a single item, so `401-fuse` can concatenate any two
 adjacent bodies blindly. Pointwise operators (map, filter, …) carry an
-empty `state`; the only stateful operator today is `distinct`, whose
-`state` builds a `java/util/HashSet` and whose body consults it — see
-"Stateful operators (distinct)" below. There is still no
+empty `state`; stateful object-stream operators use an `Object[]`
+state slot and `Φ.hone.fetch` markers inside the body — see
+"Stateful operators" below. There is still no
 continuation-passing variant.
 
 The full operator-to-rule mapping (every rule named below exists under
@@ -147,6 +147,7 @@ box/unbox cleanup + collapse     → 211, 221, 231, 232 → fold back to map/fil
 type / transform adjustments     → 241..243, 251..261, 271, 272
 dup insertion (for filter)       → 281, 282
 dup, transform, type, filter, map → 301..306 → Φ.hone.distill (auto body)
+skip(0), skip(1), skip(N)         → 210, 212, 220 → 308..310
 load `this` into a pre-distill   → 311 → flips Φ.hone.pre-distill to distill
 box-distill-unbox collapse       → 411 → primitive-typed distill
 transform-distill normalisation  → 421, 422
@@ -171,7 +172,7 @@ method that the `mapMulti` call references. The 6xx rules (601, 602,
 `Φ.hone.lambda` + `invokeinterface`, and the 7xx rules (701, 702)
 lower the lambdas to `invokedynamic`.
 
-### Stateful operators (distinct)
+### Stateful operators
 
 `distinct` is the one operator that needs per-element state — a
 `java/util/HashSet` of the elements already seen. It is treated as "a
@@ -209,13 +210,24 @@ three extra pieces:
   the opcode and prevents a 216 → 307 → 441 loop (jeo ignores the extra
   binding when assembling).
 
+`skip(long)` uses the same stateful distill path for object streams.
+Rules `210`, `212`, and `220` recognise the three javac count shapes
+(`lconst_0`, `lconst_1`, and `ldc Φ.jeo.long`). Rule `308` removes
+`skip(0L)` as a no-op, while `309` and `310` create a state block that
+stores one `long[1]` counter in the captured `Object[]`. The `309`
+state block first preserves the eager negative-count exception for
+non-0/1 constants. The distill body compares the counter with the
+threshold, increments it while dropping the first N items, and falls
+through for later items.
+
 Limitations (v1): one state variable per fused wrapper — `401-fuse` is
 gated so two stateful distills never merge (the array fill and fetch
-resolution are single-slot); object streams only (`512` hardcodes the
-`Object` item shape); and `503` reads the frame type off `bridge-input`,
-correct while every operator before the distinct preserves the element
-type. Lifting these is future work (a `size`-driven fixpoint fill plus a
-runtime fetch counter generalise to any number of state vars).
+resolution are single-slot); stateful operators are object streams only
+(`512` hardcodes the `Object` item shape); and `503` reads the frame type
+off `bridge-input`, correct while every operator before the stateful
+operator preserves the element type. Lifting these is future work (a
+`size`-driven fixpoint fill plus a runtime fetch counter generalise to
+any number of state vars).
 
 ## phino: the only rewrite engine
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Rules `301-dup-to-distill`, `302-transform-to-distill`,
   `303-type-to-distill`, `304-primitive-filter-to-distill`,
   `305-object-filter-to-distill`, and `306-map-to-distill`
   handle the individual cases,
+  `308-` through `310-` handle object `Stream.skip(long)`,
   and `311-load-this-in-pre-distill` prepares the stack
   for instance-method lambdas.
 After this stage,

--- a/src/main/resources/org/eolang/hone/rules/streams/2xx/210-recognize-skip.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/2xx/210-recognize-skip.phr
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Recognizes a stream `.skip(0L)` call — the `lconst_0` that pushes the
+# count followed by the `invokeinterface java/util/stream/Stream.skip:(J)
+# Ljava/util/stream/Stream;` — and abstracts the pair into a single
+# Φ.hone.skip block. The downstream 308 rule folds count="0" away.
+name: recognize-skip
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-push ↦ ⟦
+      φ ↦ Φ.jeo.opcode.lconst_0,
+      ρ ↦ ∅
+    ⟧,
+    𝜏-invokeinterface ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      𝜏1 ↦ "java/util/stream/Stream",
+      𝜏2 ↦ "skip",
+      𝜏3 ↦ "(J)Ljava/util/stream/Stream;",
+      𝜏4 ↦ Φ.true,
+      ρ ↦ ∅
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-skip ↦ ⟦
+      φ ↦ Φ.hone.skip,
+      stream-class ↦ "java/util/stream/Stream",
+      count ↦ "0"
+    ⟧,
+    𝐵-after
+  ⟧
+where:
+  - meta: 𝜏-skip
+    function: random-tau
+    args: [ '𝐵-before', '𝐵-after' ]

--- a/src/main/resources/org/eolang/hone/rules/streams/2xx/212-recognize-skip-one.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/2xx/212-recognize-skip-one.phr
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Recognizes a stream `.skip(1L)` call — the `lconst_1` that pushes the
+# count followed by `Stream.skip(long)` — and abstracts the pair into
+# Φ.hone.skip. Rule 310 folds it into a stateful distill.
+name: recognize-skip-one
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-push ↦ ⟦
+      φ ↦ Φ.jeo.opcode.lconst_1,
+      ρ ↦ ∅
+    ⟧,
+    𝜏-invokeinterface ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      𝜏1 ↦ "java/util/stream/Stream",
+      𝜏2 ↦ "skip",
+      𝜏3 ↦ "(J)Ljava/util/stream/Stream;",
+      𝜏4 ↦ Φ.true,
+      ρ ↦ ∅
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-skip ↦ ⟦
+      φ ↦ Φ.hone.skip,
+      stream-class ↦ "java/util/stream/Stream",
+      count ↦ "1"
+    ⟧,
+    𝐵-after
+  ⟧
+where:
+  - meta: 𝜏-skip
+    function: random-tau
+    args: [ '𝐵-before', '𝐵-after' ]

--- a/src/main/resources/org/eolang/hone/rules/streams/2xx/220-recognize-skip-ldc.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/2xx/220-recognize-skip-ldc.phr
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Recognizes a stream `.skip(N)` call where N is loaded via an `ldc`
+# carrying a `Φ.jeo.long` literal, which javac uses for long constants
+# other than 0L and 1L. The downstream 309 rule folds it into a stateful
+# distill.
+name: recognize-skip-ldc
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-push ↦ ⟦
+      φ ↦ Φ.jeo.opcode.ldc,
+      𝜏1 ↦ ⟦
+        φ ↦ Φ.jeo.long,
+        𝜏2 ↦ 𝑒-count,
+        ρ ↦ ∅
+      ⟧,
+      ρ ↦ ∅
+    ⟧,
+    𝜏-invokeinterface ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      𝜏3 ↦ "java/util/stream/Stream",
+      𝜏4 ↦ "skip",
+      𝜏5 ↦ "(J)Ljava/util/stream/Stream;",
+      𝜏6 ↦ Φ.true,
+      ρ ↦ ∅
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-skip ↦ ⟦
+      φ ↦ Φ.hone.skip,
+      stream-class ↦ "java/util/stream/Stream",
+      count ↦ 𝑒-count
+    ⟧,
+    𝐵-after
+  ⟧
+where:
+  - meta: 𝜏-skip
+    function: random-tau
+    args: [ '𝐵-before', '𝐵-after' ]

--- a/src/main/resources/org/eolang/hone/rules/streams/3xx/308-skip-zero-to-noop.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/3xx/308-skip-zero-to-noop.phr
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Eliminates Φ.hone.skip when its count is "0". `Stream.skip(0L)` is a
+# no-op slice, so the recognized pair can become a single nop.
+name: skip-zero-to-noop
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-skip ↦ ⟦
+      φ ↦ Φ.hone.skip,
+      stream-class ↦ 𝑒-stream-class,
+      count ↦ "0",
+      ρ ↦ ∅
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-nop ↦ ⟦
+      φ ↦ Φ.jeo.opcode.nop
+    ⟧,
+    𝐵-after
+  ⟧
+where:
+  - meta: 𝜏-nop
+    function: random-tau
+    args: [ '𝐵-before', '𝐵-after' ]

--- a/src/main/resources/org/eolang/hone/rules/streams/3xx/309-skip-to-distill.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/3xx/309-skip-to-distill.phr
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Folds object Stream.skip(N) into a stateful Φ.hone.distill. The state
+# is an Object[] containing one long[1] counter. The state block first
+# preserves the JDK's eager negative-count check, then builds the
+# captured counter. On each item the body compares counter[0] with N;
+# the first N items increment the counter and return early, and every
+# later item falls through to the wrapper's Consumer.accept.
+name: skip-to-distill
+pattern: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    𝐵-class-head-before,
+    name ↦ 𝑒-class-name,
+    𝐵-class-head-after,
+    𝜏-caller ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      𝐵-caller-head,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-skip ↦ ⟦
+          φ ↦ Φ.hone.skip,
+          stream-class ↦ "java/util/stream/Stream",
+          count ↦ 𝑒-count
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝐵-caller-tail
+    ⟧,
+    𝐵-class-tail,
+    ρ ↦ ∅
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    𝐵-class-head-before,
+    name ↦ 𝑒-class-name,
+    𝐵-class-head-after,
+    𝜏-caller ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      𝐵-caller-head,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-skip ↦ ⟦
+          φ ↦ Φ.hone.distill,
+          class ↦ 𝑒-class-name,
+          bridge-input ↦ "Ljava/lang/Object;",
+          bridge-output ↦ "Ljava/lang/Object;",
+          start ↦ "skip",
+          accepted ↦ "Ljava/lang/Object;",
+          returned ↦ "Ljava/lang/Object;",
+          static ↦ "true",
+          state ↦ ⟦
+            𝜏-check-ldc ↦ ⟦
+              φ ↦ Φ.jeo.opcode.ldc,
+              i1 ↦ ⟦ φ ↦ Φ.jeo.long, i1 ↦ 𝑒-count ⟧
+            ⟧,
+            𝜏-check-zero ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_0 ⟧,
+            𝜏-check-lcmp ↦ ⟦ φ ↦ Φ.jeo.opcode.lcmp ⟧,
+            𝜏-check-ifge ↦ ⟦
+              φ ↦ Φ.jeo.opcode.ifge,
+              i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label-nonnegative ⟧
+            ⟧,
+            𝜏-throw-new ↦ ⟦ φ ↦ Φ.jeo.opcode.new, i1 ↦ "java/lang/IllegalArgumentException" ⟧,
+            𝜏-throw-dup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+            𝜏-throw-init ↦ ⟦
+              φ ↦ Φ.jeo.opcode.invokespecial,
+              i2 ↦ "java/lang/IllegalArgumentException",
+              i3 ↦ "<init>",
+              i4 ↦ "()V",
+              i5 ↦ Φ.false
+            ⟧,
+            𝜏-throw-athrow ↦ ⟦ φ ↦ Φ.jeo.opcode.athrow ⟧,
+            𝜏-check-label ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label-nonnegative ⟧,
+            𝜏-check-frame ↦ ⟦
+              φ ↦ Φ.jeo.frame,
+              type ↦ 3,
+              nlocal ↦ 0,
+              locals ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+              nstack ↦ 0,
+              stack ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
+            ⟧,
+            𝜏-state-len ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_1 ⟧,
+            𝜏-state-new-arr ↦ ⟦ φ ↦ Φ.jeo.opcode.anewarray, i1 ↦ "java/lang/Object" ⟧,
+            𝜏-state-dup-arr ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+            𝜏-state-idx ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+            𝜏-counter-len ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_1 ⟧,
+            𝜏-counter-new ↦ ⟦ φ ↦ Φ.jeo.opcode.newarray, i1 ↦ 11 ⟧,
+            𝜏-state-store ↦ ⟦ φ ↦ Φ.jeo.opcode.aastore ⟧,
+            ρ ↦ ∅
+          ⟧,
+          body ↦ ⟦
+            i1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "[J" ⟧,
+            i2 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+            i3 ↦ ⟦ φ ↦ Φ.jeo.opcode.laload ⟧,
+            i4 ↦ ⟦
+              φ ↦ Φ.jeo.opcode.ldc,
+              i1 ↦ ⟦ φ ↦ Φ.jeo.long, i1 ↦ 𝑒-count ⟧
+            ⟧,
+            i5 ↦ ⟦ φ ↦ Φ.jeo.opcode.lcmp ⟧,
+            i6 ↦ ⟦
+              φ ↦ Φ.jeo.opcode.ifge,
+              i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label-accept ⟧
+            ⟧,
+            i7 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "[J" ⟧,
+            i8 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+            i9 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+            i10 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup2 ⟧,
+            i11 ↦ ⟦ φ ↦ Φ.jeo.opcode.laload ⟧,
+            i12 ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_1 ⟧,
+            i13 ↦ ⟦ φ ↦ Φ.jeo.opcode.ladd ⟧,
+            i14 ↦ ⟦ φ ↦ Φ.jeo.opcode.lastore ⟧,
+            i15 ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+            i16 ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+            i17 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+            i18 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label-accept ⟧,
+            i19 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧
+          ⟧
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝐵-caller-tail
+    ⟧,
+    𝐵-class-tail,
+    ρ ↦ ∅
+  ⟧
+when:
+  and:
+    - not:
+        eq: [ 𝑒-count, '"0"' ]
+    - not:
+        eq: [ 𝑒-count, '"1"' ]
+where:
+  - meta: 𝑒-label-accept
+    function: random-string
+    args: [ '"LskipAccept%d"' ]
+  - meta: 𝑒-label-nonnegative
+    function: random-string
+    args: [ '"LskipNonnegative%d"' ]
+  - meta: 𝜏-check-ldc
+    function: random-tau
+    args: []
+  - meta: 𝜏-check-zero
+    function: random-tau
+    args: [ '𝜏-check-ldc' ]
+  - meta: 𝜏-check-lcmp
+    function: random-tau
+    args: [ '𝜏-check-ldc', '𝜏-check-zero' ]
+  - meta: 𝜏-check-ifge
+    function: random-tau
+    args: [ '𝜏-check-ldc', '𝜏-check-zero', '𝜏-check-lcmp' ]
+  - meta: 𝜏-throw-new
+    function: random-tau
+    args: [ '𝜏-check-ldc', '𝜏-check-zero', '𝜏-check-lcmp', '𝜏-check-ifge' ]
+  - meta: 𝜏-throw-dup
+    function: random-tau
+    args: [ '𝜏-check-ldc', '𝜏-check-zero', '𝜏-check-lcmp', '𝜏-check-ifge', '𝜏-throw-new' ]
+  - meta: 𝜏-throw-init
+    function: random-tau
+    args: [ '𝜏-check-ldc', '𝜏-check-zero', '𝜏-check-lcmp', '𝜏-check-ifge', '𝜏-throw-new', '𝜏-throw-dup' ]
+  - meta: 𝜏-throw-athrow
+    function: random-tau
+    args: [ '𝜏-check-ldc', '𝜏-check-zero', '𝜏-check-lcmp', '𝜏-check-ifge', '𝜏-throw-new', '𝜏-throw-dup', '𝜏-throw-init' ]
+  - meta: 𝜏-check-label
+    function: random-tau
+    args: [ '𝜏-check-ldc', '𝜏-check-zero', '𝜏-check-lcmp', '𝜏-check-ifge', '𝜏-throw-new', '𝜏-throw-dup', '𝜏-throw-init', '𝜏-throw-athrow' ]
+  - meta: 𝜏-check-frame
+    function: random-tau
+    args: [ '𝜏-check-ldc', '𝜏-check-zero', '𝜏-check-lcmp', '𝜏-check-ifge', '𝜏-throw-new', '𝜏-throw-dup', '𝜏-throw-init', '𝜏-throw-athrow', '𝜏-check-label' ]
+  - meta: 𝜏-state-len
+    function: random-tau
+    args: [ '𝜏-check-ldc', '𝜏-check-zero', '𝜏-check-lcmp', '𝜏-check-ifge', '𝜏-throw-new', '𝜏-throw-dup', '𝜏-throw-init', '𝜏-throw-athrow', '𝜏-check-label', '𝜏-check-frame' ]
+  - meta: 𝜏-state-new-arr
+    function: random-tau
+    args: [ '𝜏-state-len' ]
+  - meta: 𝜏-state-dup-arr
+    function: random-tau
+    args: [ '𝜏-state-len', '𝜏-state-new-arr' ]
+  - meta: 𝜏-state-idx
+    function: random-tau
+    args: [ '𝜏-state-len', '𝜏-state-new-arr', '𝜏-state-dup-arr' ]
+  - meta: 𝜏-counter-len
+    function: random-tau
+    args: [ '𝜏-state-len', '𝜏-state-new-arr', '𝜏-state-dup-arr', '𝜏-state-idx' ]
+  - meta: 𝜏-counter-new
+    function: random-tau
+    args: [ '𝜏-state-len', '𝜏-state-new-arr', '𝜏-state-dup-arr', '𝜏-state-idx', '𝜏-counter-len' ]
+  - meta: 𝜏-state-store
+    function: random-tau
+    args: [ '𝜏-state-len', '𝜏-state-new-arr', '𝜏-state-dup-arr', '𝜏-state-idx', '𝜏-counter-len', '𝜏-counter-new' ]

--- a/src/main/resources/org/eolang/hone/rules/streams/3xx/310-skip-one-to-distill.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/3xx/310-skip-one-to-distill.phr
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Sibling of 309 for the javac `lconst_1` shape. It avoids re-emitting
+# the threshold as `ldc Φ.jeo.long(1)`.
+name: skip-one-to-distill
+pattern: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    𝐵-class-head-before,
+    name ↦ 𝑒-class-name,
+    𝐵-class-head-after,
+    𝜏-caller ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      𝐵-caller-head,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-skip ↦ ⟦
+          φ ↦ Φ.hone.skip,
+          stream-class ↦ "java/util/stream/Stream",
+          count ↦ "1"
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝐵-caller-tail
+    ⟧,
+    𝐵-class-tail,
+    ρ ↦ ∅
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    𝐵-class-head-before,
+    name ↦ 𝑒-class-name,
+    𝐵-class-head-after,
+    𝜏-caller ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      𝐵-caller-head,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-skip ↦ ⟦
+          φ ↦ Φ.hone.distill,
+          class ↦ 𝑒-class-name,
+          bridge-input ↦ "Ljava/lang/Object;",
+          bridge-output ↦ "Ljava/lang/Object;",
+          start ↦ "skip-one",
+          accepted ↦ "Ljava/lang/Object;",
+          returned ↦ "Ljava/lang/Object;",
+          static ↦ "true",
+          state ↦ ⟦
+            𝜏-state-len ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_1 ⟧,
+            𝜏-state-new-arr ↦ ⟦ φ ↦ Φ.jeo.opcode.anewarray, i1 ↦ "java/lang/Object" ⟧,
+            𝜏-state-dup-arr ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+            𝜏-state-idx ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+            𝜏-counter-len ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_1 ⟧,
+            𝜏-counter-new ↦ ⟦ φ ↦ Φ.jeo.opcode.newarray, i1 ↦ 11 ⟧,
+            𝜏-state-store ↦ ⟦ φ ↦ Φ.jeo.opcode.aastore ⟧,
+            ρ ↦ ∅
+          ⟧,
+          body ↦ ⟦
+            i1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "[J" ⟧,
+            i2 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+            i3 ↦ ⟦ φ ↦ Φ.jeo.opcode.laload ⟧,
+            i4 ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_1 ⟧,
+            i5 ↦ ⟦ φ ↦ Φ.jeo.opcode.lcmp ⟧,
+            i6 ↦ ⟦
+              φ ↦ Φ.jeo.opcode.ifge,
+              i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label-accept ⟧
+            ⟧,
+            i7 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "[J" ⟧,
+            i8 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+            i9 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+            i10 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup2 ⟧,
+            i11 ↦ ⟦ φ ↦ Φ.jeo.opcode.laload ⟧,
+            i12 ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_1 ⟧,
+            i13 ↦ ⟦ φ ↦ Φ.jeo.opcode.ladd ⟧,
+            i14 ↦ ⟦ φ ↦ Φ.jeo.opcode.lastore ⟧,
+            i15 ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+            i16 ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+            i17 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+            i18 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label-accept ⟧,
+            i19 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧
+          ⟧
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝐵-caller-tail
+    ⟧,
+    𝐵-class-tail,
+    ρ ↦ ∅
+  ⟧
+where:
+  - meta: 𝑒-label-accept
+    function: random-string
+    args: [ '"LskipOneAccept%d"' ]
+  - meta: 𝜏-state-len
+    function: random-tau
+    args: []
+  - meta: 𝜏-state-new-arr
+    function: random-tau
+    args: [ '𝜏-state-len' ]
+  - meta: 𝜏-state-dup-arr
+    function: random-tau
+    args: [ '𝜏-state-len', '𝜏-state-new-arr' ]
+  - meta: 𝜏-state-idx
+    function: random-tau
+    args: [ '𝜏-state-len', '𝜏-state-new-arr', '𝜏-state-dup-arr' ]
+  - meta: 𝜏-counter-len
+    function: random-tau
+    args: [ '𝜏-state-len', '𝜏-state-new-arr', '𝜏-state-dup-arr', '𝜏-state-idx' ]
+  - meta: 𝜏-counter-new
+    function: random-tau
+    args: [ '𝜏-state-len', '𝜏-state-new-arr', '𝜏-state-dup-arr', '𝜏-state-idx', '𝜏-counter-len' ]
+  - meta: 𝜏-state-store
+    function: random-tau
+    args: [ '𝜏-state-len', '𝜏-state-new-arr', '𝜏-state-dup-arr', '𝜏-state-idx', '𝜏-counter-len', '𝜏-counter-new' ]

--- a/src/test/phino/220-recognize-skip-ldc.yml
+++ b/src/test/phino/220-recognize-skip-ldc.yml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/2xx/220-recognize-skip-ldc.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      op1 ↦ ⟦
+        φ ↦ Φ.jeo.opcode.ldc,
+        v1 ↦ ⟦
+          φ ↦ Φ.jeo.long,
+          v2 ↦ "2",
+          ρ ↦ ∅
+        ⟧,
+        ρ ↦ ∅
+      ⟧,
+      op2 ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokeinterface,
+        v3 ↦ "java/util/stream/Stream",
+        v4 ↦ "skip",
+        v5 ↦ "(J)Ljava/util/stream/Stream;",
+        v6 ↦ Φ.true,
+        ρ ↦ ∅
+      ⟧
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.hone.skip, stream-class ↦ "java/util/stream/Stream", count ↦ "2" ⟧

--- a/src/test/phino/309-skip-to-distill.yml
+++ b/src/test/phino/309-skip-to-distill.yml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/3xx/309-skip-to-distill.phr
+input: |
+  {⟦
+    j$X ↦ ⟦
+      φ ↦ Φ.jeo.class,
+      name ↦ "Foo",
+      j$main ↦ ⟦
+        φ ↦ Φ.jeo.method,
+        body ↦ ⟦
+          op1 ↦ ⟦
+            φ ↦ Φ.hone.skip,
+            stream-class ↦ "java/util/stream/Stream",
+            count ↦ "2"
+          ⟧,
+          ρ ↦ ∅
+        ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.hone.distill, 𝐵-a, start ↦ "skip", 𝐵-b ⟧
+  - ⟦ φ ↦ Φ.hone.fetch, type ↦ "[J" ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.newarray, i1 ↦ 11 ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.new, i1 ↦ "java/lang/IllegalArgumentException" ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.ldc, i1 ↦ ⟦ φ ↦ Φ.jeo.long, i1 ↦ "2" ⟧ ⟧

--- a/src/test/phino/310-skip-one-to-distill.yml
+++ b/src/test/phino/310-skip-one-to-distill.yml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/3xx/310-skip-one-to-distill.phr
+input: |
+  {⟦
+    j$X ↦ ⟦
+      φ ↦ Φ.jeo.class,
+      name ↦ "Foo",
+      j$main ↦ ⟦
+        φ ↦ Φ.jeo.method,
+        body ↦ ⟦
+          op1 ↦ ⟦
+            φ ↦ Φ.hone.skip,
+            stream-class ↦ "java/util/stream/Stream",
+            count ↦ "1"
+          ⟧,
+          ρ ↦ ∅
+        ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.hone.distill, 𝐵-a, start ↦ "skip-one", 𝐵-b ⟧
+  - ⟦ φ ↦ Φ.hone.fetch, type ↦ "[J" ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.newarray, i1 ↦ 11 ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.lconst_1 ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams-skip.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-skip.yml
@@ -4,11 +4,10 @@
 # Consolidated .skip() roundtrip suite covering every shape the rule
 # pipeline handles:
 #
-#   objNop   : Stream.skip(0L)                 -> rule 311 lowers to nop
-#   objNon0  : Stream.skip(2L) with no .map    -> 220 recognises, no fold
-#   objFused : Stream.skip(2L) after .map      -> 353 mapMulti+long[1]
-#   objOne   : Stream.skip(1L) after .map      -> same shape as 353 with
-#                                                 lconst_1 in counter-init
+#   objNop   : Stream.skip(0L)                 -> rule 308 lowers to nop
+#   objNon0  : Stream.skip(2L) with no .map    -> rule 309 state distill
+#   objFused : Stream.skip(2L) after .map      -> 306 + 309 fuse
+#   objOne   : Stream.skip(1L) after .map      -> 306 + 310 fuse
 #   intP     : IntStream.skip(0L)              -> 313 nop
 #   intF     : IntStream.skip(2L) after .map   -> 355 mapMulti+long[1]
 #   longP    : LongStream.skip(2L) bare        -> 226 recognise, 722 mirror
@@ -16,8 +15,9 @@
 #   doubleP  : DoubleStream.skip(0L)           -> 313 nop
 #   doubleF  : DoubleStream.skip(1L) bare      -> primitive roundtrip
 #
-# Opcode pins are intentionally omitted: the combined class folds
-# skip-as-nop, skip-as-mapMulti, and skip-as-roundtrip into one
+# Opcode pins are intentionally omitted: the combined class mixes
+# skip-as-nop, object skip-as-stateful-mapMulti, and primitive roundtrip
+# shapes into one
 # bytecode body, and the per-rule `invokeinterface` deltas no longer
 # attribute cleanly. The runtime output is the regression guard --
 # each numeric value is sensitive to a one-element off-by-one or a


### PR DESCRIPTION
Closes #622.

This maps object `Stream.skip(long)` into the stream `distill` pipeline:

- recognizes object `skip(0L)`, `skip(1L)`, and `skip(N)` bytecode shapes;
- lowers `skip(0L)` to `nop`;
- folds `skip(1L)` and `skip(N)` into a stateful `distill` backed by a captured `long[1]` counter;
- preserves the eager negative-count exception for the `ldc` count path;
- adds phino rule packs for recognition and distill folding.

Validation run locally on Windows with Java 21.0.11 and Maven 3.9.16:

- `git diff --check origin/master...HEAD`
- `mvn -q clean -DskipTests -DskipITs package`
- `mvn -q -DskipITs -Dtest=*Test,!DockerTest test` (28 tests, 0 failures, 0 errors)
- `mvn clean install -ntp --errors --batch-mode -DskipTests -Dinvoker.skip=true -Pqulice`
- `gitleaks detect --source . --no-git --redact --verbose`

Hosted validation on this head:

- passing: `actionlint`, `bashate`, `copyrights`, `docker`, `hadolint`, `make`, `markdown-lint`, `mvn-on-rultor-image`, `pdd`, `reuse`, `shellcheck`, `typos`, `xcop`, `yamllint`;
- failing before project commands: `qulice`, `smoke`, and the Java 17/22 `mvn` matrix stopped inside `actions/setup-java@v5` while resolving Zulu with `error code: 520`.

Local limitation: this Windows host has no `phino` or Docker executable on PATH, so direct host-side phino/Docker execution was not claimed. The hosted `make`, `docker`, and `mvn-on-rultor-image` jobs cover those paths on Ubuntu/container infrastructure.