### PR TITLE
Fuse stream method references by desugaring them to lambdas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,8 @@ pipeline stages:
 
 ```text
 1xx  prep         strip line-numbers, desugar method refs to lambdas
-                  (103 unbound, 104 static), lower invokedynamic to Φ.hone.lambda
+                  (103 unbound, 104 static, 105 peek/return-drop), lower
+                  invokedynamic to Φ.hone.lambda
 2xx  recognise    lambda + invokeinterface → Φ.hone.{filter,map,unbox,box}
 3xx  fold         every pragma → uniform Φ.hone.distill
 4xx  fuse         adjacent distills → one combined distill  ← the actual win
@@ -210,6 +211,8 @@ that gap before `111`:
 
 - `103-methodref-to-lambda` — **unbound-instance** refs (handle 5).
 - `104-static-methodref-to-lambda` — **static** refs (handle 6).
+- `105-methodref-peek-to-lambda` — **unbound-instance** refs feeding a
+  `.peek(...)` (handle 5, **return-dropping**).
 
 Each synthesises a `private static lambda$hone$N` wrapper whose body is the
 forwarding the `LambdaMetafactory` would have generated (`<load arg>;
@@ -219,6 +222,21 @@ target handle at it (`invokestatic THIS.lambda$hone$N`). `111` then lifts the
 repointed indy like any javac lambda, so `201`-`207`/`451` recognise and fuse
 it. The wrapper's call opcode carries an `origin ↦ Φ.true` marker (which jeo
 ignores, like `441`'s `reverted`) so the revert below can find it.
+
+`105` is the **void-SAM** case. A peek's SAM is a `Consumer` (`accept` returns
+void); a reference like `Integer::intValue` returns a value, so javac points the
+indy at a kind-5 handle with an instantiated type of `(L…;)V` and lets the
+metafactory DROP the return. `103` declines that (its return-category guard has
+no void branch), so `105` is its return-dropping twin: the wrapper body is
+`aload 0; invoke C.m ()R; pop|pop2; return` (the drop opcode chosen by `R`'s
+category). Crucially, `105` keeps `103`'s original **predecessor gate** — it
+fires only when the reference directly follows a pointwise `map`/`filter`/`peek`
+— because, unlike a mapToX unbox (which reverts to native via `603`/`701`/`711`
+when it never fuses), a peek folds to a distill **unconditionally** (`309`) and a
+lone distill is emitted as a standalone `mapMulti` (`501`) that `711` cannot
+revert (the folded distill has dropped the SAM/instantiated types the revert
+needs). The gate guarantees a fusable neighbour, so a lone peek reference is
+left native — never pessimised.
 
 A reference that does **not** fuse (it followed a barrier, a stateful
 operator, or a `boxed()` roundtrip, or feeds a terminal) is restored to its
@@ -235,15 +253,16 @@ stateful paths at run time; the wrapper's `invokestatic`-to-a-real-method shape
 is what keeps the downstream, which assumes `lambda$…` are static methods,
 correct.)
 
-`103`/`104` currently cover only the **adaptation-free** case: the referenced
-method's argument and return types match the SAM's instantiated type, so the
-wrapper needs no receiver `checkcast`, argument/return box/unbox/widen, and a
-single argument. Boxing/widening adaptation (e.g. `String::length` returning
-`int` where a `Function` wants `Integer`), multi-argument refs (`Integer::sum`),
-constructor refs (handle 8, `Integer[]::new`), interface targets (handle 9) and
-captured-receiver refs (`self::decorate`, which need invokedynamic-argument
-surgery) stay native and are the next puzzles — the wrapper mechanism extends
-to them by generating the matching adaptation body.
+`103`/`104` cover the **adaptation-free** case (argument and return types match
+the SAM's instantiated type, single argument, no receiver `checkcast`); `105`
+adds the one **return-dropping** adaptation (a value-returning ref against a
+void `Consumer` SAM). Still native and the next puzzles: boxing/widening
+adaptation (e.g. `String::length` returning `int` where a `Function` wants
+`Integer`), multi-argument refs (`Integer::sum`), constructor refs (handle 8,
+`Integer[]::new`), interface targets (handle 9), captured-receiver refs
+(`self::decorate`, which need invokedynamic-argument surgery), and a static
+(handle 6) peek ref — the wrapper mechanism extends to them by generating the
+matching adaptation body.
 
 `501-distill-to-mapMulti` then rewrites each remaining *empty-state*
 distill into a `Φ.hone.mapMulti` dispatch, and `511-distill-lambda-to-method`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,8 @@ that same order. The `NNN-` prefix is *the* mechanism that defines the
 pipeline stages:
 
 ```text
-1xx  prep         strip line-numbers, lower invokedynamic to Φ.hone.lambda
+1xx  prep         strip line-numbers, desugar method refs to lambdas (103),
+                  lower invokedynamic to Φ.hone.lambda
 2xx  recognise    lambda + invokeinterface → Φ.hone.{filter,map,unbox,box}
 3xx  fold         every pragma → uniform Φ.hone.distill
 4xx  fuse         adjacent distills → one combined distill  ← the actual win
@@ -197,11 +198,30 @@ while the `consumer` the body drives, the resulting stream class and the
 method name (`mapMulti` vs `mapMultiToInt`/`…Long`/`…Double`) follow the
 OUTPUT. `501`/`511`/`601` thread two extra pragma fields — `stream-method`
 and `result-stream-class` — to carry that split (a symmetric distill sets
-them to its input-side values, so nothing changes there). Limitation: the
-mapper must be a lambda; a method-reference mapToX (`Integer::intValue`)
-is not yet lifted, because `111` only turns `lambda$…` targets into a
-`Φ.hone.lambda`, and admitting method refs there breaks the
-`boxed`-roundtrip and stateful paths. That is the next puzzle.
+them to its input-side values, so nothing changes there).
+
+A method-reference mapToX (`Integer::intValue`, the canonical idiom) is
+handled by `103-methodref-to-lambda`, which runs before `111` and desugars
+the reference into the lambda the compiler could have emitted: it synthesises
+a `private static lambda$hone$N` wrapper whose body is the unboxing the
+`LambdaMetafactory` would have generated (`aload 0; invokevirtual C.m ();
+Xreturn`), appends it to the class (the same class-level binding-insertion
+`501` uses), and repoints the `invokedynamic`'s target handle at it
+(`invokestatic THIS.lambda$hone$N`). `111` then lifts the repointed indy like
+any javac lambda, so `205`/`451` fuse it with no special-casing. `103` fires
+only when the reference directly follows a pointwise object operator
+(`map`/`filter`/`peek`), where `451` can fuse the resulting unbox — desugaring
+a reference after a barrier, a stateful `distinct`/`skip`, or a `boxed()`
+roundtrip would only add a wrapper that never fuses (a pessimisation), and
+admitting method refs in `111` directly breaks those `boxed`-roundtrip and
+stateful paths (the wrapper's `invokestatic`-to-a-real-method shape is what
+keeps the downstream — which assumes `lambda$…` are static methods — correct).
+`103` currently covers only the adaptation-free unbound-instance case (handle
+5, no-arg target, `To{Int,Long,Double}Function` SAM, no checkcast or
+box/unbox/widen). Static refs (handle 6), constructor refs (handle 8),
+interface targets (handle 9), captured-receiver refs and any argument/return
+adaptation are the next puzzles — the wrapper mechanism extends to them by
+generating the matching adaptation body.
 
 `501-distill-to-mapMulti` then rewrites each remaining *empty-state*
 distill into a `Φ.hone.mapMulti` dispatch, and `511-distill-lambda-to-method`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,14 +94,15 @@ that same order. The `NNN-` prefix is *the* mechanism that defines the
 pipeline stages:
 
 ```text
-1xx  prep         strip line-numbers, desugar method refs to lambdas (103),
-                  lower invokedynamic to Φ.hone.lambda
+1xx  prep         strip line-numbers, desugar method refs to lambdas
+                  (103 unbound, 104 static), lower invokedynamic to Φ.hone.lambda
 2xx  recognise    lambda + invokeinterface → Φ.hone.{filter,map,unbox,box}
 3xx  fold         every pragma → uniform Φ.hone.distill
 4xx  fuse         adjacent distills → one combined distill  ← the actual win
 5xx  emit         distill → Φ.hone.mapMulti + private static method
 6xx  unrecognise  Φ.hone.* pragmas → Φ.hone.lambda + invokeinterface
-7xx  lower        Φ.hone.lambda → Φ.jeo.opcode.invokedynamic
+7xx  lower        Φ.hone.lambda → Φ.jeo.opcode.invokedynamic; revert an
+                  unfused method-ref wrapper to its native ref (711, 712)
 ```
 
 If you insert a rule with a prefix that lies between two phases (say,
@@ -200,28 +201,49 @@ OUTPUT. `501`/`511`/`601` thread two extra pragma fields — `stream-method`
 and `result-stream-class` — to carry that split (a symmetric distill sets
 them to its input-side values, so nothing changes there).
 
-A method-reference mapToX (`Integer::intValue`, the canonical idiom) is
-handled by `103-methodref-to-lambda`, which runs before `111` and desugars
-the reference into the lambda the compiler could have emitted: it synthesises
-a `private static lambda$hone$N` wrapper whose body is the unboxing the
-`LambdaMetafactory` would have generated (`aload 0; invokevirtual C.m ();
-Xreturn`), appends it to the class (the same class-level binding-insertion
-`501` uses), and repoints the `invokedynamic`'s target handle at it
-(`invokestatic THIS.lambda$hone$N`). `111` then lifts the repointed indy like
-any javac lambda, so `205`/`451` fuse it with no special-casing. `103` fires
-only when the reference directly follows a pointwise object operator
-(`map`/`filter`/`peek`), where `451` can fuse the resulting unbox — desugaring
-a reference after a barrier, a stateful `distinct`/`skip`, or a `boxed()`
-roundtrip would only add a wrapper that never fuses (a pessimisation), and
-admitting method refs in `111` directly breaks those `boxed`-roundtrip and
-stateful paths (the wrapper's `invokestatic`-to-a-real-method shape is what
-keeps the downstream — which assumes `lambda$…` are static methods — correct).
-`103` currently covers only the adaptation-free unbound-instance case (handle
-5, no-arg target, `To{Int,Long,Double}Function` SAM, no checkcast or
-box/unbox/widen). Static refs (handle 6), constructor refs (handle 8),
-interface targets (handle 9), captured-receiver refs and any argument/return
-adaptation are the next puzzles — the wrapper mechanism extends to them by
-generating the matching adaptation body.
+A method reference (`Integer::intValue`, `String::toUpperCase`, `X::keep`, …)
+is **desugared into a lambda** up front so the rest of the pipeline picks it
+up with no special-casing. A method-ref `invokedynamic` is byte-identical to a
+lambda's except its target handle points straight at the referenced method, so
+`111` (which only lifts `lambda$…` targets) leaves it native. Two rules close
+that gap before `111`:
+
+- `103-methodref-to-lambda` — **unbound-instance** refs (handle 5).
+- `104-static-methodref-to-lambda` — **static** refs (handle 6).
+
+Each synthesises a `private static lambda$hone$N` wrapper whose body is the
+forwarding the `LambdaMetafactory` would have generated (`<load arg>;
+invoke{virtual,static} C.m …; Xreturn`), appends it to the class (the same
+class-level binding-insertion `501` uses), and repoints the `invokedynamic`'s
+target handle at it (`invokestatic THIS.lambda$hone$N`). `111` then lifts the
+repointed indy like any javac lambda, so `201`-`207`/`451` recognise and fuse
+it. The wrapper's call opcode carries an `origin ↦ Φ.true` marker (which jeo
+ignores, like `441`'s `reverted`) so the revert below can find it.
+
+A reference that does **not** fuse (it followed a barrier, a stateful
+operator, or a `boxed()` roundtrip, or feeds a terminal) is restored to its
+native form by `711-revert-unfused-methodref` (handle 5) and
+`712-revert-unfused-static-methodref` (handle 6): once `701`/`702` have
+lowered the unfused wrapper-lambda back to `invokedynamic → lambda$hone$N`,
+the revert reads the referenced method from the `origin`-marked wrapper call,
+repoints the indy at it and deletes the wrapper — leaving exactly the bytecode
+javac emitted. So conversion is universal and **never pessimises**: it fuses
+where it can and reverts where it cannot, the same stance as the `441`/`442`
+distinct/skip reverts. (Admitting method refs in `111` *directly* instead does
+not work — it `IncompatibleClassChangeError`s the `boxed`-roundtrip and
+stateful paths at run time; the wrapper's `invokestatic`-to-a-real-method shape
+is what keeps the downstream, which assumes `lambda$…` are static methods,
+correct.)
+
+`103`/`104` currently cover only the **adaptation-free** case: the referenced
+method's argument and return types match the SAM's instantiated type, so the
+wrapper needs no receiver `checkcast`, argument/return box/unbox/widen, and a
+single argument. Boxing/widening adaptation (e.g. `String::length` returning
+`int` where a `Function` wants `Integer`), multi-argument refs (`Integer::sum`),
+constructor refs (handle 8, `Integer[]::new`), interface targets (handle 9) and
+captured-receiver refs (`self::decorate`, which need invokedynamic-argument
+surgery) stay native and are the next puzzles — the wrapper mechanism extends
+to them by generating the matching adaptation body.
 
 `501-distill-to-mapMulti` then rewrites each remaining *empty-state*
 distill into a `Φ.hone.mapMulti` dispatch, and `511-distill-lambda-to-method`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,11 +232,11 @@ no void branch), so `105` is its return-dropping twin: the wrapper body is
 category). Crucially, `105` keeps `103`'s original **predecessor gate** — it
 fires only when the reference directly follows a pointwise `map`/`filter`/`peek`
 — because, unlike a mapToX unbox (which reverts to native via `603`/`701`/`711`
-when it never fuses), a peek folds to a distill **unconditionally** (`309`) and a
-lone distill is emitted as a standalone `mapMulti` (`501`) that `711` cannot
-revert (the folded distill has dropped the SAM/instantiated types the revert
-needs). The gate guarantees a fusable neighbour, so a lone peek reference is
-left native — never pessimised.
+when it never fuses), a peek folds to a distill **unconditionally** (`309`)
+and a lone distill is emitted as a standalone `mapMulti` (`501`) that `711`
+cannot revert (the folded distill has dropped the SAM/instantiated types the
+revert needs). The gate guarantees a fusable neighbour, so a lone peek
+reference is left native — never pessimised.
 
 A reference that does **not** fuse (it followed a barrier, a stateful
 operator, or a `boxed()` roundtrip, or feeds a terminal) is restored to its

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/103-methodref-to-lambda.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/103-methodref-to-lambda.phr
@@ -1,0 +1,282 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Desugars an unbound-instance method reference feeding mapToInt / mapToLong /
+# mapToDouble (e.g. Integer::intValue, Long::doubleValue) into the lambda the
+# compiler could have emitted, so the rest of the pipeline — which only
+# recognises lambda$… targets (111) — picks it up with no special-casing. A
+# method-ref invokedynamic is byte-identical to a lambda's except its target
+# handle points straight at the referenced method; 111 rejects it solely
+# because the target name is not lambda$…. This rule synthesises a fresh
+# private-static-synthetic wrapper method whose body is exactly what
+# LambdaMetafactory would have generated, repoints the invokedynamic's target
+# handle at that wrapper (invokestatic THIS.lambda$hone$N with the instantiated
+# descriptor), and leaves everything else of the invokedynamic untouched. 111
+# then lifts the repointed indy normally and 205/451 fuse it.
+#
+# Two important restrictions keep this from pessimising code:
+#
+#   1. It fires only when the method-ref directly follows a pointwise object
+#      operator (map / filter / peek). Those are exactly the predecessors
+#      451 can fuse a trailing unbox into (an empty-state distill), so the
+#      synthesised wrapper is always consumed by a fusion. A method-ref after
+#      a barrier, a stateful distinct/skip, or a boxed() roundtrip is left
+#      native — desugaring it there would only add a wrapper that never fuses
+#      and reverts (a strict pessimisation), the same "do not pessimise a lone
+#      operator" stance as the 441/442 reverts.
+#
+#   2. It handles only the adaptation-free unbound-instance case: handle 5,
+#      the referenced method takes no arguments (the receiver is the single
+#      SAM parameter) and the SAM is a To{Int,Long,Double}Function, so the
+#      wrapper body is the straight line `aload 0; invokevirtual C.m (); Xreturn`
+#      with no receiver checkcast (the descriptor types the parameter) and no
+#      return adaptation (the referenced primitive return equals the SAM
+#      return). A single basic block needs no stackmap frames (see 511).
+#
+# Captured/bound refs, constructor refs (handle 8), interface targets (handle
+# 9), argument/return adaptation and static refs (handle 6) do not match and
+# stay native — those are follow-up puzzles.
+name: methodref-to-lambda
+pattern: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    version ↦ 𝑒-class-version,
+    access ↦ 𝑒-class-access,
+    modifiers ↦ 𝑒-class-modifiers,
+    name ↦ 𝑒-class,
+    supername ↦ 𝑒-class-supername,
+    interfaces ↦ 𝑒-class-interfaces,
+    𝐵-class-body-head,
+    𝜏-function ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 𝑒-method-access,
+      modifiers ↦ ⟦
+        𝐵-modifiers-before,
+        static ↦ Φ.true,
+        𝐵-modifiers-after
+      ⟧,
+      name ↦ 𝑒-function,
+      descriptor ↦ 𝑒-method-descriptor,
+      signature ↦ 𝑒-method-signature,
+      exceptions ↦ 𝑒-method-exceptions,
+      maxs ↦ 𝑒-method-maxs,
+      params ↦ 𝑒-method-params,
+      annotations ↦ 𝑒-annotations,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-predecessor ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          𝜏20 ↦ "java/util/stream/Stream",
+          𝜏22 ↦ 𝑒-predecessor-method,
+          𝜏23 ↦ 𝑒-predecessor-signature,
+          𝜏28 ↦ Φ.true,
+          ρ ↦ ∅
+        ⟧,
+        𝜏-invokedynamic ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokedynamic,
+          𝜏3 ↦ 𝑒-method,
+          𝜏4 ↦ 𝑒-interface,
+          𝜏5 ↦ ⟦
+            φ ↦ Φ.jeo.handle,
+            𝜏6 ↦ 6,
+            𝜏7 ↦ "java/lang/invoke/LambdaMetafactory",
+            𝜏8 ↦ "metafactory",
+            𝜏9 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+            𝜏10 ↦ Φ.false,
+            ρ ↦ ∅
+          ⟧,
+          𝜏11 ↦ ⟦
+            φ ↦ Φ.jeo.type,
+            𝜏12 ↦ 𝑒-lambda-signature,
+            ρ ↦ ∅
+          ⟧,
+          𝜏13 ↦ ⟦
+            φ ↦ Φ.jeo.handle,
+            𝜏14 ↦ 5,
+            𝜏15 ↦ 𝑒-target-class,
+            𝜏16 ↦ 𝑒-target-method,
+            𝜏17 ↦ 𝑒-target-signature,
+            𝜏18 ↦ Φ.false,
+            ρ ↦ ∅
+          ⟧,
+          𝜏19 ↦ ⟦
+            φ ↦ Φ.jeo.type,
+            𝜏21 ↦ 𝑒-bridge-signature,
+            ρ ↦ ∅
+          ⟧,
+          ρ ↦ ∅
+        ⟧,
+        𝜏-invokeinterface ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          𝜏24 ↦ 𝑒-stream-class,
+          𝜏25 ↦ 𝑒-stream-method,
+          𝜏26 ↦ 𝑒-stream-signature,
+          𝜏27 ↦ Φ.true,
+          ρ ↦ ∅
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝜏-trycatchblocks ↦ 𝑒-trycatchblocks,
+      local-variable-table ↦ 𝑒-lvt,
+      ρ ↦ ∅
+    ⟧,
+    𝐵-class-body-tail
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    version ↦ 𝑒-class-version,
+    access ↦ 𝑒-class-access,
+    modifiers ↦ 𝑒-class-modifiers,
+    name ↦ 𝑒-class,
+    supername ↦ 𝑒-class-supername,
+    interfaces ↦ 𝑒-class-interfaces,
+    𝐵-class-body-head,
+    𝜏-function ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 𝑒-method-access,
+      modifiers ↦ ⟦
+        𝐵-modifiers-before,
+        static ↦ Φ.true,
+        𝐵-modifiers-after
+      ⟧,
+      name ↦ 𝑒-function,
+      descriptor ↦ 𝑒-method-descriptor,
+      signature ↦ 𝑒-method-signature,
+      exceptions ↦ 𝑒-method-exceptions,
+      maxs ↦ 𝑒-method-maxs,
+      params ↦ 𝑒-method-params,
+      annotations ↦ 𝑒-annotations,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-predecessor ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          𝜏20 ↦ "java/util/stream/Stream",
+          𝜏22 ↦ 𝑒-predecessor-method,
+          𝜏23 ↦ 𝑒-predecessor-signature,
+          𝜏28 ↦ Φ.true,
+          ρ ↦ ∅
+        ⟧,
+        𝜏-invokedynamic ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokedynamic,
+          𝜏3 ↦ 𝑒-method,
+          𝜏4 ↦ 𝑒-interface,
+          𝜏5 ↦ ⟦
+            φ ↦ Φ.jeo.handle,
+            𝜏6 ↦ 6,
+            𝜏7 ↦ "java/lang/invoke/LambdaMetafactory",
+            𝜏8 ↦ "metafactory",
+            𝜏9 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+            𝜏10 ↦ Φ.false,
+            ρ ↦ ∅
+          ⟧,
+          𝜏11 ↦ ⟦
+            φ ↦ Φ.jeo.type,
+            𝜏12 ↦ 𝑒-lambda-signature,
+            ρ ↦ ∅
+          ⟧,
+          𝜏13 ↦ ⟦
+            φ ↦ Φ.jeo.handle,
+            𝜏14 ↦ 6,
+            𝜏15 ↦ 𝑒-class,
+            𝜏16 ↦ 𝑒-wrapper-name,
+            𝜏17 ↦ 𝑒-bridge-signature,
+            𝜏18 ↦ Φ.false,
+            ρ ↦ ∅
+          ⟧,
+          𝜏19 ↦ ⟦
+            φ ↦ Φ.jeo.type,
+            𝜏21 ↦ 𝑒-bridge-signature,
+            ρ ↦ ∅
+          ⟧,
+          ρ ↦ ∅
+        ⟧,
+        𝜏-invokeinterface ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          𝜏24 ↦ 𝑒-stream-class,
+          𝜏25 ↦ 𝑒-stream-method,
+          𝜏26 ↦ 𝑒-stream-signature,
+          𝜏27 ↦ Φ.true,
+          ρ ↦ ∅
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝜏-trycatchblocks ↦ 𝑒-trycatchblocks,
+      local-variable-table ↦ 𝑒-lvt,
+      ρ ↦ ∅
+    ⟧,
+    𝜏-wrapper ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 4106,
+      descriptor ↦ 𝑒-bridge-signature,
+      signature ↦ "",
+      maxs ↦ ⟦
+        φ ↦ Φ.jeo.maxs,
+        max-stack ↦ 𝑒-max-stack,
+        max-locals ↦ 1
+      ⟧,
+      params ↦ ⟦ φ ↦ Φ.jeo.params ⟧,
+      body ↦ ⟦
+        φ ↦ Φ.jeo.seq.of,
+        w-load ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 0 ⟧,
+        w-call ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokevirtual,
+          v0 ↦ 𝑒-target-class,
+          v1 ↦ 𝑒-target-method,
+          v2 ↦ 𝑒-target-signature,
+          v3 ↦ Φ.false
+        ⟧,
+        w-return ↦ ⟦ φ ↦ Φ.jeo.opcode.𝜏-return ⟧,
+        ρ ↦ ∅
+      ⟧,
+      name ↦ 𝑒-wrapper-name
+    ⟧,
+    𝐵-class-body-tail
+  ⟧
+when:
+  and:
+    - not:
+        matches:
+          - 'lambda\$.+'
+          - 𝑒-target-method
+    - or:
+        - eq: [𝑒-predecessor-method, '"map"']
+        - eq: [𝑒-predecessor-method, '"filter"']
+        - eq: [𝑒-predecessor-method, '"peek"']
+    - or:
+        - and:
+            - matches: ['\(\)Ljava/util/function/ToIntFunction;', 𝑒-interface]
+            - matches: ['\(\)I', 𝑒-target-signature]
+        - and:
+            - matches: ['\(\)Ljava/util/function/ToLongFunction;', 𝑒-interface]
+            - matches: ['\(\)J', 𝑒-target-signature]
+        - and:
+            - matches: ['\(\)Ljava/util/function/ToDoubleFunction;', 𝑒-interface]
+            - matches: ['\(\)D', 𝑒-target-signature]
+where:
+  - meta: 𝜏-wrapper
+    function: random-tau
+    args: ['𝐵-class-body-head', '𝐵-class-body-tail', '𝜏-function']
+  - meta: 𝑒-wrapper-name
+    function: random-string
+    args: ['"lambda$hone$%d"']
+  - meta: 𝑒-return-op
+    function: sed
+    args:
+      - 𝑒-target-signature
+      - '"s/^\\(\\)I$/ireturn/g"'
+      - '"s/^\\(\\)J$/lreturn/g"'
+      - '"s/^\\(\\)D$/dreturn/g"'
+  - meta: 𝜏-return
+    function: tau
+    args: [𝑒-return-op]
+  - meta: 𝑒-max-stack-str
+    function: sed
+    args:
+      - 𝑒-target-signature
+      - '"s/^\\(\\)[JD]$/2/g"'
+      - '"s/^\\(\\)I$/1/g"'
+  - meta: 𝑒-max-stack
+    function: number
+    args: [𝑒-max-stack-str]

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/104-static-methodref-to-lambda.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/104-static-methodref-to-lambda.phr
@@ -2,42 +2,24 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-# Desugars an unbound-instance method reference feeding mapToInt / mapToLong /
-# mapToDouble (e.g. Integer::intValue, Long::doubleValue) into the lambda the
-# compiler could have emitted, so the rest of the pipeline — which only
-# recognises lambda$… targets (111) — picks it up with no special-casing. A
-# method-ref invokedynamic is byte-identical to a lambda's except its target
-# handle points straight at the referenced method; 111 rejects it solely
-# because the target name is not lambda$…. This rule synthesises a fresh
-# private-static-synthetic wrapper method whose body is exactly what
-# LambdaMetafactory would have generated, repoints the invokedynamic's target
-# handle at that wrapper (invokestatic THIS.lambda$hone$N with the instantiated
-# descriptor), and leaves everything else of the invokedynamic untouched. 111
-# then lifts the repointed indy normally and 205/451 fuse it.
+# The static-method-reference twin of 103. A static method reference
+# (Integer::valueOf, X::keep, X::triple) compiles to an invokedynamic whose
+# target handle is kind 6 (invokestatic) pointing straight at the referenced
+# static method, so 111 leaves it native. This rule desugars it into the
+# lambda the compiler could have emitted: a private-static lambda$hone$N
+# wrapper that just forwards the argument to the referenced method, with the
+# invokedynamic repointed at the wrapper. 111 then lifts it; 205/451 fuse it
+# where a pointwise predecessor allows, otherwise 712 reverts it to the native
+# reference (so nothing is pessimised).
 #
-# Two important restrictions keep this from pessimising code:
-#
-#   1. It fires only when the method-ref directly follows a pointwise object
-#      operator (map / filter / peek). Those are exactly the predecessors
-#      451 can fuse a trailing unbox into (an empty-state distill), so the
-#      synthesised wrapper is always consumed by a fusion. A method-ref after
-#      a barrier, a stateful distinct/skip, or a boxed() roundtrip is left
-#      native — desugaring it there would only add a wrapper that never fuses
-#      and reverts (a strict pessimisation), the same "do not pessimise a lone
-#      operator" stance as the 441/442 reverts.
-#
-#   2. It handles only the adaptation-free unbound-instance case: handle 5,
-#      the referenced method takes no arguments (the receiver is the single
-#      SAM parameter) and the SAM is a To{Int,Long,Double}Function, so the
-#      wrapper body is the straight line `aload 0; invokevirtual C.m (); Xreturn`
-#      with no receiver checkcast (the descriptor types the parameter) and no
-#      return adaptation (the referenced primitive return equals the SAM
-#      return). A single basic block needs no stackmap frames (see 511).
-#
-# Captured/bound refs, constructor refs (handle 8), interface targets (handle
-# 9), argument/return adaptation and static refs (handle 6) do not match and
-# stay native — those are follow-up puzzles.
-name: methodref-to-lambda
+# It handles only the adaptation-free case: a SINGLE argument whose type the
+# referenced method accepts unchanged and whose return the SAM accepts
+# unchanged — i.e. the instantiated SAM type equals the target signature. The
+# wrapper body is the straight line `<load arg>; invokestatic C.m (arg)R;
+# Xreturn` (single basic block, no frames). Multi-argument refs (Integer::sum),
+# constructor refs and any boxing/widening adaptation do not match and stay
+# native; those are follow-up puzzles.
+name: static-methodref-to-lambda
 pattern: |
   ⟦
     φ ↦ Φ.jeo.class,
@@ -85,7 +67,7 @@ pattern: |
           ⟧,
           𝜏13 ↦ ⟦
             φ ↦ Φ.jeo.handle,
-            𝜏14 ↦ 5,
+            𝜏14 ↦ 6,
             𝜏15 ↦ 𝑒-target-class,
             𝜏16 ↦ 𝑒-target-method,
             𝜏17 ↦ 𝑒-target-signature,
@@ -198,14 +180,14 @@ result: |
       maxs ↦ ⟦
         φ ↦ Φ.jeo.maxs,
         max-stack ↦ 𝑒-max-stack,
-        max-locals ↦ 1
+        max-locals ↦ 𝑒-max-locals
       ⟧,
       params ↦ ⟦ φ ↦ Φ.jeo.params ⟧,
       body ↦ ⟦
         φ ↦ Φ.jeo.seq.of,
-        w-load ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 0 ⟧,
+        w-load ↦ ⟦ φ ↦ Φ.jeo.opcode.𝜏-load, v0 ↦ 0 ⟧,
         w-call ↦ ⟦
-          φ ↦ Φ.jeo.opcode.invokevirtual,
+          φ ↦ Φ.jeo.opcode.invokestatic,
           v0 ↦ 𝑒-target-class,
           v1 ↦ 𝑒-target-method,
           v2 ↦ 𝑒-target-signature,
@@ -226,21 +208,10 @@ when:
           - 'lambda\$.+'
           - 𝑒-target-method
     - matches: ['\(\).+', 𝑒-interface]
-    - matches: ['\(\).+', 𝑒-target-signature]
-    - matches: ['\(L[^;]*;\)', 𝑒-bridge-signature]
+    - eq: [𝑒-bridge-signature, 𝑒-target-signature]
     - or:
-        - and:
-            - matches: ['\(\)[IZBCS]', 𝑒-target-signature]
-            - matches: ['\)[IZBCS]', 𝑒-bridge-signature]
-        - and:
-            - matches: ['\(\)J', 𝑒-target-signature]
-            - matches: ['\)J', 𝑒-bridge-signature]
-        - and:
-            - matches: ['\(\)D', 𝑒-target-signature]
-            - matches: ['\)D', 𝑒-bridge-signature]
-        - and:
-            - matches: ['\(\)L', 𝑒-target-signature]
-            - matches: ['\)L', 𝑒-bridge-signature]
+        - matches: ['\(L[^;]*;\)', 𝑒-bridge-signature]
+        - matches: ['\(.\)', 𝑒-bridge-signature]
 where:
   - meta: 𝜏-wrapper
     function: random-tau
@@ -248,24 +219,59 @@ where:
   - meta: 𝑒-wrapper-name
     function: random-string
     args: ['"lambda$hone$%d"']
+  - meta: 𝑒-param
+    function: sed
+    args:
+      - 𝑒-bridge-signature
+      - '"s/\\((.*)\\).*/$1/g"'
+  - meta: 𝑒-return
+    function: sed
+    args:
+      - 𝑒-bridge-signature
+      - '"s/\\(.*\\)(.+)/$1/g"'
+  - meta: 𝑒-load-op
+    function: sed
+    args:
+      - 𝑒-param
+      - '"s/^[IZBCS]$/iload/g"'
+      - '"s/^J$/lload/g"'
+      - '"s/^D$/dload/g"'
+      - '"s/^F$/fload/g"'
+      - '"s/^(L.+;|\\[.+)$/aload/g"'
+  - meta: 𝜏-load
+    function: tau
+    args: [𝑒-load-op]
   - meta: 𝑒-return-op
     function: sed
     args:
-      - 𝑒-target-signature
-      - '"s/^\\(\\)[IZBCS]$/ireturn/g"'
-      - '"s/^\\(\\)J$/lreturn/g"'
-      - '"s/^\\(\\)D$/dreturn/g"'
-      - '"s/^\\(\\)L.*$/areturn/g"'
-      - '"s/^\\(\\)\\[.*$/areturn/g"'
+      - 𝑒-return
+      - '"s/^[IZBCS]$/ireturn/g"'
+      - '"s/^J$/lreturn/g"'
+      - '"s/^D$/dreturn/g"'
+      - '"s/^F$/freturn/g"'
+      - '"s/^(L.+;|\\[.+)$/areturn/g"'
   - meta: 𝜏-return
     function: tau
     args: [𝑒-return-op]
+  - meta: 𝑒-param-width
+    function: sed
+    args:
+      - 𝑒-param
+      - '"s/^[JD]$/2/g"'
+      - '"s/^[^2].*$/1/g"'
+  - meta: 𝑒-max-locals
+    function: number
+    args: [𝑒-param-width]
+  - meta: 𝑒-widths
+    function: concat
+    args: [𝑒-param-width, 𝑒-return]
   - meta: 𝑒-max-stack-str
     function: sed
     args:
-      - 𝑒-target-signature
-      - '"s/^\\(\\)[JD]$/2/g"'
-      - '"s/^\\(\\)[^JD].*$/1/g"'
+      - 𝑒-widths
+      - '"s/^2.*$/2/g"'
+      - '"s/^1[JD]$/2/g"'
+      - '"s/^1.*$/1/g"'
   - meta: 𝑒-max-stack
     function: number
     args: [𝑒-max-stack-str]

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/105-methodref-peek-to-lambda.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/105-methodref-peek-to-lambda.phr
@@ -1,0 +1,272 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Desugars an unbound-instance method reference feeding `.peek(...)` into the
+# lambda the compiler could have emitted, so the rest of the pipeline (which
+# only recognises lambda$… targets, 111) folds and fuses it like any peek
+# lambda. A peek's SAM is a Consumer, whose `accept` returns void; a reference
+# such as Integer::intValue returns a value, so javac points the invokedynamic
+# straight at the referenced method (handle 5) with an instantiated type of
+# `(L…;)V` and lets LambdaMetafactory DROP the return to fit void. 103 desugars
+# only the adaptation-free case and so leaves this one native; this rule is its
+# return-dropping twin: the synthesised wrapper is `aload 0; invoke C.m ()R;
+# pop|pop2; return` — the same forwarding LambdaMetafactory would generate,
+# discarding the result before the void return.
+#
+# Unlike 103's mapToX path — where an unfused unbox reverts to native via
+# 603/701/711 — a peek folds to a distill UNCONDITIONALLY (309) and a lone
+# distill is emitted as a standalone mapMulti (501), which a method reference
+# (whose native form synthesises no method) would be pessimised by, and which
+# 711 cannot revert (the folded distill has dropped the SAM/instantiated types
+# the revert needs). So this rule keeps 103's original predecessor gate: it
+# fires only when the reference directly follows a pointwise map / filter /
+# peek, which is exactly the neighbour 401 fuses it into. A peek reference with
+# no fusable predecessor is left native — no wrapper, no pessimisation, the
+# same "do not pessimise a lone operator" stance as the 441/442 reverts.
+#
+# It handles only the unbound-instance, single-object-parameter, value-return
+# case (handle 5, target `()R` with R not void): no receiver checkcast (the
+# instantiated type already names the parameter), no argument adaptation, just
+# the trailing pop. A single basic block needs no stackmap frames (see 511).
+# Captured/bound refs (System.out::println), static refs (handle 6) and any
+# argument adaptation stay native and are follow-up puzzles.
+name: methodref-peek-to-lambda
+pattern: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    version ↦ 𝑒-class-version,
+    access ↦ 𝑒-class-access,
+    modifiers ↦ 𝑒-class-modifiers,
+    name ↦ 𝑒-class,
+    supername ↦ 𝑒-class-supername,
+    interfaces ↦ 𝑒-class-interfaces,
+    𝐵-class-body-head,
+    𝜏-function ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 𝑒-method-access,
+      modifiers ↦ ⟦
+        𝐵-modifiers-before,
+        static ↦ Φ.true,
+        𝐵-modifiers-after
+      ⟧,
+      name ↦ 𝑒-function,
+      descriptor ↦ 𝑒-method-descriptor,
+      signature ↦ 𝑒-method-signature,
+      exceptions ↦ 𝑒-method-exceptions,
+      maxs ↦ 𝑒-method-maxs,
+      params ↦ 𝑒-method-params,
+      annotations ↦ 𝑒-annotations,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-predecessor ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          𝜏20 ↦ "java/util/stream/Stream",
+          𝜏22 ↦ 𝑒-predecessor-method,
+          𝜏23 ↦ 𝑒-predecessor-signature,
+          𝜏28 ↦ Φ.true,
+          ρ ↦ ∅
+        ⟧,
+        𝜏-invokedynamic ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokedynamic,
+          𝜏3 ↦ 𝑒-method,
+          𝜏4 ↦ 𝑒-interface,
+          𝜏5 ↦ ⟦
+            φ ↦ Φ.jeo.handle,
+            𝜏6 ↦ 6,
+            𝜏7 ↦ "java/lang/invoke/LambdaMetafactory",
+            𝜏8 ↦ "metafactory",
+            𝜏9 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+            𝜏10 ↦ Φ.false,
+            ρ ↦ ∅
+          ⟧,
+          𝜏11 ↦ ⟦
+            φ ↦ Φ.jeo.type,
+            𝜏12 ↦ 𝑒-lambda-signature,
+            ρ ↦ ∅
+          ⟧,
+          𝜏13 ↦ ⟦
+            φ ↦ Φ.jeo.handle,
+            𝜏14 ↦ 5,
+            𝜏15 ↦ 𝑒-target-class,
+            𝜏16 ↦ 𝑒-target-method,
+            𝜏17 ↦ 𝑒-target-signature,
+            𝜏18 ↦ Φ.false,
+            ρ ↦ ∅
+          ⟧,
+          𝜏19 ↦ ⟦
+            φ ↦ Φ.jeo.type,
+            𝜏21 ↦ 𝑒-bridge-signature,
+            ρ ↦ ∅
+          ⟧,
+          ρ ↦ ∅
+        ⟧,
+        𝜏-invokeinterface ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          𝜏24 ↦ 𝑒-stream-class,
+          𝜏25 ↦ 𝑒-stream-method,
+          𝜏26 ↦ 𝑒-stream-signature,
+          𝜏27 ↦ Φ.true,
+          ρ ↦ ∅
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝜏-trycatchblocks ↦ 𝑒-trycatchblocks,
+      local-variable-table ↦ 𝑒-lvt,
+      ρ ↦ ∅
+    ⟧,
+    𝐵-class-body-tail
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    version ↦ 𝑒-class-version,
+    access ↦ 𝑒-class-access,
+    modifiers ↦ 𝑒-class-modifiers,
+    name ↦ 𝑒-class,
+    supername ↦ 𝑒-class-supername,
+    interfaces ↦ 𝑒-class-interfaces,
+    𝐵-class-body-head,
+    𝜏-function ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 𝑒-method-access,
+      modifiers ↦ ⟦
+        𝐵-modifiers-before,
+        static ↦ Φ.true,
+        𝐵-modifiers-after
+      ⟧,
+      name ↦ 𝑒-function,
+      descriptor ↦ 𝑒-method-descriptor,
+      signature ↦ 𝑒-method-signature,
+      exceptions ↦ 𝑒-method-exceptions,
+      maxs ↦ 𝑒-method-maxs,
+      params ↦ 𝑒-method-params,
+      annotations ↦ 𝑒-annotations,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-predecessor ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          𝜏20 ↦ "java/util/stream/Stream",
+          𝜏22 ↦ 𝑒-predecessor-method,
+          𝜏23 ↦ 𝑒-predecessor-signature,
+          𝜏28 ↦ Φ.true,
+          ρ ↦ ∅
+        ⟧,
+        𝜏-invokedynamic ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokedynamic,
+          𝜏3 ↦ 𝑒-method,
+          𝜏4 ↦ 𝑒-interface,
+          𝜏5 ↦ ⟦
+            φ ↦ Φ.jeo.handle,
+            𝜏6 ↦ 6,
+            𝜏7 ↦ "java/lang/invoke/LambdaMetafactory",
+            𝜏8 ↦ "metafactory",
+            𝜏9 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+            𝜏10 ↦ Φ.false,
+            ρ ↦ ∅
+          ⟧,
+          𝜏11 ↦ ⟦
+            φ ↦ Φ.jeo.type,
+            𝜏12 ↦ 𝑒-lambda-signature,
+            ρ ↦ ∅
+          ⟧,
+          𝜏13 ↦ ⟦
+            φ ↦ Φ.jeo.handle,
+            𝜏14 ↦ 6,
+            𝜏15 ↦ 𝑒-class,
+            𝜏16 ↦ 𝑒-wrapper-name,
+            𝜏17 ↦ 𝑒-bridge-signature,
+            𝜏18 ↦ Φ.false,
+            ρ ↦ ∅
+          ⟧,
+          𝜏19 ↦ ⟦
+            φ ↦ Φ.jeo.type,
+            𝜏21 ↦ 𝑒-bridge-signature,
+            ρ ↦ ∅
+          ⟧,
+          ρ ↦ ∅
+        ⟧,
+        𝜏-invokeinterface ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          𝜏24 ↦ 𝑒-stream-class,
+          𝜏25 ↦ 𝑒-stream-method,
+          𝜏26 ↦ 𝑒-stream-signature,
+          𝜏27 ↦ Φ.true,
+          ρ ↦ ∅
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝜏-trycatchblocks ↦ 𝑒-trycatchblocks,
+      local-variable-table ↦ 𝑒-lvt,
+      ρ ↦ ∅
+    ⟧,
+    𝜏-wrapper ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 4106,
+      descriptor ↦ 𝑒-bridge-signature,
+      signature ↦ "",
+      maxs ↦ ⟦
+        φ ↦ Φ.jeo.maxs,
+        max-stack ↦ 𝑒-max-stack,
+        max-locals ↦ 1
+      ⟧,
+      params ↦ ⟦ φ ↦ Φ.jeo.params ⟧,
+      body ↦ ⟦
+        φ ↦ Φ.jeo.seq.of,
+        w-load ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 0 ⟧,
+        w-call ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokevirtual,
+          v0 ↦ 𝑒-target-class,
+          v1 ↦ 𝑒-target-method,
+          v2 ↦ 𝑒-target-signature,
+          v3 ↦ Φ.false,
+          origin ↦ Φ.true
+        ⟧,
+        w-drop ↦ ⟦ φ ↦ Φ.jeo.opcode.𝜏-drop ⟧,
+        w-return ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+        ρ ↦ ∅
+      ⟧,
+      name ↦ 𝑒-wrapper-name
+    ⟧,
+    𝐵-class-body-tail
+  ⟧
+when:
+  and:
+    - not:
+        matches:
+          - 'lambda\$.+'
+          - 𝑒-target-method
+    - or:
+        - eq: [𝑒-predecessor-method, '"map"']
+        - eq: [𝑒-predecessor-method, '"filter"']
+        - eq: [𝑒-predecessor-method, '"peek"']
+    - matches: ['\(\)Ljava/util/function/Consumer;', 𝑒-interface]
+    - matches: ['\(L[^;]*;\)V', 𝑒-bridge-signature]
+    - matches: ['\(\).+', 𝑒-target-signature]
+    - not:
+        matches: ['\(\)V', 𝑒-target-signature]
+where:
+  - meta: 𝜏-wrapper
+    function: random-tau
+    args: ['𝐵-class-body-head', '𝐵-class-body-tail', '𝜏-function']
+  - meta: 𝑒-wrapper-name
+    function: random-string
+    args: ['"lambda$hone$%d"']
+  - meta: 𝑒-drop-op
+    function: sed
+    args:
+      - 𝑒-target-signature
+      - '"s/^\\(\\)[JD]$/pop2/g"'
+      - '"s/^\\(\\).*$/pop/g"'
+  - meta: 𝜏-drop
+    function: tau
+    args: [𝑒-drop-op]
+  - meta: 𝑒-max-stack-str
+    function: sed
+    args:
+      - 𝑒-target-signature
+      - '"s/^\\(\\)[JD]$/2/g"'
+      - '"s/^\\(\\).*$/1/g"'
+  - meta: 𝑒-max-stack
+    function: number
+    args: [𝑒-max-stack-str]

--- a/src/main/resources/org/eolang/hone/rules/streams/7xx/711-revert-unfused-methodref.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/7xx/711-revert-unfused-methodref.phr
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Reverts a method-reference wrapper that never fused back to the original
+# native method reference, so desugaring a reference (103) never pessimises
+# code that the pipeline could not optimise. 103 turns `Stream…mapToInt(
+# Integer::intValue)` into an invokedynamic pointing at a synthesised
+# lambda$hone$N wrapper; when that wrapper fuses into a distill it is inlined
+# and the invokedynamic disappears, but when it does NOT fuse the 6xx/7xx
+# unrecognise pass lowers it straight back to `invokedynamic → lambda$hone$N`,
+# leaving an extra wrapper method and an extra call frame that the original
+# native reference never had.
+#
+# This rule runs after the lambdas are lowered (701/702). It matches a class
+# in which an invokedynamic still targets a lambda$hone$N wrapper AND that
+# wrapper is still present, recovers the referenced method from the wrapper's
+# origin-marked call opcode, repoints the invokedynamic's target handle at it
+# (handle 5, invokevirtual — the only kind 103 currently produces) and drops
+# the now-unused wrapper. The result is byte-identical to the method reference
+# javac emitted. The `origin ↦ Φ.true` marker on the wrapper's call opcode is
+# what tells a HONE wrapper apart from a real javac lambda$… method and locates
+# the referenced target; jeo ignores the extra binding (see 441's `reverted`).
+# A fused wrapper is never matched here — its invokedynamic is gone and the
+# wrapper is reached only through an invokestatic inside the distill method.
+name: revert-unfused-methodref
+pattern: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    𝐵-class-head,
+    𝜏-function ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      𝐵-method-head,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-invokedynamic ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokedynamic,
+          𝜏3 ↦ 𝑒-sam-method,
+          𝜏4 ↦ 𝑒-interface,
+          𝜏5 ↦ 𝑒-bootstrap,
+          𝜏11 ↦ 𝑒-sam-type,
+          𝜏13 ↦ ⟦
+            φ ↦ Φ.jeo.handle,
+            𝜏14 ↦ 6,
+            𝜏15 ↦ 𝑒-class,
+            𝜏16 ↦ 𝑒-wrapper-name,
+            𝜏17 ↦ 𝑒-wrapper-descriptor,
+            𝜏18 ↦ Φ.false,
+            ρ ↦ ∅
+          ⟧,
+          𝜏19 ↦ 𝑒-instantiated-type,
+          ρ ↦ ∅
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝐵-method-tail
+    ⟧,
+    𝐵-class-mid,
+    𝜏-wrapper ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      𝐵-wrapper-head,
+      body ↦ ⟦
+        𝐵-wrapper-body-head,
+        𝜏-origin ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokevirtual,
+          v0 ↦ 𝑒-origin-class,
+          v1 ↦ 𝑒-origin-method,
+          v2 ↦ 𝑒-origin-signature,
+          v3 ↦ 𝑒-origin-is-interface,
+          origin ↦ Φ.true,
+          ρ ↦ ∅
+        ⟧,
+        𝐵-wrapper-body-tail
+      ⟧,
+      name ↦ 𝑒-wrapper-name,
+      ρ ↦ ∅
+    ⟧,
+    𝐵-class-tail
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    𝐵-class-head,
+    𝜏-function ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      𝐵-method-head,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-invokedynamic ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokedynamic,
+          𝜏3 ↦ 𝑒-sam-method,
+          𝜏4 ↦ 𝑒-interface,
+          𝜏5 ↦ 𝑒-bootstrap,
+          𝜏11 ↦ 𝑒-sam-type,
+          𝜏13 ↦ ⟦
+            φ ↦ Φ.jeo.handle,
+            𝜏14 ↦ 5,
+            𝜏15 ↦ 𝑒-origin-class,
+            𝜏16 ↦ 𝑒-origin-method,
+            𝜏17 ↦ 𝑒-origin-signature,
+            𝜏18 ↦ 𝑒-origin-is-interface,
+            ρ ↦ ∅
+          ⟧,
+          𝜏19 ↦ 𝑒-instantiated-type,
+          ρ ↦ ∅
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝐵-method-tail
+    ⟧,
+    𝐵-class-mid,
+    𝐵-class-tail
+  ⟧

--- a/src/main/resources/org/eolang/hone/rules/streams/7xx/712-revert-unfused-static-methodref.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/7xx/712-revert-unfused-static-methodref.phr
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Reverts a method-reference wrapper that never fused back to the original
+# native method reference, so desugaring a reference (103) never pessimises
+# code that the pipeline could not optimise. 103 turns `Stream…mapToInt(
+# Integer::intValue)` into an invokedynamic pointing at a synthesised
+# lambda$hone$N wrapper; when that wrapper fuses into a distill it is inlined
+# and the invokedynamic disappears, but when it does NOT fuse the 6xx/7xx
+# unrecognise pass lowers it straight back to `invokedynamic → lambda$hone$N`,
+# leaving an extra wrapper method and an extra call frame that the original
+# native reference never had.
+#
+# This rule runs after the lambdas are lowered (701/702). It matches a class
+# in which an invokedynamic still targets a lambda$hone$N wrapper AND that
+# wrapper is still present, recovers the referenced method from the wrapper's
+# origin-marked call opcode, repoints the invokedynamic's target handle at it
+# (handle 5, invokevirtual — the only kind 103 currently produces) and drops
+# the now-unused wrapper. The result is byte-identical to the method reference
+# javac emitted. The `origin ↦ Φ.true` marker on the wrapper's call opcode is
+# what tells a HONE wrapper apart from a real javac lambda$… method and locates
+# the referenced target; jeo ignores the extra binding (see 441's `reverted`).
+# A fused wrapper is never matched here — its invokedynamic is gone and the
+# wrapper is reached only through an invokestatic inside the distill method.
+name: revert-unfused-static-methodref
+pattern: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    𝐵-class-head,
+    𝜏-function ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      𝐵-method-head,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-invokedynamic ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokedynamic,
+          𝜏3 ↦ 𝑒-sam-method,
+          𝜏4 ↦ 𝑒-interface,
+          𝜏5 ↦ 𝑒-bootstrap,
+          𝜏11 ↦ 𝑒-sam-type,
+          𝜏13 ↦ ⟦
+            φ ↦ Φ.jeo.handle,
+            𝜏14 ↦ 6,
+            𝜏15 ↦ 𝑒-class,
+            𝜏16 ↦ 𝑒-wrapper-name,
+            𝜏17 ↦ 𝑒-wrapper-descriptor,
+            𝜏18 ↦ Φ.false,
+            ρ ↦ ∅
+          ⟧,
+          𝜏19 ↦ 𝑒-instantiated-type,
+          ρ ↦ ∅
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝐵-method-tail
+    ⟧,
+    𝐵-class-mid,
+    𝜏-wrapper ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      𝐵-wrapper-head,
+      body ↦ ⟦
+        𝐵-wrapper-body-head,
+        𝜏-origin ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokestatic,
+          v0 ↦ 𝑒-origin-class,
+          v1 ↦ 𝑒-origin-method,
+          v2 ↦ 𝑒-origin-signature,
+          v3 ↦ 𝑒-origin-is-interface,
+          origin ↦ Φ.true,
+          ρ ↦ ∅
+        ⟧,
+        𝐵-wrapper-body-tail
+      ⟧,
+      name ↦ 𝑒-wrapper-name,
+      ρ ↦ ∅
+    ⟧,
+    𝐵-class-tail
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    𝐵-class-head,
+    𝜏-function ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      𝐵-method-head,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-invokedynamic ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokedynamic,
+          𝜏3 ↦ 𝑒-sam-method,
+          𝜏4 ↦ 𝑒-interface,
+          𝜏5 ↦ 𝑒-bootstrap,
+          𝜏11 ↦ 𝑒-sam-type,
+          𝜏13 ↦ ⟦
+            φ ↦ Φ.jeo.handle,
+            𝜏14 ↦ 6,
+            𝜏15 ↦ 𝑒-origin-class,
+            𝜏16 ↦ 𝑒-origin-method,
+            𝜏17 ↦ 𝑒-origin-signature,
+            𝜏18 ↦ 𝑒-origin-is-interface,
+            ρ ↦ ∅
+          ⟧,
+          𝜏19 ↦ 𝑒-instantiated-type,
+          ρ ↦ ∅
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝐵-method-tail
+    ⟧,
+    𝐵-class-mid,
+    𝐵-class-tail
+  ⟧

--- a/src/test/phino/103-methodref-to-lambda.yml
+++ b/src/test/phino/103-methodref-to-lambda.yml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A method-reference mapToInt (Integer::intValue) that directly follows a
+# pointwise object operator (.map here) is desugared into a lambda: a fresh
+# private-static lambda$hone$N wrapper is synthesised (its body is the
+# unboxing `aload 0; invokevirtual Integer.intValue (); ireturn` the
+# LambdaMetafactory would have generated) and the invokedynamic's target
+# handle is repointed at it (invokestatic THIS.lambda$hone$N). After this 111
+# lifts it like any javac lambda. The first match asserts the wrapper body was
+# synthesised (it introduces the only Φ.jeo.opcode.invokevirtual on
+# Integer.intValue); the second asserts the target handle now points at THIS
+# class "T" (before the rule it pointed at "java/lang/Integer").
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/1xx/103-methodref-to-lambda.phr
+input: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    version ↦ 68,
+    access ↦ 33,
+    modifiers ↦ ⟦ φ ↦ Φ.jeo.modifiers, public ↦ Φ.true ⟧,
+    name ↦ "T",
+    supername ↦ "java/lang/Object",
+    interfaces ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+    m ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 9,
+      modifiers ↦ ⟦ φ ↦ Φ.jeo.modifiers, static ↦ Φ.true ⟧,
+      name ↦ "m",
+      descriptor ↦ "()V",
+      signature ↦ "",
+      exceptions ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, max-stack ↦ 2, max-locals ↦ 1 ⟧,
+      params ↦ ⟦ φ ↦ Φ.jeo.params ⟧,
+      annotations ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      body ↦ ⟦
+        φ ↦ Φ.jeo.seq.of,
+        p ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "map", v2 ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;", v3 ↦ Φ.true ⟧,
+        d ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokedynamic,
+          v0 ↦ "applyAsInt",
+          v1 ↦ "()Ljava/util/function/ToIntFunction;",
+          h2 ↦ ⟦ φ ↦ Φ.jeo.handle, v0 ↦ 6, v1 ↦ "java/lang/invoke/LambdaMetafactory", v2 ↦ "metafactory", v3 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;", v4 ↦ Φ.false ⟧,
+          t3 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Object;)I" ⟧,
+          h4 ↦ ⟦ φ ↦ Φ.jeo.handle, v0 ↦ 5, v1 ↦ "java/lang/Integer", v2 ↦ "intValue", v3 ↦ "()I", v4 ↦ Φ.false ⟧,
+          t5 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Integer;)I" ⟧
+        ⟧,
+        i ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "mapToInt", v2 ↦ "(Ljava/util/function/ToIntFunction;)Ljava/util/stream/IntStream;", v3 ↦ Φ.true ⟧
+      ⟧,
+      trycatchblocks ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      local-variable-table ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
+    ⟧
+  ⟧
+expected:
+  - ⟦ 𝐵-x, φ ↦ Φ.jeo.opcode.invokevirtual, 𝐵-y, 𝜏-m ↦ "intValue", 𝐵-z ⟧
+  - ⟦ 𝐵-a, φ ↦ Φ.jeo.handle, 𝐵-b, 𝜏-c ↦ "T", 𝐵-d ⟧

--- a/src/test/phino/105-methodref-peek-to-lambda.yml
+++ b/src/test/phino/105-methodref-peek-to-lambda.yml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A method-reference peek (Integer::intValue) that directly follows a pointwise
+# object operator (.map here) is desugared into a lambda. Because peek's SAM is
+# a Consumer (void return) and intValue returns int, the synthesised
+# private-static lambda$hone$N wrapper must DROP the return: its body is
+# `aload 0; invokevirtual Integer.intValue (); pop; return`. The invokedynamic's
+# target handle is repointed at the wrapper (invokestatic THIS.lambda$hone$N).
+# The first match asserts the wrapper introduced the only Φ.jeo.opcode.pop (the
+# return-drop); the second asserts the origin-marked invokevirtual on intValue
+# was synthesised; the third asserts the target handle now points at THIS class
+# "T" (before the rule it pointed at "java/lang/Integer").
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/1xx/105-methodref-peek-to-lambda.phr
+input: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    version ↦ 68,
+    access ↦ 33,
+    modifiers ↦ ⟦ φ ↦ Φ.jeo.modifiers, public ↦ Φ.true ⟧,
+    name ↦ "T",
+    supername ↦ "java/lang/Object",
+    interfaces ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+    m ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 9,
+      modifiers ↦ ⟦ φ ↦ Φ.jeo.modifiers, static ↦ Φ.true ⟧,
+      name ↦ "m",
+      descriptor ↦ "()V",
+      signature ↦ "",
+      exceptions ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, max-stack ↦ 2, max-locals ↦ 1 ⟧,
+      params ↦ ⟦ φ ↦ Φ.jeo.params ⟧,
+      annotations ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      body ↦ ⟦
+        φ ↦ Φ.jeo.seq.of,
+        p ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "map", v2 ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;", v3 ↦ Φ.true ⟧,
+        d ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokedynamic,
+          v0 ↦ "accept",
+          v1 ↦ "()Ljava/util/function/Consumer;",
+          h2 ↦ ⟦ φ ↦ Φ.jeo.handle, v0 ↦ 6, v1 ↦ "java/lang/invoke/LambdaMetafactory", v2 ↦ "metafactory", v3 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;", v4 ↦ Φ.false ⟧,
+          t3 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Object;)V" ⟧,
+          h4 ↦ ⟦ φ ↦ Φ.jeo.handle, v0 ↦ 5, v1 ↦ "java/lang/Integer", v2 ↦ "intValue", v3 ↦ "()I", v4 ↦ Φ.false ⟧,
+          t5 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Integer;)V" ⟧
+        ⟧,
+        i ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "peek", v2 ↦ "(Ljava/util/function/Consumer;)Ljava/util/stream/Stream;", v3 ↦ Φ.true ⟧
+      ⟧,
+      trycatchblocks ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      local-variable-table ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
+    ⟧
+  ⟧
+expected:
+  - ⟦ φ ↦ Φ.jeo.opcode.pop ⟧
+  - ⟦ 𝐵-x, φ ↦ Φ.jeo.opcode.invokevirtual, 𝐵-y, 𝜏-m ↦ "intValue", 𝐵-z ⟧
+  - ⟦ 𝐵-a, φ ↦ Φ.jeo.handle, 𝐵-b, 𝜏-c ↦ "T", 𝐵-d ⟧

--- a/src/test/phino/711-revert-unfused-methodref.yml
+++ b/src/test/phino/711-revert-unfused-methodref.yml
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A method-reference wrapper (lambda$hone$1) that never fused is reverted to
+# the native reference: the invokedynamic that still targets the wrapper is
+# repointed at the referenced method (read from the wrapper's origin-marked
+# invokevirtual — java/lang/Integer.intValue, handle 5) and the wrapper method
+# is dropped. The assertion checks the invokedynamic's target handle now names
+# java/lang/Integer (before the rule the only handle to that class was inside
+# the wrapper body as an opcode, not a Φ.jeo.handle), proving the repoint.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/7xx/711-revert-unfused-methodref.phr
+input: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    version ↦ 68,
+    access ↦ 33,
+    modifiers ↦ ⟦ φ ↦ Φ.jeo.modifiers, public ↦ Φ.true ⟧,
+    name ↦ "T",
+    supername ↦ "java/lang/Object",
+    interfaces ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+    m ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 9,
+      modifiers ↦ ⟦ φ ↦ Φ.jeo.modifiers, static ↦ Φ.true ⟧,
+      name ↦ "m",
+      descriptor ↦ "()V",
+      signature ↦ "",
+      exceptions ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, max-stack ↦ 1, max-locals ↦ 0 ⟧,
+      params ↦ ⟦ φ ↦ Φ.jeo.params ⟧,
+      annotations ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      body ↦ ⟦
+        φ ↦ Φ.jeo.seq.of,
+        d ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokedynamic,
+          v0 ↦ "applyAsInt",
+          v1 ↦ "()Ljava/util/function/ToIntFunction;",
+          h2 ↦ ⟦ φ ↦ Φ.jeo.handle, v0 ↦ 6, v1 ↦ "java/lang/invoke/LambdaMetafactory", v2 ↦ "metafactory", v3 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;", v4 ↦ Φ.false ⟧,
+          t3 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Object;)I" ⟧,
+          h4 ↦ ⟦ φ ↦ Φ.jeo.handle, v0 ↦ 6, v1 ↦ "T", v2 ↦ "lambda$hone$1", v3 ↦ "(Ljava/lang/Integer;)I", v4 ↦ Φ.false ⟧,
+          t5 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Integer;)I" ⟧
+        ⟧
+      ⟧,
+      trycatchblocks ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      local-variable-table ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
+    ⟧,
+    w ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 4106,
+      descriptor ↦ "(Ljava/lang/Integer;)I",
+      signature ↦ "",
+      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, max-stack ↦ 1, max-locals ↦ 1 ⟧,
+      params ↦ ⟦ φ ↦ Φ.jeo.params ⟧,
+      body ↦ ⟦
+        φ ↦ Φ.jeo.seq.of,
+        w-load ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 0 ⟧,
+        w-call ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, v0 ↦ "java/lang/Integer", v1 ↦ "intValue", v2 ↦ "()I", v3 ↦ Φ.false, origin ↦ Φ.true ⟧,
+        w-return ↦ ⟦ φ ↦ Φ.jeo.opcode.ireturn ⟧
+      ⟧,
+      name ↦ "lambda$hone$1"
+    ⟧
+  ⟧
+expected:
+  - ⟦ 𝐵-a, φ ↦ Φ.jeo.handle, 𝐵-b, 𝜏-c ↦ "java/lang/Integer", 𝐵-d ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams-fusion.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-fusion.yml
@@ -9,7 +9,10 @@
 #   mapped : a chain of .map().filter().map().map().mapToInt().sum() --
 #            every operator on the stateless point-wise path; the
 #            collapsed body should leave one mapMulti and one
-#            mapToInt+sum dispatch.
+#            mapToInt+sum dispatch. Two of its operators are method
+#            references -- X::addOne is a static ref (desugared by 104)
+#            and Integer::intValue an unbound-instance ref (103) -- so a
+#            mix of refs and lambdas must fuse together.
 #   sorted : .map().sorted(Comparator) -- sorted is a fundamental
 #            non-fusable barrier; the Comparator handle must survive.
 #            See issue #549.
@@ -24,12 +27,15 @@ java: |
   import java.util.*;
   import java.util.stream.*;
   public class X {
+    static Integer addOne(Integer n) {
+      return n + 1;
+    }
     public static void main(String[] a) {
       long peeked = Stream.of(1, 2, 3, 4, 5)
         .map(n -> n + 1).peek(n -> {}).count();
       int mapped = Arrays.asList(1, 2, 3, 4).stream()
         .map(n -> n * 2).filter(n -> n % 2 == 0)
-        .map(n -> n + 1).map(n -> n + 2)
+        .map(X::addOne).map(n -> n + 2)
         .mapToInt(Integer::intValue).sum();
       long sorted = Stream.of(5, 3, 8, 1, 4)
         .map(n -> n + 1).sorted((x, y) -> y - x).count();

--- a/src/test/resources/org/eolang/hone/optimize/streams-maptoint-methodref.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-maptoint-methodref.yml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A trailing mapToInt whose mapper is a METHOD REFERENCE (Integer::intValue),
+# the canonical idiom, must fuse into the preceding object pipeline exactly as
+# the lambda form (n -> n.intValue()) already does. A method reference points
+# its invokedynamic target handle straight at the referenced method, so 111
+# (which only lifts lambda$… targets) leaves it native. 103-methodref-to-lambda
+# desugars it first: it synthesises a private-static lambda$hone$N wrapper whose
+# body performs the unboxing the LambdaMetafactory would have generated and
+# repoints the invokedynamic at it, after which 111 / 205 / 451 lower the whole
+# map + mapToInt chain to a single Stream.mapMultiToInt dispatch.
+#
+# 103 fires only when the method reference directly follows a pointwise object
+# operator (here .map), where 451 can fuse the resulting unbox; that drops the
+# two invokedynamic factories (map + mapToInt) to one.
+java: |
+  package methodref;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      int r = Stream.of(5, 3, 8, 5, 2, 7, 4, 1, 6, 9)
+        .map(n -> n + 1)
+        .mapToInt(Integer::intValue)
+        .sum();
+      System.out.printf("The result is %d\n", r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 60"
+before:
+  invokedynamic: 2
+after:
+  invokedynamic: 1

--- a/src/test/resources/org/eolang/hone/optimize/streams-maptoint-methodref.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-maptoint-methodref.yml
@@ -2,30 +2,32 @@
 # SPDX-License-Identifier: MIT
 ---
 # A pipeline whose mappers are METHOD REFERENCES, the canonical idiom, must
-# fuse exactly as the lambda forms (n -> n.intValue(), o -> o.toString(),
-# s -> s.length()) already do. A method reference points its invokedynamic
-# target handle straight at the referenced method, so 111 (which only lifts
-# lambda$… targets) leaves it native. 103-methodref-to-lambda desugars each
-# one first: it synthesises a private-static lambda$hone$N wrapper whose body
-# is the forwarding the LambdaMetafactory would have generated and repoints the
-# invokedynamic at it, after which 111 / 205 / 451 lower the chain to a single
-# Stream.mapMultiToInt dispatch.
+# fuse exactly as the lambda forms (X.plusOne(n), o.toString(), s.length())
+# would. A method reference points its invokedynamic target handle straight at
+# the referenced method, so 111 (which only lifts lambda$… targets) leaves it
+# native. The 1xx desugaring rules rewrite each one first: they synthesise a
+# private-static lambda$hone$N wrapper whose body is the forwarding the
+# LambdaMetafactory would have generated and repoint the invokedynamic at it,
+# after which 111 / 205 / 451 lower the chain to a single Stream.mapMultiToInt
+# dispatch.
 #
-# Both references here are UNBOUND-INSTANCE (handle 5, the method runs on each
-# element), which is what 103 handles — Object::toString in an object .map
-# (Integer -> String) and String::length in the trailing mapToInt
-# (String -> int). Static references (Integer::valueOf) are a different handle
-# kind (6) and a different rule (104). 103 fires only when the reference
-# directly follows a pointwise object operator (here .map), where 451 can fuse
-# the resulting unbox; that drops the three invokedynamic factories (two maps
-# and the mapToInt) to one.
+# The chain mixes both reference kinds, so it exercises both desugaring rules:
+# X::plusOne is a STATIC reference (handle 6, the element is an argument), which
+# 104 handles, while Object::toString and String::length are UNBOUND-INSTANCE
+# references (handle 5, the method runs on each element), which 103 handles. All
+# three fuse: the static map and the object map collapse together and 451 folds
+# the trailing String::length unbox onto them, dropping the three invokedynamic
+# factories (two maps and the mapToInt) to one.
 java: |
   package methodref;
   import java.util.stream.Stream;
   public class X {
+    static Integer plusOne(Integer n) {
+      return n + 1;
+    }
     public static void main(String[] a) {
       int r = Stream.of(5, 3, 8, 5, 2, 7, 4, 1, 6, 9)
-        .map(n -> n + 1)
+        .map(X::plusOne)
         .map(Object::toString)
         .mapToInt(String::length)
         .sum();

--- a/src/test/resources/org/eolang/hone/optimize/streams-maptoint-methodref.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-maptoint-methodref.yml
@@ -1,19 +1,24 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
-# A trailing mapToInt whose mapper is a METHOD REFERENCE (Integer::intValue),
-# the canonical idiom, must fuse into the preceding object pipeline exactly as
-# the lambda form (n -> n.intValue()) already does. A method reference points
-# its invokedynamic target handle straight at the referenced method, so 111
-# (which only lifts lambda$… targets) leaves it native. 103-methodref-to-lambda
-# desugars it first: it synthesises a private-static lambda$hone$N wrapper whose
-# body performs the unboxing the LambdaMetafactory would have generated and
-# repoints the invokedynamic at it, after which 111 / 205 / 451 lower the whole
-# map + mapToInt chain to a single Stream.mapMultiToInt dispatch.
+# A pipeline whose mappers are METHOD REFERENCES, the canonical idiom, must
+# fuse exactly as the lambda forms (n -> n.intValue(), o -> o.toString(),
+# s -> s.length()) already do. A method reference points its invokedynamic
+# target handle straight at the referenced method, so 111 (which only lifts
+# lambda$… targets) leaves it native. 103-methodref-to-lambda desugars each
+# one first: it synthesises a private-static lambda$hone$N wrapper whose body
+# is the forwarding the LambdaMetafactory would have generated and repoints the
+# invokedynamic at it, after which 111 / 205 / 451 lower the chain to a single
+# Stream.mapMultiToInt dispatch.
 #
-# 103 fires only when the method reference directly follows a pointwise object
-# operator (here .map), where 451 can fuse the resulting unbox; that drops the
-# two invokedynamic factories (map + mapToInt) to one.
+# Both references here are UNBOUND-INSTANCE (handle 5, the method runs on each
+# element), which is what 103 handles — Object::toString in an object .map
+# (Integer -> String) and String::length in the trailing mapToInt
+# (String -> int). Static references (Integer::valueOf) are a different handle
+# kind (6) and a different rule (104). 103 fires only when the reference
+# directly follows a pointwise object operator (here .map), where 451 can fuse
+# the resulting unbox; that drops the three invokedynamic factories (two maps
+# and the mapToInt) to one.
 java: |
   package methodref;
   import java.util.stream.Stream;
@@ -21,7 +26,8 @@ java: |
     public static void main(String[] a) {
       int r = Stream.of(5, 3, 8, 5, 2, 7, 4, 1, 6, 9)
         .map(n -> n + 1)
-        .mapToInt(Integer::intValue)
+        .map(Object::toString)
+        .mapToInt(String::length)
         .sum();
       System.out.printf("The result is %d\n", r);
     }
@@ -30,8 +36,8 @@ log:
   - "Modified 1/1 X.phi"
   - "Finished rewriting 1 file"
   - "BUILD SUCCESS"
-  - "The result is 60"
+  - "The result is 11"
 before:
-  invokedynamic: 2
+  invokedynamic: 3
 after:
   invokedynamic: 1

--- a/src/test/resources/org/eolang/hone/optimize/streams-peek.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-peek.yml
@@ -6,12 +6,26 @@
 # 309 folds it into the uniform auto-style distill, whose body is a `dup`
 # (keep the element for the next stage) followed by the consumer invocation
 # that swallows the duplicate. Because the body is one-in-one-out, 401-fuse
-# concatenates it blindly with its map neighbours, so the whole
-# `.map(+1).peek({}).map(*2)` chain collapses into a SINGLE Stream.mapMulti
-# dispatch. The surviving single invokedynamic proves the fusion: three
-# lambdas (two maps and one peek) became one mapMulti.
+# concatenates it blindly with its map neighbours, so a `.map(+1).peek({})`
+# pair collapses into one Stream.mapMulti dispatch.
 #
-#   [1,2,3,4,5] --map(+1)--> [2,3,4,5,6] --peek--> (forwarded unchanged)
+# This pack also pins how a peek fed a METHOD REFERENCE fuses. A peek's SAM is
+# a Consumer, whose `accept` returns void; `Integer::intValue` returns int, so
+# javac compiles the reference to a direct kind-5 method handle
+# (java/lang/Integer.intValue ()I) with an instantiated type of
+# `(Ljava/lang/Integer;)V` — the LambdaMetafactory DROPS the int return to fit
+# the void SAM. 105 desugars exactly that return-dropping case: it synthesises
+# a `lambda$hone$N` wrapper whose body is `aload 0; invokevirtual intValue;
+# pop; return`, repoints the invokedynamic at it, and 111/207/309 then fold it
+# into an ordinary peek distill. So all four operators fuse into a SINGLE
+# Stream.mapMulti and only one invokedynamic survives. The inlined `intValue`
+# call is the extra invokevirtual in the `after` count. 105 keeps 103's
+# predecessor gate (it fires only after a pointwise map/filter/peek) because a
+# folded peek that never fuses would emit as a standalone mapMulti that 711
+# cannot revert — so a lone method-ref peek is left native, never pessimised.
+#
+#   [1,2,3,4,5] --map(+1)--> [2,3,4,5,6] --peek({})--> (forwarded unchanged)
+#               --peek(Integer::intValue)--> (intValue called, result dropped)
 #               --map(*2)--> [4,6,8,10,12] --count()--> 5
 java: |
   package peek;
@@ -21,6 +35,7 @@ java: |
       long n = Stream.of(1, 2, 3, 4, 5)
         .map(x -> x + 1)
         .peek(x -> {})
+        .peek(Integer::intValue)
         .map(x -> x * 2)
         .count();
       System.out.printf("The result is %d\n", n);
@@ -32,14 +47,14 @@ log:
   - "BUILD SUCCESS"
   - "The result is 5"
 before:
-  invokedynamic: 3
-  invokeinterface: 4
+  invokedynamic: 4
+  invokeinterface: 5
   invokestatic: 9
   invokevirtual: 3
   return: 3
 after:
   invokedynamic: 1
   invokeinterface: 3
-  invokestatic: 12
-  invokevirtual: 3
-  return: 4
+  invokestatic: 13
+  invokevirtual: 4
+  return: 5

--- a/src/test/resources/org/eolang/hone/optimize/streams-terminals.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-terminals.yml
@@ -7,7 +7,8 @@
 #   anyMatch  : boolean-returning short-circuit terminal
 #   findFirst : Optional-returning short-circuit terminal
 #   forEach   : Consumer side-effect terminal
-#   minMax    : Optional with Comparator.naturalOrder()
+#   minMax    : Optional with Comparator.naturalOrder(); its map is the
+#               static reference X::plusHundred (desugared by 104)
 #   reduce    : identity + Integer::sum accumulator
 #   toArray   : IntFunction (Integer[]::new) constructor reference
 #   joining   : Collectors.joining over Stream<String>
@@ -18,6 +19,9 @@ java: |
   import java.util.*;
   import java.util.stream.*;
   public class X {
+    static Integer plusHundred(Integer n) {
+      return n + 100;
+    }
     public static void main(String[] a) {
       boolean anyMatch = Stream.of(1, 2, 3, 4, 5)
         .filter(n -> n > 0).map(n -> n + 1).anyMatch(n -> n > 4);
@@ -28,7 +32,7 @@ java: |
         .filter(n -> n % 2 == 1).map(n -> n * n)
         .forEach(n -> sb.append(n).append(','));
       Optional<Integer> min = Stream.of(5, 3, 8, 1, 9, 2)
-        .filter(n -> n > 0).map(n -> n + 100)
+        .filter(n -> n > 0).map(X::plusHundred)
         .min(Comparator.naturalOrder());
       int reduce = Stream.of(1, 2, 3, 4, 5)
         .filter(n -> n > 1).map(n -> n + 10).reduce(0, Integer::sum);


### PR DESCRIPTION
This teaches the optimizer to fuse a stream operator whose argument is a method reference, not just a lambda. Forms like `Stream.of(...).map(n -> n + 1).mapToInt(Integer::intValue).sum()` or `.peek(Integer::intValue)` used to stay as native calls; only the explicit lambda (`n -> n.intValue()`) fused, even though the method-reference form is what most people actually write.

The reason is that rule 111 only lifts an `invokedynamic` whose target is a synthetic `lambda$…` method, and a method reference points its target handle straight at the referenced method. So instead of touching 111, a set of rules running before it desugar the reference into the lambda the compiler could have emitted: they synthesise a private-static `lambda$hone$N` wrapper whose body is the forwarding the `LambdaMetafactory` would have generated, append it to the class, and repoint the `invokedynamic` at it. After that 111 lifts it like any lambda and the existing recognise/fold/fuse pipeline collapses the whole chain into a single `mapMulti`. Trying to admit method refs in 111 directly was the obvious shortcut, but it breaks the `boxed()`-roundtrip and stateful paths at run time — the wrapper's invokestatic-to-a-real-method shape is what keeps the downstream rules (which assume `lambda$…` are static methods) correct.

Three flavours are covered: 103 for unbound-instance refs (`Integer::intValue`), 104 for static refs (`Integer::valueOf`, `X::keep`), and 105 for an unbound-instance ref feeding `.peek(...)`, where the Consumer SAM returns void so the wrapper drops the reference's return value (`invoke …; pop; return`). Conversion never pessimises code: an unbox ref that does not fuse is reverted to its native call by 711/712, and the peek rule keeps a predecessor gate (it fires only after a pointwise `map`/`filter`/`peek`) because a folded peek that never fuses cannot be reverted. Still left native, as follow-ups the same wrapper mechanism can grow into: boxing/widening adaptation (`String::length`), multi-argument refs (`Integer::sum`), constructor refs, interface targets, and captured-receiver refs (`self::decorate`).