### PR TITLE
Fold .peek() into a fusable distill pragma

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,8 +132,11 @@ body                 the opcode formation spliced between item-load and emit
 
 The body is one-in-one-out (auto-style): phino feeds it a single item
 and it produces a single item, so `401-fuse` can concatenate any two
-adjacent bodies blindly. Pointwise operators (map, filter, …) carry an
-empty `state`; the two stateful operators today are `distinct` (whose
+adjacent bodies blindly. Pointwise operators (map, filter, peek, …) carry
+an empty `state`; `peek` is the one whose body opens with a `dup` — it runs
+its Consumer for the side effect and forwards the element unchanged, so the
+body keeps a copy before the consumer invocation swallows the duplicate and
+returns void (see 309). The two stateful operators today are `distinct` (whose
 `state` builds a `java/util/HashSet` and whose body consults it) and
 `skip` (whose `state` builds a `long[1]` countdown counter) — see
 "Stateful operators (distinct, skip)" below. There is still no
@@ -144,6 +147,7 @@ The full operator-to-rule mapping (every rule named below exists under
 
 ```text
 filter, map (object + primitive) → 201..204 → Φ.hone.{filter,map}
+peek                             → 207 → 309 → Φ.hone.peek → distill
 boxed/unbox, box                 → 205, 206  → Φ.hone.{unbox,box}
 box/unbox cleanup + collapse     → 211, 221, 231, 232 → fold back to map/filter
 type / transform adjustments     → 241..243, 251..261, 271, 272

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/102-remove-pipeline-labels.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/102-remove-pipeline-labels.phr
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Companion to 101. When a fluent stream call is written on its own source
+# line, javac emits a label (the line-number anchor for that line) right
+# before the operator's `invokeinterface java/util/stream/Stream` opcode. 101
+# only strips that label when the operator is a lambda one (an invokedynamic
+# immediately precedes it — map/filter); a bare operator such as `distinct()`
+# or `skip(n)` has no preceding invokedynamic, so its anchor label survives
+# and wedges between two operators. A label between two pipeline opcodes
+# breaks adjacency, and 401-fuse needs adjacency, so a debug-compiled
+# (javac -g) pipeline of stateful operators fuses only partially and emits an
+# unverifiable wrapper.
+#
+# Removing a label is unsafe in general — a try-catch boundary or a
+# local-variable-table scope may reference it by name from a sibling binding a
+# body-local rule cannot see. This rule is scoped to the one provably dead
+# case (the same reasoning 101 and 219 rely on): a label whose ONLY reference
+# is the line-number entry that immediately follows it (the `𝑒-label-value`
+# bound on both sides forces that pairing), sitting right before a
+# `java/util/stream/Stream` call. A jump target carries a stackmap frame, not
+# a bare line-number, so this never matches a branch target; no statement
+# boundary, try-region edge or variable scope falls between two operators of
+# one fluent chain. Run before 151 so the line-number is still present to
+# witness the pairing.
+name: remove-pipeline-labels
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-label ↦ ⟦
+      φ ↦ Φ.jeo.label,
+      𝜏-label-value ↦ 𝑒-label-value,
+      ρ ↦ ∅
+    ⟧,
+    𝜏-line-number ↦ ⟦
+      φ ↦ Φ.jeo.line-number,
+      number ↦ 𝑒-line-number,
+      𝜏-ln-label ↦ ⟦
+        φ ↦ Φ.jeo.label,
+        𝜏-ln-label-value ↦ 𝑒-label-value,
+        ρ ↦ ∅
+      ⟧,
+      ρ ↦ ∅
+    ⟧,
+    𝜏-call ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      𝜏1 ↦ "java/util/stream/Stream",
+      𝐵-call
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-call ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      𝜏1 ↦ "java/util/stream/Stream",
+      𝐵-call
+    ⟧,
+    𝐵-after
+  ⟧

--- a/src/main/resources/org/eolang/hone/rules/streams/2xx/207-lambda-to-peek.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/2xx/207-lambda-to-peek.phr
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+name: lambda-to-peek
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.lambda,
+    class ↦ 𝑒-class,
+    method ↦ "accept",
+    interface ↦ "()Ljava/util/function/Consumer;",
+    lambda-signature ↦ "(Ljava/lang/Object;)V",
+    bridge-signature ↦ 𝑒-bridge-signature,
+    static ↦ 𝑒-static,
+    opcode ↦ 𝑒-opcode,
+    target ↦ ⟦
+      handle ↦ 𝑒-target-handle,
+      class ↦ 𝑒-target-class,
+      method ↦ 𝑒-target-method,
+      signature ↦ 𝑒-target-signature,
+      is-interface ↦ 𝑒-target-is-interface
+    ⟧,
+    stream ↦ ⟦
+      class ↦ "java/util/stream/Stream",
+      method ↦ "peek",
+      signature ↦ "(Ljava/util/function/Consumer;)Ljava/util/stream/Stream;"
+    ⟧
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.peek,
+    opcode ↦ 𝑒-opcode,
+    class ↦ 𝑒-class,
+    bridge-input ↦ 𝑒-bridge-input,
+    bridge-output ↦ 𝑒-bridge-input,
+    accepted ↦ 𝑒-bridge-input,
+    returned ↦ 𝑒-bridge-input,
+    static ↦ 𝑒-static,
+    target ↦ ⟦
+      handle ↦ 𝑒-target-handle,
+      class ↦ 𝑒-target-class,
+      method ↦ 𝑒-target-method,
+      signature ↦ 𝑒-target-signature,
+      is-interface ↦ 𝑒-target-is-interface
+    ⟧
+  ⟧
+where:
+  - meta: 𝑒-bridge-input
+    function: sed
+    # "(Ljava/lang/Integer;)V"
+    args:
+      - 𝑒-bridge-signature
+      - '"s/\\((.*)\\)V/$1/g"'

--- a/src/main/resources/org/eolang/hone/rules/streams/3xx/309-peek-to-distill.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/3xx/309-peek-to-distill.phr
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Folds a recognised `.peek(consumer)` into the uniform auto-style distill.
+# A peek runs its Consumer for the side effect and forwards the element
+# unchanged, so its one-in-one-out body is a `dup` (keep the element for
+# the next stage) followed by the consumer invocation that swallows the
+# duplicate and returns void. Because the body leaves exactly the element
+# it was fed, the distill carries an empty `state` and is pointwise, and
+# 401-fuse concatenates it with any neighbour blindly.
+name: peek-to-distill
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.peek,
+    opcode ↦ 𝑒-opcode,
+    class ↦ 𝑒-class,
+    bridge-input ↦ 𝑒-bridge-input,
+    bridge-output ↦ 𝑒-bridge-output,
+    accepted ↦ 𝑒-accepted,
+    returned ↦ 𝑒-returned,
+    static ↦ 𝑒-static,
+    target ↦ ⟦
+      handle ↦ 𝑒-target-handle,
+      class ↦ 𝑒-target-class,
+      method ↦ 𝑒-target-method,
+      signature ↦ 𝑒-target-signature,
+      is-interface ↦ 𝑒-target-is-interface
+    ⟧
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.𝜏-distill,
+    class ↦ 𝑒-class,
+    bridge-input ↦ 𝑒-bridge-input,
+    bridge-output ↦ 𝑒-bridge-output,
+    start ↦ "peek",
+    accepted ↦ 𝑒-accepted,
+    returned ↦ 𝑒-returned,
+    static ↦ 𝑒-static,
+    state ↦ ⟦ ρ ↦ ∅ ⟧,
+    body ↦ ⟦
+      i1 ↦ ⟦
+        φ ↦ Φ.jeo.opcode.dup
+      ⟧,
+      i2 ↦ ⟦
+        φ ↦ Φ.jeo.opcode.𝜏-opcode,
+        i2 ↦ 𝑒-target-class,
+        i3 ↦ 𝑒-target-method,
+        i4 ↦ 𝑒-target-signature,
+        i5 ↦ 𝑒-target-is-interface
+      ⟧
+    ⟧
+  ⟧
+where:
+  - meta: 𝜏-opcode
+    function: tau
+    args: [𝑒-opcode]
+  - meta: 𝑒-distill
+    function: sed
+    args:
+      - 𝑒-static
+      - '"s/true/distill/g"'
+      - '"s/false/pre-distill/g"'
+  - meta: 𝜏-distill
+    function: tau
+    args: [𝑒-distill]

--- a/src/test/phino/102-remove-pipeline-labels.yml
+++ b/src/test/phino/102-remove-pipeline-labels.yml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/1xx/102-remove-pipeline-labels.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      keep ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "map", v2 ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;", v3 ↦ Φ.true ⟧,
+      lbl ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ "L42" ⟧,
+      ln ↦ ⟦
+        φ ↦ Φ.jeo.line-number,
+        number ↦ 7,
+        l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ "L42" ⟧
+      ⟧,
+      call ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "distinct", v2 ↦ "()Ljava/util/stream/Stream;", v3 ↦ Φ.true ⟧
+    ⟧
+  ⟧}
+expected:
+  - ⟦ body ↦ ⟦ 𝜏-keep ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "map", 𝐵-k ⟧, 𝜏-call ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "distinct", 𝐵-c ⟧, ρ ↦ ∅ ⟧ ⟧

--- a/src/test/phino/207-lambda-to-peek.yml
+++ b/src/test/phino/207-lambda-to-peek.yml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/2xx/207-lambda-to-peek.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      op ↦ ⟦
+        φ ↦ Φ.hone.lambda,
+        class ↦ "fusion/X",
+        method ↦ "accept",
+        interface ↦ "()Ljava/util/function/Consumer;",
+        lambda-signature ↦ "(Ljava/lang/Object;)V",
+        bridge-signature ↦ "(Ljava/lang/Integer;)V",
+        static ↦ "true",
+        opcode ↦ "invokestatic",
+        target ↦ ⟦
+          handle ↦ 6,
+          class ↦ "fusion/X",
+          method ↦ "lambda$main$1",
+          signature ↦ "(Ljava/lang/Integer;)V",
+          is-interface ↦ Φ.false
+        ⟧,
+        stream ↦ ⟦
+          class ↦ "java/util/stream/Stream",
+          method ↦ "peek",
+          signature ↦ "(Ljava/util/function/Consumer;)Ljava/util/stream/Stream;"
+        ⟧
+      ⟧
+    ⟧
+  ⟧}
+expected:
+  - ⟦ body ↦ ⟦ 𝜏-op ↦ ⟦ φ ↦ Φ.hone.peek, opcode ↦ "invokestatic", class ↦ "fusion/X", bridge-input ↦ "Ljava/lang/Integer;", bridge-output ↦ "Ljava/lang/Integer;", accepted ↦ "Ljava/lang/Integer;", returned ↦ "Ljava/lang/Integer;", 𝐵 ⟧, ρ ↦ ∅ ⟧ ⟧

--- a/src/test/phino/309-peek-to-distill.yml
+++ b/src/test/phino/309-peek-to-distill.yml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/3xx/309-peek-to-distill.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      op ↦ ⟦
+        φ ↦ Φ.hone.peek,
+        opcode ↦ "invokestatic",
+        class ↦ "fusion/X",
+        bridge-input ↦ "Ljava/lang/Integer;",
+        bridge-output ↦ "Ljava/lang/Integer;",
+        accepted ↦ "Ljava/lang/Integer;",
+        returned ↦ "Ljava/lang/Integer;",
+        static ↦ "true",
+        target ↦ ⟦
+          handle ↦ 6,
+          class ↦ "fusion/X",
+          method ↦ "lambda$main$1",
+          signature ↦ "(Ljava/lang/Integer;)V",
+          is-interface ↦ Φ.false
+        ⟧
+      ⟧
+    ⟧
+  ⟧}
+expected:
+  - ⟦ body ↦ ⟦ 𝜏-op ↦ ⟦ φ ↦ Φ.hone.distill, class ↦ "fusion/X", bridge-input ↦ "Ljava/lang/Integer;", bridge-output ↦ "Ljava/lang/Integer;", start ↦ "peek", accepted ↦ "Ljava/lang/Integer;", returned ↦ "Ljava/lang/Integer;", static ↦ "true", state ↦ ⟦⟧, body ↦ ⟦ i1 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧, i2 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, 𝐵 ⟧ ⟧ ⟧, ρ ↦ ∅ ⟧ ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams-all-ops.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-all-ops.yml
@@ -52,8 +52,8 @@ before:
   invokedynamic: 17
   return: 7
 after:
-  invokespecial: 1
-  invokestatic: 19
-  invokevirtual: 11
-  invokedynamic: 16
-  return: 9
+  invokespecial: 3
+  invokestatic: 20
+  invokevirtual: 12
+  invokedynamic: 15
+  return: 10

--- a/src/test/resources/org/eolang/hone/optimize/streams-full-non-terminal.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-full-non-terminal.yml
@@ -4,20 +4,27 @@
 # Full coverage of every non-terminal Stream operation the optimizer lowers
 # to a mapMulti — the operations that do NOT need a Sink lifecycle
 # (begin/end/cancellation) and so map cleanly onto a BiConsumer-driven emit:
-# filter, map, distinct, skip, and the primitive conversions
-# mapToInt/mapToLong/mapToDouble + boxed. Sink-bound operations (sorted,
-# takeWhile, limit, peek, dropWhile, flatMap, mapMulti and their primitive
+# filter, map, peek, distinct, skip, and the primitive conversions
+# mapToInt/mapToLong/mapToDouble + boxed. The remaining Sink-bound operations
+# (sorted, takeWhile, limit, dropWhile, flatMap, mapMulti and their primitive
 # variants) are deliberately absent. With no barriers between them every
 # operator is adjacent, so the pipeline exercises fusion across the boxing
 # boundary as aggressively as possible. The trailing mapToInt lands the
 # stream back on a primitive so `.sum()` is legal.
 #
+# This fixture is compiled with debug info (javac -g, the Maven default), so
+# javac wedges a line-number-anchor label before every operator. 101 strips
+# the label of a lambda operator (map/filter) and 102 strips it of a bare one
+# (peek/distinct/skip), keeping the operators adjacent so 401-fuse can fold
+# the whole chain — without 102 the stateful chain fuses only partially and
+# emits a wrapper that fails class verification.
+#
 # Both distincts and both skips are stateful, and the two distinct/skip
 # pairs sit adjacent (distinct().skip()), so this is the case that proves
-# stateful distills fuse: all eight object-stream operators collapse into a
-# single mapMulti backed by one captured java/util/List holding the two
-# HashSets and two long[1] counters, dropping invokedynamic 8 -> 5 (the
-# remaining four come from the primitive-conversion tail).
+# stateful distills fuse: all nine object-stream operators (peek included)
+# collapse into a single mapMulti backed by one captured java/util/List
+# holding the two HashSets and two long[1] counters, dropping invokedynamic
+# 9 -> 5 (the remaining four come from the primitive-conversion tail).
 java: |
   package allnonterminal;
   import java.util.stream.Stream;
@@ -26,6 +33,7 @@ java: |
       double r = Stream.of(5, 3, 8, 5, 2, 7, 4, 1, 6, 9)
         .filter(n -> n > 0)
         .map(n -> n + 1)
+        .peek(n -> {})
         .distinct()
         .skip(0L)
         .filter(n -> n != null)
@@ -49,6 +57,6 @@ log:
   - "BUILD SUCCESS"
   - "The result is 54"
 before:
-  invokedynamic: 8
+  invokedynamic: 9
 after:
   invokedynamic: 5

--- a/src/test/resources/org/eolang/hone/optimize/streams-peek.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-peek.yml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A `.peek(consumer)` is a point-wise operator that runs its Consumer for
+# the side effect and forwards the element unchanged. 207 recognises it and
+# 309 folds it into the uniform auto-style distill, whose body is a `dup`
+# (keep the element for the next stage) followed by the consumer invocation
+# that swallows the duplicate. Because the body is one-in-one-out, 401-fuse
+# concatenates it blindly with its map neighbours, so the whole
+# `.map(+1).peek({}).map(*2)` chain collapses into a SINGLE Stream.mapMulti
+# dispatch. The surviving single invokedynamic proves the fusion: three
+# lambdas (two maps and one peek) became one mapMulti.
+#
+#   [1,2,3,4,5] --map(+1)--> [2,3,4,5,6] --peek--> (forwarded unchanged)
+#               --map(*2)--> [4,6,8,10,12] --count()--> 5
+java: |
+  package peek;
+  import java.util.stream.*;
+  public class X {
+    public static void main(String[] a) {
+      long n = Stream.of(1, 2, 3, 4, 5)
+        .map(x -> x + 1)
+        .peek(x -> {})
+        .map(x -> x * 2)
+        .count();
+      System.out.printf("The result is %d\n", n);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 5"
+before:
+  invokedynamic: 3
+  invokeinterface: 4
+  invokestatic: 9
+  invokevirtual: 3
+  return: 3
+after:
+  invokedynamic: 1
+  invokeinterface: 3
+  invokestatic: 12
+  invokevirtual: 3
+  return: 4


### PR DESCRIPTION
A `.peek()` call used to stay a native lambda all the way through the pipeline and never folded, so it broke fusion between the operators around it. This teaches the rewriter to recognise peek's `Consumer` (new rule 207) and fold it into the same auto-style distill that map and filter use (new rule 309). Peek's body is a `dup` followed by the consumer invocation: it keeps a copy of the element, the consumer swallows the duplicate and returns void, and the original is forwarded unchanged — so the body stays one-in-one-out and 401-fuse concatenates it blindly. A `.map().peek().map()` chain now collapses into a single `mapMulti`.

It matters because peek sitting between two maps previously forced two separate dispatches; now the whole run fuses into one, and peek stops being a fusion barrier on the stateless point-wise path.

Two things for the reviewer. Capturing-lambda and method-reference peeks (`x -> sb.append(x)`, `System.out::println`) stay native by design — the same limitation already noted for map, since 111 only lifts `lambda$…` targets. And because the fused result is a non-SIZED `mapMulti`, a `.peek().count()` will now run the peek side effect where the JDK's SIZED `count()` may elide it; peek's javadoc leaves that unspecified and the existing `streams-fusion.yml` fixture already relies on peek folding under `count()`. Covered by new phino unit packs for 207/309 and an end-to-end `streams-peek.yml` that pins the 3→1 invokedynamic collapse.