### PR TITLE
Fuse capturing-closure stream lambdas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,8 @@ pipeline stages:
 ```text
 1xx  prep         strip line-numbers, desugar method refs to lambdas
                   (103 unbound, 104 static, 105 peek/return-drop), lower
-                  invokedynamic to Φ.hone.lambda
+                  invokedynamic to Φ.hone.lambda; lift a single-int-capture
+                  map/filter indy straight to Φ.hone.{c-map,cp-filter} (112, 113)
 2xx  recognise    lambda + invokeinterface → Φ.hone.{filter,map,unbox,box}
 3xx  fold         every pragma → uniform Φ.hone.distill
 4xx  fuse         adjacent distills → one combined distill  ← the actual win
@@ -167,6 +168,10 @@ distinct                         → 216 → 307 → state distill;
 skip                             → 220 → 308 → state distill;
                                     442 reverts it (count and call)
                                     to invokeinterface if it never fused
+capturing map (one int)          → 112 → 316 → c-map state distill;
+                                    443 reverts it to invokedynamic if unfused
+capturing filter (one int)       → 113 → 314 → c-filter state distill;
+                                    444 reverts it to invokedynamic if unfused
 ```
 
 `401-fuse` is the only fuser: it matches two adjacent `Φ.hone.distill`
@@ -357,6 +362,79 @@ Limitations (v1): object streams only (`512` hardcodes the `Object` item
 shape); and `503` reads the frame type off `bridge-input`, correct while
 every operator before the distinct preserves the element type. Lifting
 these is future work.
+
+### Capturing operators (closures)
+
+A capturing lambda — `map(i -> i + x)`, `filter(n -> n > t)` over an
+effectively-final local — is the case issue #636 reported as unfusable.
+javac compiles the captured value as an extra argument on the lambda
+factory: the `invokedynamic` descriptor is `(I)L…Function;` rather than the
+zero-capture `()L…Function;`, and a single `iload k` pushes the value
+immediately before the indy. `111`'s `\(\).+` interface guard matches only
+zero captures, so a capturing indy never became a `Φ.hone.lambda` and was
+invisible to the whole 2xx→7xx pipeline.
+
+The insight that makes it cheap: **a capture is just a pointwise operator
+that owns one slot in the shared state List** — structurally identical to
+`distinct`/`skip`, which already thread per-element state through that List.
+So capturing operators reuse the entire stateful machinery (`401` fuse,
+`502`/`512`/`521` emit, `503`/`504` frames, `601` factory-widen) with **no
+edits to any existing rule**. They ride a parallel set of pragma names
+(`Φ.hone.c-map`, `Φ.hone.cp-filter`) and distill `start` labels (`"c-map"`,
+`"c-filter"`) so no existing recogniser, fold, dup-inserter or revert ever
+touches them.
+
+The v1 path (one new pragma family, six new rules, object streams only):
+
+- `112` / `113` lift a capturing map / primitive-filter indy directly to
+  `Φ.hone.c-map` / `Φ.hone.cp-filter`, **grabbing the `iload k` push out of
+  the body** (modelled on `220`'s skip-count grab) and carrying it as
+  `capture-push` plus the captured JVM type as `captured`. Leaving the push
+  inline would strand an int nothing consumes. They partition the indy space
+  with `111`: anchored `^\(I\)L…;$` guards match exactly one int capture, a
+  handle-6 static `lambda$` target, and a `Stream<Integer>` instantiated
+  type. A reference capture (push is `aload`), multi-capture (`(II)…`),
+  category-2 (`J`/`D`), `this`-capture (handle 5 / non-static enclosing
+  method), type-transforming map, computed/field push — all stay native.
+- `316` / `314` fold those into a stateful `Φ.hone.distill`. The `state`
+  block boxes the captured int and appends it to the List
+  (`dup; <iload k>; Integer.valueOf; List.add; pop`, peak 3); the body opens
+  with `fetch` (→ `521` → `List.get(counter++); checkcast Integer`), unboxes
+  with `intValue`, then a **`swap`** so the captured int sits below the item
+  — the static `lambda$(int captured, Integer item)` wants the item on top.
+  The swap is the single load-bearing step: omit it and the two int-ish
+  operands silently invert (the verifier accepts it), which is why the e2e
+  asserts the numeric runtime result, not just opcode counts. `314`'s filter
+  body also opens with a `dup` (the predicate consumes the item, so a copy is
+  kept for the keep path) and ends at a `Φ.hone.frame-item` keep-label — it
+  builds its own dup rather than relying on `431`, because the `"c-filter"`
+  start label keeps `431`/`281` away.
+- `401` fuses two capturing distills exactly like two `distinct`s: `join`
+  concatenates the two boxed appends into the List (slot 0, slot 1…) and the
+  two bodies in order, so guard *k*'s fetch reads slot *k*. `502`/`512`/`521`
+  emit one `Stream.mapMulti` whose wrapper reads each capture back from the
+  List by the per-call counter; `601` widens the factory descriptor by the
+  captured List. The captured int never touches the indy descriptor (it hides
+  inside the List), so the `IncompatibleClassChangeError` class CLAUDE.md
+  warns about does not arise.
+- `443` / `444` are the never-pessimise reverts (twins of `441`/`442`): a
+  capturing operator that never fused — including the issue's literal lone
+  `map(i -> i + x)` — is put back as the native `invokedynamic` +
+  `Stream.{map,filter}`, replaying the captured push and marking the call
+  `reverted ↦ Φ.true` so `112`/`113` cannot re-lift it (their invokeinterface
+  patterns are closed; the marker is the same loop-break `442` uses). The SAM
+  constants the fold dropped (`apply`/`test`, the erased and instantiated
+  types) are reconstructed literally for the int-capture `Stream<Integer>`
+  case.
+
+Deferred puzzles (each extends the same shared-List channel): reference
+captures (drop the box/unbox), other type-preserving element types (relax the
+literal `Stream<Integer>` bridge-signature to a `bridge-input == bridge-output`
+guard), multi-capture `map(i -> i + x + y)` (grab the run of leaf-loads and
+emit N appends/fetches; the single-capture `swap` does not generalise — park
+the item in a scratch local and reload it last), category-2 captures,
+`this`-field captures, and capturing `peek`/`mapToX`. See the `@todo` in
+`112`'s header.
 
 ## phino: the only rewrite engine
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,8 +96,9 @@ pipeline stages:
 ```text
 1xx  prep         strip line-numbers, desugar method refs to lambdas
                   (103 unbound, 104 static, 105 peek/return-drop), lower
-                  invokedynamic to Φ.hone.lambda; lift a single-int-capture
-                  map/filter indy straight to Φ.hone.{c-map,cp-filter} (112, 113)
+                  invokedynamic to Φ.hone.lambda; lift a capturing map/filter
+                  indy to Φ.hone.{c-map,cp-filter} (112, 113), peel a
+                  multi-int capture run into the c-map (114)
 2xx  recognise    lambda + invokeinterface → Φ.hone.{filter,map,unbox,box}
 3xx  fold         every pragma → uniform Φ.hone.distill
 4xx  fuse         adjacent distills → one combined distill  ← the actual win
@@ -168,8 +169,9 @@ distinct                         → 216 → 307 → state distill;
 skip                             → 220 → 308 → state distill;
                                     442 reverts it (count and call)
                                     to invokeinterface if it never fused
-capturing map (one int)          → 112 → 316 → c-map state distill;
-                                    443 reverts it to invokedynamic if unfused
+capturing map (N ints)           → 112 → 114 → 316 → c-map state distill;
+                                    443 reverts a lone single-capture map if
+                                    unfused (multi-capture stays mapMulti)
 capturing filter (one int)       → 113 → 314 → c-filter state distill;
                                     444 reverts it to invokedynamic if unfused
 ```
@@ -365,14 +367,15 @@ these is future work.
 
 ### Capturing operators (closures)
 
-A capturing lambda — `map(i -> i + x)`, `filter(n -> n > t)` over an
-effectively-final local — is the case issue #636 reported as unfusable.
-javac compiles the captured value as an extra argument on the lambda
-factory: the `invokedynamic` descriptor is `(I)L…Function;` rather than the
-zero-capture `()L…Function;`, and a single `iload k` pushes the value
-immediately before the indy. `111`'s `\(\).+` interface guard matches only
-zero captures, so a capturing indy never became a `Φ.hone.lambda` and was
-invisible to the whole 2xx→7xx pipeline.
+A capturing lambda — `map(i -> i + x)`, `map(i -> i + x + y + z)`,
+`filter(n -> n > t)` over effectively-final locals — is the case issue #636
+reported as unfusable. javac compiles each captured value as an extra argument
+on the lambda factory: the `invokedynamic` descriptor is `(I)L…Function;` (one
+capture) or `(III)L…Function;` (three) rather than the zero-capture
+`()L…Function;`, and a run of `iload k` pushes the values immediately before
+the indy. `111`'s `\(\).+` interface guard matches only zero captures, so a
+capturing indy never became a `Φ.hone.lambda` and was invisible to the whole
+2xx→7xx pipeline.
 
 The insight that makes it cheap: **a capture is just a pointwise operator
 that owns one slot in the shared state List** — structurally identical to
@@ -384,57 +387,70 @@ edits to any existing rule**. They ride a parallel set of pragma names
 `"c-filter"`) so no existing recogniser, fold, dup-inserter or revert ever
 touches them.
 
-The v1 path (one new pragma family, six new rules, object streams only):
+The path (object streams, int captures; map handles any number, filter one):
 
-- `112` / `113` lift a capturing map / primitive-filter indy directly to
-  `Φ.hone.c-map` / `Φ.hone.cp-filter`, **grabbing the `iload k` push out of
-  the body** (modelled on `220`'s skip-count grab) and carrying it as
-  `capture-push` plus the captured JVM type as `captured`. Leaving the push
-  inline would strand an int nothing consumes. They partition the indy space
-  with `111`: anchored `^\(I\)L…;$` guards match exactly one int capture, a
-  handle-6 static `lambda$` target, and a `Stream<Integer>` instantiated
-  type. A reference capture (push is `aload`), multi-capture (`(II)…`),
-  category-2 (`J`/`D`), `this`-capture (handle 5 / non-static enclosing
-  method), type-transforming map, computed/field push — all stay native.
-- `316` / `314` fold those into a stateful `Φ.hone.distill`. The `state`
-  block boxes the captured int and appends it to the List
-  (`dup; <iload k>; Integer.valueOf; List.add; pop`, peak 3); the body opens
-  with `fetch` (→ `521` → `List.get(counter++); checkcast Integer`), unboxes
-  with `intValue`, then a **`swap`** so the captured int sits below the item
-  — the static `lambda$(int captured, Integer item)` wants the item on top.
-  The swap is the single load-bearing step: omit it and the two int-ish
-  operands silently invert (the verifier accepts it), which is why the e2e
-  asserts the numeric runtime result, not just opcode counts. `314`'s filter
-  body also opens with a `dup` (the predicate consumes the item, so a copy is
-  kept for the keep path) and ends at a `Φ.hone.frame-item` keep-label — it
-  builds its own dup rather than relying on `431`, because the `"c-filter"`
-  start label keeps `431`/`281` away.
+- `112` / `113` lift a capturing map / primitive-filter indy to
+  `Φ.hone.c-map` / `Φ.hone.cp-filter`. `113` (single capture) still **grabs the
+  one `iload k` push** and carries it as `capture-push`. `112` is now arity-
+  agnostic: its guard is `\(I+\)L…Function;` (one OR MORE ints) and it grabs
+  **no** push — it leaves the whole run of `iload`s inline in front of the
+  c-map and seeds two EMPTY accumulators (`state-acc`, `body-acc`). They
+  partition the indy space with `111`: `\(\)` matches zero captures, `\(I…\)`
+  matches int captures, a handle-6 static `lambda$` target, and a
+  `Stream<Integer>` instantiated type (the SAM type is capture-independent, so
+  it is unchanged by arity). A reference capture (push is `aload`), category-2
+  (`J`/`D`), `this`-capture (handle 5), type-transforming map, computed/field
+  push — all stay native.
+- `114` gathers `112`'s inline pushes into the c-map, one per firing,
+  re-applying at fixpoint (the same self-iteration `521` uses). It matches the
+  single `iload` **directly in front of** the c-map; phino's leading group is
+  greedy, so the bound push is always the LAST one and the rule peels
+  right-to-left. Each peel PREPENDS one boxing append
+  (`dup; iload k; Integer.valueOf; List.add; pop`) to `state-acc` and one
+  `fetch; intValue` to `body-acc`, so the captures end up appended in
+  left-to-right (x, y, z) order — slot 0 = x, guard *k* reads capture *k*. The
+  run is bounded on the left by the previous operator's invokeinterface, never
+  another iload, so peeling stops cleanly.
+- `316` / `314` fold into a stateful `Φ.hone.distill`. `316` copies the filled
+  `state-acc` into `state` and wraps `body-acc` into the auto emit-shape
+  `astore 1; <fetch; intValue>×N; aload 1; invokestatic lambda$`: the item is
+  parked in its own (now-dead) local-1 slot, the N unboxed captures left below
+  it exactly as the static `lambda$(int…, Integer)` signature wants. Parking in
+  local 1 needs no extra local, so `512`'s max-locals is untouched. This N-ary
+  park/reload **replaces v1's single-capture `swap`**, unifying one and many
+  captures (omit the reload and the operands silently invert — the verifier
+  accepts it, so the e2e asserts the numeric runtime result, not just opcode
+  counts). `314`'s single-capture FILTER still uses the `swap` body plus its
+  own opening `dup` and a `Φ.hone.frame-item` keep-label (the `"c-filter"`
+  start label keeps `431`/`281` away); a multi-capture filter stays native
+  (113's `\(I\)` guard declines it) — its park/reload twin, which must also
+  defer the keep-frame, is a follow-up puzzle.
 - `401` fuses two capturing distills exactly like two `distinct`s: `join`
-  concatenates the two boxed appends into the List (slot 0, slot 1…) and the
+  concatenates the boxed appends into the List (slots in body order) and the
   two bodies in order, so guard *k*'s fetch reads slot *k*. `502`/`512`/`521`
   emit one `Stream.mapMulti` whose wrapper reads each capture back from the
   List by the per-call counter; `601` widens the factory descriptor by the
-  captured List. The captured int never touches the indy descriptor (it hides
-  inside the List), so the `IncompatibleClassChangeError` class CLAUDE.md
-  warns about does not arise.
-- `443` / `444` are the never-pessimise reverts (twins of `441`/`442`): a
-  capturing operator that never fused — including the issue's literal lone
+  captured List. No capture touches the indy descriptor (they hide inside the
+  List), so the `IncompatibleClassChangeError` class CLAUDE.md warns about does
+  not arise.
+- `443` / `444` are the never-pessimise reverts (twins of `441`/`442`): a LONE
+  single-capture operator that never fused — including the issue's literal
   `map(i -> i + x)` — is put back as the native `invokedynamic` +
-  `Stream.{map,filter}`, replaying the captured push and marking the call
-  `reverted ↦ Φ.true` so `112`/`113` cannot re-lift it (their invokeinterface
-  patterns are closed; the marker is the same loop-break `442` uses). The SAM
-  constants the fold dropped (`apply`/`test`, the erased and instantiated
-  types) are reconstructed literally for the int-capture `Stream<Integer>`
-  case.
+  `Stream.{map,filter}`, replaying the push and marking the call
+  `reverted ↦ Φ.true` so `112`/`113` cannot re-lift it (closed patterns plus
+  the marker, the same loop-break `442` uses). `443` matches the park/reload
+  single-capture body. A LONE multi-capture map (two or more appends) fails
+  that closed pattern and is emitted as a standalone `mapMulti` — correct, only
+  marginally slower than native, and rarer than a lone single-capture map;
+  reverting it (replaying N pushes, rebuilding the `(I^N)` descriptor) is a
+  follow-up puzzle.
 
-Deferred puzzles (each extends the same shared-List channel): reference
-captures (drop the box/unbox), other type-preserving element types (relax the
-literal `Stream<Integer>` bridge-signature to a `bridge-input == bridge-output`
-guard), multi-capture `map(i -> i + x + y)` (grab the run of leaf-loads and
-emit N appends/fetches; the single-capture `swap` does not generalise — park
-the item in a scratch local and reload it last), category-2 captures,
-`this`-field captures, and capturing `peek`/`mapToX`. See the `@todo` in
-`112`'s header.
+Deferred puzzles (each extends the same shared-List channel): a multi-capture
+FILTER and the lone-multi-capture-map revert (both above); reference captures
+(drop the box/unbox); other type-preserving element types (relax the literal
+`Stream<Integer>` instantiated type to a `bridge-input == bridge-output`
+guard); category-2 captures; `this`-field captures; and capturing
+`peek`/`mapToX`. See the `@todo` in `112`'s header.
 
 ## phino: the only rewrite engine
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -450,7 +450,7 @@ FILTER and the lone-multi-capture-map revert (both above); reference captures
 (drop the box/unbox); other type-preserving element types (relax the literal
 `Stream<Integer>` instantiated type to a `bridge-input == bridge-output`
 guard); category-2 captures; `this`-field captures; and capturing
-`peek`/`mapToX`. See the `@todo` in `112`'s header.
+`peek`/`mapToX`. See the puzzle marker in `112`'s header.
 
 ## phino: the only rewrite engine
 

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
@@ -3,34 +3,37 @@
 ---
 # yamllint disable rule:line-length
 # Lifts a CAPTURING map invokedynamic — one that 111 declines because its
-# factory descriptor carries a captured argument (e.g. "(I)L…Function;"
-# instead of "()L…Function;") — into a Φ.hone.c-map pragma, the capturing
-# sibling of the Φ.hone.map that 202 produces. 111 is left untouched: its
-# `\(\).+` interface guard matches the zero-capture space, this rule's
-# anchored `^\(I\)…$` guard matches the single-int-capture space, so the two
+# factory descriptor carries captured arguments (e.g. "(I)L…Function;" or
+# "(III)L…Function;" instead of "()L…Function;") — into a Φ.hone.c-map pragma,
+# the capturing sibling of the Φ.hone.map that 202 produces. 111 is left
+# untouched: its `\(\).+` interface guard matches the zero-capture space, this
+# rule's `\(I+\)…` guard matches the one-or-more-int-capture space, so the two
 # partition the indy population with no overlap.
 #
-# The capture rides the lambda-metafactory's only extra argument. javac
-# pushes it with a single leaf-load (`iload k`) immediately before the indy
-# and the indy consumes it to build the Function. We GRAB that push (𝜏-capture,
-# modelled on 220's count-push grab) out of the body and carry it on the pragma
-# as `capture-push`, so the value is gone from the operand stack (leaving it
-# inline would strand an int nothing consumes). 316 re-materialises it as a
-# boxed append to the shared state List; 443 replays it before the reverted
-# indy when the operator never fuses. The captured JVM type rides as `captured`.
+# Each capture rides the lambda-metafactory as one extra factory argument.
+# javac pushes them with a run of leaf-loads (`iload k`) immediately before the
+# indy and the indy consumes them to build the Function. This rule does NOT
+# grab those pushes — it leaves the whole run inline before the emitted c-map
+# and seeds two EMPTY accumulators (`state-acc`, `body-acc`). 114 then peels the
+# pushes one at a time (right-to-left, greedy-left makes the match exact),
+# prepending one boxed append to `state-acc` and one fetch+unbox to `body-acc`
+# per capture, so the captures land in the shared state List in left-to-right
+# order. 316 finally assembles the two accumulators into a stateful distill.
+# Treating a capture as "a pointwise operator that owns one slot in the shared
+# state List" is what lets N captures (and any number of fused capturing
+# operators) reuse the distinct/skip machinery (502/512/521/601) verbatim.
 #
-# v1 scope (issue #636): a single category-1 INT capture, a type-preserving
-# Stream<Integer> map (bridge-signature "(Ljava/lang/Integer;)Ljava/lang/Integer;"),
-# a handle-6 static lambda$ target, the push a constant-index iload. Reference
-# captures, other element types, type-transforming maps, category-2 captures,
-# multi-capture and field/computed pushes are declined here (left native) and
-# tracked as follow-up puzzles.
+# v1.1 scope (issue #636): one OR MORE category-1 INT captures, a type-preserving
+# Stream<Integer> map (instantiated type "(Ljava/lang/Integer;)Ljava/lang/Integer;"),
+# a handle-6 static lambda$ target, every push a constant-index iload. Reference
+# captures, other element types, type-transforming maps and category-2 captures
+# are declined here (left native) and tracked as follow-up puzzles.
 #
-# @todo #636:60min Generalise the capture beyond a single int on a
-#  Stream<Integer> map: a reference capture (drop the box/unbox), other
-#  type-preserving element types (relax the literal bridge-signature to a
-#  bridge-input==bridge-output guard), and multi-capture (grab the run of
-#  leaf-loads). Each extends the same shared-List channel.
+# @todo #636:60min Generalise the capture beyond ints on a Stream<Integer> map:
+#  a reference capture (drop the box/unbox), other type-preserving element types
+#  (relax the literal instantiated-type guard to a bridge-input==bridge-output
+#  guard), and category-2 (J/D) captures. Each extends the same shared-List
+#  channel; a multi-capture FILTER (113/314) is the nearest unfinished twin.
 name: capturing-invokedynamic-to-map
 pattern: |
   ⟦
@@ -59,10 +62,6 @@ pattern: |
       annotations ↦ 𝑒-annotations,
       body ↦ ⟦
         𝐵-body-head,
-        𝜏-capture ↦ ⟦
-          φ ↦ Φ.jeo.opcode.iload,
-          𝐵-cap-rest
-        ⟧,
         𝜏-invokedynamic ↦ ⟦
           φ ↦ Φ.jeo.opcode.invokedynamic,
           𝜏3 ↦ 𝑒-method,
@@ -142,21 +141,14 @@ result: |
         𝐵-body-head,
         𝜏-c-map ↦ ⟦
           φ ↦ Φ.hone.c-map,
+          state-acc ↦ ⟦ ρ ↦ ∅ ⟧,
+          body-acc ↦ ⟦ ρ ↦ ∅ ⟧,
           class ↦ 𝑒-class,
           bridge-input ↦ "Ljava/lang/Integer;",
           bridge-output ↦ "Ljava/lang/Integer;",
           accepted ↦ "Ljava/lang/Integer;",
           returned ↦ "Ljava/lang/Integer;",
           static ↦ "true",
-          captured ↦ "I",
-          capture-push ↦ ⟦
-            φ ↦ Φ.jeo.opcode.iload,
-            𝐵-cap-rest
-          ⟧,
-          interface ↦ 𝑒-interface,
-          method ↦ 𝑒-method,
-          lambda-signature ↦ 𝑒-lambda-signature,
-          bridge-signature ↦ "(Ljava/lang/Integer;)Ljava/lang/Integer;",
           target ↦ ⟦
             handle ↦ 6,
             class ↦ 𝑒-target-class,
@@ -179,9 +171,9 @@ when:
         - 'lambda\$.+'
         - 𝑒-target-method
     - matches:
-        - '\(I\)Ljava/util/function/Function;'
+        - '\(I+\)Ljava/util/function/Function;'
         - 𝑒-interface
 where:
   - meta: 𝜏-c-map
     function: random-tau
-    args: ['𝐵-body-head', '𝐵-body-tail', '𝜏-invokeinterface', '𝜏-invokedynamic', '𝜏-capture']
+    args: ['𝐵-body-head', '𝐵-body-tail', '𝜏-invokeinterface', '𝜏-invokedynamic']

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
@@ -1,0 +1,187 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Lifts a CAPTURING map invokedynamic — one that 111 declines because its
+# factory descriptor carries a captured argument (e.g. "(I)L…Function;"
+# instead of "()L…Function;") — into a Φ.hone.c-map pragma, the capturing
+# sibling of the Φ.hone.map that 202 produces. 111 is left untouched: its
+# `\(\).+` interface guard matches the zero-capture space, this rule's
+# anchored `^\(I\)…$` guard matches the single-int-capture space, so the two
+# partition the indy population with no overlap.
+#
+# The capture rides the lambda-metafactory's only extra argument. javac
+# pushes it with a single leaf-load (`iload k`) immediately before the indy
+# and the indy consumes it to build the Function. We GRAB that push (𝜏-capture,
+# modelled on 220's count-push grab) out of the body and carry it on the pragma
+# as `capture-push`, so the value is gone from the operand stack (leaving it
+# inline would strand an int nothing consumes). 316 re-materialises it as a
+# boxed append to the shared state List; 443 replays it before the reverted
+# indy when the operator never fuses. The captured JVM type rides as `captured`.
+#
+# v1 scope (issue #636): a single category-1 INT capture, a type-preserving
+# Stream<Integer> map (bridge-signature "(Ljava/lang/Integer;)Ljava/lang/Integer;"),
+# a handle-6 static lambda$ target, the push a constant-index iload. Reference
+# captures, other element types, type-transforming maps, category-2 captures,
+# multi-capture and field/computed pushes are declined here (left native) and
+# tracked as follow-up puzzles.
+#
+# @todo #636:60min Generalise the capture beyond a single int on a
+#  Stream<Integer> map: a reference capture (drop the box/unbox), other
+#  type-preserving element types (relax the literal bridge-signature to a
+#  bridge-input==bridge-output guard), and multi-capture (grab the run of
+#  leaf-loads). Each extends the same shared-List channel.
+name: capturing-invokedynamic-to-map
+pattern: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    version ↦ 𝑒-class-version,
+    access ↦ 𝑒-class-access,
+    modifiers ↦ 𝑒-class-modifiers,
+    name ↦ 𝑒-class,
+    supername ↦ 𝑒-class-supername,
+    interfaces ↦ 𝑒-class-interfaces,
+    𝐵-class-body-head,
+    𝜏-function ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 𝑒-method-access,
+      modifiers ↦ ⟦
+        𝐵-modifiers-before,
+        static ↦ Φ.true,
+        𝐵-modifiers-after
+      ⟧,
+      name ↦ 𝑒-function,
+      descriptor ↦ 𝑒-method-descriptor,
+      signature ↦ 𝑒-method-signature,
+      exceptions ↦ 𝑒-method-exceptions,
+      maxs ↦ 𝑒-method-maxs,
+      params ↦ 𝑒-method-params,
+      annotations ↦ 𝑒-annotations,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-capture ↦ ⟦
+          φ ↦ Φ.jeo.opcode.iload,
+          𝐵-cap-rest
+        ⟧,
+        𝜏-invokedynamic ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokedynamic,
+          𝜏3 ↦ 𝑒-method,
+          𝜏4 ↦ 𝑒-interface,
+          𝜏5 ↦ ⟦
+            φ ↦ Φ.jeo.handle,
+            𝜏6 ↦ 6,
+            𝜏7 ↦ "java/lang/invoke/LambdaMetafactory",
+            𝜏8 ↦ "metafactory",
+            𝜏9 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+            𝜏10 ↦ Φ.false,
+            ρ ↦ ∅
+          ⟧,
+          𝜏11 ↦ ⟦
+            φ ↦ Φ.jeo.type,
+            𝜏12 ↦ 𝑒-lambda-signature,
+            ρ ↦ ∅
+          ⟧,
+          𝜏13 ↦ ⟦
+            φ ↦ Φ.jeo.handle,
+            𝜏14 ↦ 6,
+            𝜏15 ↦ 𝑒-target-class,
+            𝜏16 ↦ 𝑒-target-method,
+            𝜏17 ↦ 𝑒-target-signature,
+            𝜏18 ↦ 𝑒-target-is-interface,
+            ρ ↦ ∅
+          ⟧,
+          𝜏19 ↦ ⟦
+            φ ↦ Φ.jeo.type,
+            𝜏21 ↦ "(Ljava/lang/Integer;)Ljava/lang/Integer;",
+            ρ ↦ ∅
+          ⟧,
+          ρ ↦ ∅
+        ⟧,
+        𝜏-invokeinterface ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          𝜏24 ↦ "java/util/stream/Stream",
+          𝜏25 ↦ "map",
+          𝜏26 ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;",
+          𝜏27 ↦ Φ.true,
+          ρ ↦ ∅
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝜏-trycatchblocks ↦ 𝑒-trycatchblocks,
+      local-variable-table ↦ 𝑒-lvt,
+      ρ ↦ ∅
+    ⟧,
+    𝐵-class-body-tail
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    version ↦ 𝑒-class-version,
+    access ↦ 𝑒-class-access,
+    modifiers ↦ 𝑒-class-modifiers,
+    name ↦ 𝑒-class,
+    supername ↦ 𝑒-class-supername,
+    interfaces ↦ 𝑒-class-interfaces,
+    𝐵-class-body-head,
+    𝜏-function ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 𝑒-method-access,
+      modifiers ↦ ⟦
+        𝐵-modifiers-before,
+        static ↦ Φ.true,
+        𝐵-modifiers-after
+      ⟧,
+      name ↦ 𝑒-function,
+      descriptor ↦ 𝑒-method-descriptor,
+      signature ↦ 𝑒-method-signature,
+      exceptions ↦ 𝑒-method-exceptions,
+      maxs ↦ 𝑒-method-maxs,
+      params ↦ 𝑒-method-params,
+      annotations ↦ 𝑒-annotations,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-c-map ↦ ⟦
+          φ ↦ Φ.hone.c-map,
+          class ↦ 𝑒-class,
+          bridge-input ↦ "Ljava/lang/Integer;",
+          bridge-output ↦ "Ljava/lang/Integer;",
+          accepted ↦ "Ljava/lang/Integer;",
+          returned ↦ "Ljava/lang/Integer;",
+          static ↦ "true",
+          captured ↦ "I",
+          capture-push ↦ ⟦
+            φ ↦ Φ.jeo.opcode.iload,
+            𝐵-cap-rest
+          ⟧,
+          interface ↦ 𝑒-interface,
+          method ↦ 𝑒-method,
+          lambda-signature ↦ 𝑒-lambda-signature,
+          bridge-signature ↦ "(Ljava/lang/Integer;)Ljava/lang/Integer;",
+          target ↦ ⟦
+            handle ↦ 6,
+            class ↦ 𝑒-target-class,
+            method ↦ 𝑒-target-method,
+            signature ↦ 𝑒-target-signature,
+            is-interface ↦ 𝑒-target-is-interface
+          ⟧
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝜏-trycatchblocks ↦ 𝑒-trycatchblocks,
+      local-variable-table ↦ 𝑒-lvt,
+      ρ ↦ ∅
+    ⟧,
+    𝐵-class-body-tail
+  ⟧
+when:
+  and:
+    - matches:
+        - 'lambda\$.+'
+        - 𝑒-target-method
+    - matches:
+        - '\(I\)Ljava/util/function/Function;'
+        - 𝑒-interface
+where:
+  - meta: 𝜏-c-map
+    function: random-tau
+    args: ['𝐵-body-head', '𝐵-body-tail', '𝜏-invokeinterface', '𝜏-invokedynamic', '𝜏-capture']

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/113-capturing-invokedynamic-to-filter.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/113-capturing-invokedynamic-to-filter.phr
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The filter twin of 112. Lifts a CAPTURING primitive-filter invokedynamic —
+# one 111 declines for its "(I)L…Predicate;" factory descriptor — into a
+# Φ.hone.cp-filter pragma, the capturing sibling of the Φ.hone.p-filter that
+# 201 produces for a predicate whose backing lambda$ returns Z. The captured
+# int rides exactly as in 112: grabbed out of the body as `capture-push`,
+# carried as `captured`, re-materialised by 314 as a boxed append to the shared
+# state List (and replayed by 444 if the filter never fuses).
+#
+# v1 scope: a single category-1 INT capture, a Stream<Integer> predicate
+# (bridge-signature "(Ljava/lang/Integer;)Z"), a handle-6 static lambda$
+# target, the push a constant-index iload. See 112's header for the deferred
+# generalisations; they apply here unchanged.
+name: capturing-invokedynamic-to-filter
+pattern: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    version ↦ 𝑒-class-version,
+    access ↦ 𝑒-class-access,
+    modifiers ↦ 𝑒-class-modifiers,
+    name ↦ 𝑒-class,
+    supername ↦ 𝑒-class-supername,
+    interfaces ↦ 𝑒-class-interfaces,
+    𝐵-class-body-head,
+    𝜏-function ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 𝑒-method-access,
+      modifiers ↦ ⟦
+        𝐵-modifiers-before,
+        static ↦ Φ.true,
+        𝐵-modifiers-after
+      ⟧,
+      name ↦ 𝑒-function,
+      descriptor ↦ 𝑒-method-descriptor,
+      signature ↦ 𝑒-method-signature,
+      exceptions ↦ 𝑒-method-exceptions,
+      maxs ↦ 𝑒-method-maxs,
+      params ↦ 𝑒-method-params,
+      annotations ↦ 𝑒-annotations,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-capture ↦ ⟦
+          φ ↦ Φ.jeo.opcode.iload,
+          𝐵-cap-rest
+        ⟧,
+        𝜏-invokedynamic ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokedynamic,
+          𝜏3 ↦ 𝑒-method,
+          𝜏4 ↦ 𝑒-interface,
+          𝜏5 ↦ ⟦
+            φ ↦ Φ.jeo.handle,
+            𝜏6 ↦ 6,
+            𝜏7 ↦ "java/lang/invoke/LambdaMetafactory",
+            𝜏8 ↦ "metafactory",
+            𝜏9 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+            𝜏10 ↦ Φ.false,
+            ρ ↦ ∅
+          ⟧,
+          𝜏11 ↦ ⟦
+            φ ↦ Φ.jeo.type,
+            𝜏12 ↦ 𝑒-lambda-signature,
+            ρ ↦ ∅
+          ⟧,
+          𝜏13 ↦ ⟦
+            φ ↦ Φ.jeo.handle,
+            𝜏14 ↦ 6,
+            𝜏15 ↦ 𝑒-target-class,
+            𝜏16 ↦ 𝑒-target-method,
+            𝜏17 ↦ 𝑒-target-signature,
+            𝜏18 ↦ 𝑒-target-is-interface,
+            ρ ↦ ∅
+          ⟧,
+          𝜏19 ↦ ⟦
+            φ ↦ Φ.jeo.type,
+            𝜏21 ↦ "(Ljava/lang/Integer;)Z",
+            ρ ↦ ∅
+          ⟧,
+          ρ ↦ ∅
+        ⟧,
+        𝜏-invokeinterface ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          𝜏24 ↦ "java/util/stream/Stream",
+          𝜏25 ↦ "filter",
+          𝜏26 ↦ "(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;",
+          𝜏27 ↦ Φ.true,
+          ρ ↦ ∅
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝜏-trycatchblocks ↦ 𝑒-trycatchblocks,
+      local-variable-table ↦ 𝑒-lvt,
+      ρ ↦ ∅
+    ⟧,
+    𝐵-class-body-tail
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    version ↦ 𝑒-class-version,
+    access ↦ 𝑒-class-access,
+    modifiers ↦ 𝑒-class-modifiers,
+    name ↦ 𝑒-class,
+    supername ↦ 𝑒-class-supername,
+    interfaces ↦ 𝑒-class-interfaces,
+    𝐵-class-body-head,
+    𝜏-function ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 𝑒-method-access,
+      modifiers ↦ ⟦
+        𝐵-modifiers-before,
+        static ↦ Φ.true,
+        𝐵-modifiers-after
+      ⟧,
+      name ↦ 𝑒-function,
+      descriptor ↦ 𝑒-method-descriptor,
+      signature ↦ 𝑒-method-signature,
+      exceptions ↦ 𝑒-method-exceptions,
+      maxs ↦ 𝑒-method-maxs,
+      params ↦ 𝑒-method-params,
+      annotations ↦ 𝑒-annotations,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-cp-filter ↦ ⟦
+          φ ↦ Φ.hone.cp-filter,
+          class ↦ 𝑒-class,
+          bridge-input ↦ "Ljava/lang/Integer;",
+          bridge-output ↦ "Ljava/lang/Integer;",
+          accepted ↦ "Ljava/lang/Integer;",
+          returned ↦ "Ljava/lang/Integer;",
+          static ↦ "true",
+          captured ↦ "I",
+          capture-push ↦ ⟦
+            φ ↦ Φ.jeo.opcode.iload,
+            𝐵-cap-rest
+          ⟧,
+          interface ↦ 𝑒-interface,
+          method ↦ 𝑒-method,
+          lambda-signature ↦ 𝑒-lambda-signature,
+          bridge-signature ↦ "(Ljava/lang/Integer;)Z",
+          target ↦ ⟦
+            handle ↦ 6,
+            class ↦ 𝑒-target-class,
+            method ↦ 𝑒-target-method,
+            signature ↦ 𝑒-target-signature,
+            is-interface ↦ 𝑒-target-is-interface
+          ⟧
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝜏-trycatchblocks ↦ 𝑒-trycatchblocks,
+      local-variable-table ↦ 𝑒-lvt,
+      ρ ↦ ∅
+    ⟧,
+    𝐵-class-body-tail
+  ⟧
+when:
+  and:
+    - matches:
+        - 'lambda\$.+'
+        - 𝑒-target-method
+    - matches:
+        - '\(I\)Ljava/util/function/Predicate;'
+        - 𝑒-interface
+where:
+  - meta: 𝜏-cp-filter
+    function: random-tau
+    args: ['𝐵-body-head', '𝐵-body-tail', '𝜏-invokeinterface', '𝜏-invokedynamic', '𝜏-capture']

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/114-c-map-peel-capture.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/114-c-map-peel-capture.phr
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Peels one captured push off a Φ.hone.c-map and folds it into the operator's
+# shared-List state. 112 emits the c-map with the whole run of `iload k` pushes
+# still inline in front of it and two EMPTY accumulators; this rule does the
+# gathering, one capture per firing, re-applying at fixpoint until the run is
+# gone (the same self-iteration 521 uses to resolve every fetch).
+#
+# It matches the single `iload` directly in front of the c-map: phino's leading
+# `𝐵-h` group is greedy, so for a run "iload x; iload y; iload z; <c-map>" the
+# bound `𝜏-il` is always the LAST push (z), and the rule peels right-to-left
+# (z, then y, then x). Each peel PREPENDS its unit to the accumulators, so the
+# captures end up in left-to-right (x, y, z) order — exactly the order javac
+# pushed them and the order the static lambda$ expects, and the order in which
+# they are appended to the List (slot 0 = x, …) so guard k reads capture k.
+#
+# state-acc gains one boxing append `dup; iload k; Integer.valueOf; List.add;
+# pop` (begins and ends at [list], peak 3, so any number of them — across this
+# operator and any fused neighbours — join without growing the caller's stack).
+# body-acc gains one `fetch; intValue` (521 turns the fetch into List.get(counter++)
+# at emit, the intValue unboxes it). 316 wraps the finished body-acc as
+# `astore 1; <fetches>; aload 1; invokestatic lambda$`, so the unboxed captures
+# sit below the parked item exactly as the lambda$ (int…, Integer) signature wants.
+#
+# The run is always bounded on the left by the previous stream operator's
+# invokeinterface (which left a Stream ref on the stack), never by another
+# iload, so peeling stops cleanly once every capture has been gathered.
+name: c-map-peel-capture
+pattern: |
+  ⟦
+    𝐵-h,
+    𝜏-il ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, 𝐵-ilr ⟧,
+    𝜏-cm ↦ ⟦
+      φ ↦ Φ.hone.c-map,
+      state-acc ↦ ⟦ 𝐵-sacc, ρ ↦ ∅ ⟧,
+      body-acc ↦ ⟦ 𝐵-bacc, ρ ↦ ∅ ⟧,
+      𝐵-cm-tail
+    ⟧,
+    𝐵-t
+  ⟧
+result: |
+  ⟦
+    𝐵-h,
+    𝜏-cm ↦ ⟦
+      φ ↦ Φ.hone.c-map,
+      state-acc ↦ ⟦
+        𝜏-dup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+        𝜏-load ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, 𝐵-ilr ⟧,
+        𝜏-box ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokestatic,
+          i2 ↦ "java/lang/Integer",
+          i3 ↦ "valueOf",
+          i4 ↦ "(I)Ljava/lang/Integer;",
+          i5 ↦ Φ.false
+        ⟧,
+        𝜏-add ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          i2 ↦ "java/util/List",
+          i3 ↦ "add",
+          i4 ↦ "(Ljava/lang/Object;)Z",
+          i5 ↦ Φ.true
+        ⟧,
+        𝜏-pop ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+        𝐵-sacc,
+        ρ ↦ ∅
+      ⟧,
+      body-acc ↦ ⟦
+        𝜏-fetch ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
+        𝜏-iv ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokevirtual,
+          i1 ↦ "java/lang/Integer",
+          i2 ↦ "intValue",
+          i3 ↦ "()I",
+          i4 ↦ Φ.false
+        ⟧,
+        𝐵-bacc,
+        ρ ↦ ∅
+      ⟧,
+      𝐵-cm-tail
+    ⟧,
+    𝐵-t
+  ⟧
+where:
+  - meta: 𝜏-dup
+    function: random-tau
+    args: ['𝐵-sacc', '𝐵-bacc']
+  - meta: 𝜏-load
+    function: random-tau
+    args: ['𝐵-sacc', '𝐵-bacc', '𝜏-dup']
+  - meta: 𝜏-box
+    function: random-tau
+    args: ['𝐵-sacc', '𝐵-bacc', '𝜏-dup', '𝜏-load']
+  - meta: 𝜏-add
+    function: random-tau
+    args: ['𝐵-sacc', '𝐵-bacc', '𝜏-dup', '𝜏-load', '𝜏-box']
+  - meta: 𝜏-pop
+    function: random-tau
+    args: ['𝐵-sacc', '𝐵-bacc', '𝜏-dup', '𝜏-load', '𝜏-box', '𝜏-add']
+  - meta: 𝜏-fetch
+    function: random-tau
+    args: ['𝐵-sacc', '𝐵-bacc', '𝜏-dup', '𝜏-load', '𝜏-box', '𝜏-add', '𝜏-pop']
+  - meta: 𝜏-iv
+    function: random-tau
+    args: ['𝐵-sacc', '𝐵-bacc', '𝜏-dup', '𝜏-load', '𝜏-box', '𝜏-add', '𝜏-pop', '𝜏-fetch']

--- a/src/main/resources/org/eolang/hone/rules/streams/3xx/314-cp-filter-to-distill.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/3xx/314-cp-filter-to-distill.phr
@@ -5,7 +5,7 @@
 # Folds a Φ.hone.cp-filter (a capturing primitive filter recognised by 113) into
 # a Φ.hone.distill, the capturing analogue of 304 + the state mechanism of
 # 307/308. The captured int rides the shared List exactly as in 316 (see its
-# header for the state block and the load-bearing swap).
+# header for the state block).
 #
 # body: a filter guard prefixed with the fetch+unbox+swap that brings the
 # captured int below the item. Because the predicate consumes the item, the body

--- a/src/main/resources/org/eolang/hone/rules/streams/3xx/314-cp-filter-to-distill.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/3xx/314-cp-filter-to-distill.phr
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Folds a Φ.hone.cp-filter (a capturing primitive filter recognised by 113) into
+# a Φ.hone.distill, the capturing analogue of 304 + the state mechanism of
+# 307/308. The captured int rides the shared List exactly as in 316 (see its
+# header for the state block and the load-bearing swap).
+#
+# body: a filter guard prefixed with the fetch+unbox+swap that brings the
+# captured int below the item. Because the predicate consumes the item, the body
+# opens with a `dup` to keep a copy for the keep path — unlike a plain filter
+# (305/304) whose dup is spliced in later by 431/281, a c-filter carries its own
+# dup so the "c-filter" start label can keep 431 (which only matches start
+# "filter") away. The sequence on entry [item]:
+#   dup            [item, item]
+#   fetch;intValue [item, item, int captured]
+#   swap           [item, int captured, item]
+#   invokestatic   [item, Z]          (predicate consumes captured + item copy)
+#   ifne L         [item]             keep, else fall through and return (drop)
+# The keep label leaves a single [item], so the Φ.hone.frame-item marker (503
+# fills it with the counter-aware of4 frame once 502 has set captured=List) is
+# the same single-item frame distinct/skip use.
+name: cp-filter-to-distill
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.cp-filter,
+    class ↦ 𝑒-class,
+    bridge-input ↦ 𝑒-bridge-input,
+    bridge-output ↦ 𝑒-bridge-output,
+    accepted ↦ 𝑒-accepted,
+    returned ↦ 𝑒-returned,
+    static ↦ 𝑒-static,
+    captured ↦ 𝑒-captured,
+    capture-push ↦ 𝑒-capture-push,
+    interface ↦ 𝑒-interface,
+    method ↦ 𝑒-method,
+    lambda-signature ↦ 𝑒-lambda-signature,
+    bridge-signature ↦ 𝑒-bridge-signature,
+    target ↦ ⟦
+      handle ↦ 𝑒-target-handle,
+      class ↦ 𝑒-target-class,
+      method ↦ 𝑒-target-method,
+      signature ↦ 𝑒-target-signature,
+      is-interface ↦ 𝑒-target-is-interface
+    ⟧
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.distill,
+    class ↦ 𝑒-class,
+    bridge-input ↦ 𝑒-bridge-input,
+    bridge-output ↦ 𝑒-bridge-output,
+    start ↦ "c-filter",
+    accepted ↦ 𝑒-accepted,
+    returned ↦ 𝑒-returned,
+    static ↦ 𝑒-static,
+    state ↦ ⟦
+      𝜏-dup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+      𝜏-load ↦ 𝑒-capture-push,
+      𝜏-box ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokestatic,
+        i2 ↦ "java/lang/Integer",
+        i3 ↦ "valueOf",
+        i4 ↦ "(I)Ljava/lang/Integer;",
+        i5 ↦ Φ.false
+      ⟧,
+      𝜏-add ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokeinterface,
+        i2 ↦ "java/util/List",
+        i3 ↦ "add",
+        i4 ↦ "(Ljava/lang/Object;)Z",
+        i5 ↦ Φ.true
+      ⟧,
+      𝜏-pop ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+      ρ ↦ ∅
+    ⟧,
+    body ↦ ⟦
+      i1 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+      i2 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
+      i3 ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokevirtual,
+        i1 ↦ "java/lang/Integer",
+        i2 ↦ "intValue",
+        i3 ↦ "()I",
+        i4 ↦ Φ.false
+      ⟧,
+      i4 ↦ ⟦ φ ↦ Φ.jeo.opcode.swap ⟧,
+      i5 ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokestatic,
+        i1 ↦ 𝑒-target-class,
+        i2 ↦ 𝑒-target-method,
+        i3 ↦ 𝑒-target-signature,
+        i4 ↦ 𝑒-target-is-interface
+      ⟧,
+      i6 ↦ ⟦
+        φ ↦ Φ.jeo.opcode.ifne,
+        i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label ⟧
+      ⟧,
+      i7 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      i8 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label ⟧,
+      i9 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧
+    ⟧
+  ⟧
+where:
+  - meta: 𝑒-label
+    function: random-string
+    args: ['"L%d"']
+  - meta: 𝜏-dup
+    function: random-tau
+    args: []
+  - meta: 𝜏-load
+    function: random-tau
+    args: ['𝜏-dup']
+  - meta: 𝜏-box
+    function: random-tau
+    args: ['𝜏-dup', '𝜏-load']
+  - meta: 𝜏-add
+    function: random-tau
+    args: ['𝜏-dup', '𝜏-load', '𝜏-box']
+  - meta: 𝜏-pop
+    function: random-tau
+    args: ['𝜏-dup', '𝜏-load', '𝜏-box', '𝜏-add']

--- a/src/main/resources/org/eolang/hone/rules/streams/3xx/316-c-map-to-distill.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/3xx/316-c-map-to-distill.phr
@@ -2,46 +2,43 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-# Folds a Φ.hone.c-map (a capturing map recognised by 112) into a Φ.hone.distill,
-# the capturing analogue of how 306 folds a plain map — except a capture is, in
-# this design, "a map that owns one slot in the shared state List". So the fold
-# borrows the state mechanism distinct/skip use (307/308): the captured int is
-# appended to the List in the `state` block and read back in the body via a
-# Φ.hone.fetch marker, so two capturing operators fuse by 401's blind state+body
-# join exactly like two distincts.
+# Folds a Φ.hone.c-map (a capturing map recognised by 112 and gathered by 114)
+# into a Φ.hone.distill, the capturing analogue of how 306 folds a plain map —
+# except a capture is, in this design, "a map that owns one slot in the shared
+# state List per captured value". So the fold borrows the state mechanism
+# distinct/skip use (307/308): every captured int is appended to the List in the
+# `state` block and read back in the body via a Φ.hone.fetch marker, so two
+# capturing operators fuse by 401's blind state+body join exactly like two
+# distincts.
 #
-# state: with the List already on the stack, `dup; <capture-push>; Integer.valueOf;
-# List.add; pop` boxes the captured int and appends it — beginning and ending at
-# [list], peak 3, so any number of these join without growing the caller's stack.
-# The <capture-push> is the original `iload k` 112 lifted out of the body, so the
-# value is read in the ORIGINAL method's frame where local k is still live.
-#
-# body (auto emit-shape, one item in one item out): `fetch; intValue; swap;
-# invokestatic lambda$`. The fetch (521 -> aload0; iload3; List.get; iinc;
-# checkcast Integer) pushes the boxed capture, intValue unboxes it, and the SWAP
-# is the load-bearing step — the static lambda$ wants (int captured, Integer item)
-# with the item on top, but item+fetch leaves [item, captured]; the swap restores
-# [captured, item]. Omitting it inverts the two operands silently (both are
-# int-ish, so the verifier accepts it) — a miscompile the e2e numeric result
-# catches. The start label "c-map" (not "map") keeps 431/281 off this body — the
-# dup they insert for a plain filter has no business here — and lets 443 find an
-# unfused capturing map to revert.
+# 114 has already assembled both halves into the c-map's accumulators:
+#   state-acc — one `dup; iload k; Integer.valueOf; List.add; pop` per capture,
+#               in left-to-right order (slot 0 = first capture); it becomes the
+#               distill `state` verbatim.
+#   body-acc  — one `fetch; intValue` per capture (521 later turns each fetch
+#               into List.get(counter++); the intValue unboxes it).
+# This rule wraps body-acc into the auto emit-shape (one item in, one item out):
+#   astore 1            park the incoming item in its own (now-dead) param slot
+#   <body-acc>          push capture 0, 1, … N-1 as ints
+#   aload 1             reload the item on top
+#   invokestatic lambda$  call (int…, Integer) -> Integer with the right stack
+# Parking in local 1 (which 512's wrapper only reads once, at entry) needs no
+# extra local, so 512's max-locals is untouched. The N-ary park/reload replaces
+# v1's single-capture `swap`, so one capture and many captures share one shape.
+# The start label "c-map" (not "map") keeps 431/281 off this body and lets 443
+# find an unfused single-capture map to revert.
 name: c-map-to-distill
 pattern: |
   ⟦
     φ ↦ Φ.hone.c-map,
+    state-acc ↦ ⟦ 𝐵-sacc, ρ ↦ ∅ ⟧,
+    body-acc ↦ ⟦ 𝐵-bacc, ρ ↦ ∅ ⟧,
     class ↦ 𝑒-class,
     bridge-input ↦ 𝑒-bridge-input,
     bridge-output ↦ 𝑒-bridge-output,
     accepted ↦ 𝑒-accepted,
     returned ↦ 𝑒-returned,
     static ↦ 𝑒-static,
-    captured ↦ 𝑒-captured,
-    capture-push ↦ 𝑒-capture-push,
-    interface ↦ 𝑒-interface,
-    method ↦ 𝑒-method,
-    lambda-signature ↦ 𝑒-lambda-signature,
-    bridge-signature ↦ 𝑒-bridge-signature,
     target ↦ ⟦
       handle ↦ 𝑒-target-handle,
       class ↦ 𝑒-target-class,
@@ -60,58 +57,28 @@ result: |
     accepted ↦ 𝑒-accepted,
     returned ↦ 𝑒-returned,
     static ↦ 𝑒-static,
-    state ↦ ⟦
-      𝜏-dup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
-      𝜏-load ↦ 𝑒-capture-push,
-      𝜏-box ↦ ⟦
-        φ ↦ Φ.jeo.opcode.invokestatic,
-        i2 ↦ "java/lang/Integer",
-        i3 ↦ "valueOf",
-        i4 ↦ "(I)Ljava/lang/Integer;",
-        i5 ↦ Φ.false
-      ⟧,
-      𝜏-add ↦ ⟦
-        φ ↦ Φ.jeo.opcode.invokeinterface,
-        i2 ↦ "java/util/List",
-        i3 ↦ "add",
-        i4 ↦ "(Ljava/lang/Object;)Z",
-        i5 ↦ Φ.true
-      ⟧,
-      𝜏-pop ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
-      ρ ↦ ∅
-    ⟧,
+    state ↦ ⟦ 𝐵-sacc, ρ ↦ ∅ ⟧,
     body ↦ ⟦
-      i1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
-      i2 ↦ ⟦
-        φ ↦ Φ.jeo.opcode.invokevirtual,
-        i1 ↦ "java/lang/Integer",
-        i2 ↦ "intValue",
-        i3 ↦ "()I",
-        i4 ↦ Φ.false
-      ⟧,
-      i3 ↦ ⟦ φ ↦ Φ.jeo.opcode.swap ⟧,
-      i4 ↦ ⟦
+      𝜏-park ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, i1 ↦ 1 ⟧,
+      𝐵-bacc,
+      𝜏-reload ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
+      𝜏-call ↦ ⟦
         φ ↦ Φ.jeo.opcode.invokestatic,
         i1 ↦ 𝑒-target-class,
         i2 ↦ 𝑒-target-method,
         i3 ↦ 𝑒-target-signature,
         i4 ↦ 𝑒-target-is-interface
-      ⟧
+      ⟧,
+      ρ ↦ ∅
     ⟧
   ⟧
 where:
-  - meta: 𝜏-dup
+  - meta: 𝜏-park
     function: random-tau
-    args: []
-  - meta: 𝜏-load
+    args: ['𝐵-bacc']
+  - meta: 𝜏-reload
     function: random-tau
-    args: ['𝜏-dup']
-  - meta: 𝜏-box
+    args: ['𝐵-bacc', '𝜏-park']
+  - meta: 𝜏-call
     function: random-tau
-    args: ['𝜏-dup', '𝜏-load']
-  - meta: 𝜏-add
-    function: random-tau
-    args: ['𝜏-dup', '𝜏-load', '𝜏-box']
-  - meta: 𝜏-pop
-    function: random-tau
-    args: ['𝜏-dup', '𝜏-load', '𝜏-box', '𝜏-add']
+    args: ['𝐵-bacc', '𝜏-park', '𝜏-reload']

--- a/src/main/resources/org/eolang/hone/rules/streams/3xx/316-c-map-to-distill.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/3xx/316-c-map-to-distill.phr
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Folds a Φ.hone.c-map (a capturing map recognised by 112) into a Φ.hone.distill,
+# the capturing analogue of how 306 folds a plain map — except a capture is, in
+# this design, "a map that owns one slot in the shared state List". So the fold
+# borrows the state mechanism distinct/skip use (307/308): the captured int is
+# appended to the List in the `state` block and read back in the body via a
+# Φ.hone.fetch marker, so two capturing operators fuse by 401's blind state+body
+# join exactly like two distincts.
+#
+# state: with the List already on the stack, `dup; <capture-push>; Integer.valueOf;
+# List.add; pop` boxes the captured int and appends it — beginning and ending at
+# [list], peak 3, so any number of these join without growing the caller's stack.
+# The <capture-push> is the original `iload k` 112 lifted out of the body, so the
+# value is read in the ORIGINAL method's frame where local k is still live.
+#
+# body (auto emit-shape, one item in one item out): `fetch; intValue; swap;
+# invokestatic lambda$`. The fetch (521 -> aload0; iload3; List.get; iinc;
+# checkcast Integer) pushes the boxed capture, intValue unboxes it, and the SWAP
+# is the load-bearing step — the static lambda$ wants (int captured, Integer item)
+# with the item on top, but item+fetch leaves [item, captured]; the swap restores
+# [captured, item]. Omitting it inverts the two operands silently (both are
+# int-ish, so the verifier accepts it) — a miscompile the e2e numeric result
+# catches. The start label "c-map" (not "map") keeps 431/281 off this body — the
+# dup they insert for a plain filter has no business here — and lets 443 find an
+# unfused capturing map to revert.
+name: c-map-to-distill
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.c-map,
+    class ↦ 𝑒-class,
+    bridge-input ↦ 𝑒-bridge-input,
+    bridge-output ↦ 𝑒-bridge-output,
+    accepted ↦ 𝑒-accepted,
+    returned ↦ 𝑒-returned,
+    static ↦ 𝑒-static,
+    captured ↦ 𝑒-captured,
+    capture-push ↦ 𝑒-capture-push,
+    interface ↦ 𝑒-interface,
+    method ↦ 𝑒-method,
+    lambda-signature ↦ 𝑒-lambda-signature,
+    bridge-signature ↦ 𝑒-bridge-signature,
+    target ↦ ⟦
+      handle ↦ 𝑒-target-handle,
+      class ↦ 𝑒-target-class,
+      method ↦ 𝑒-target-method,
+      signature ↦ 𝑒-target-signature,
+      is-interface ↦ 𝑒-target-is-interface
+    ⟧
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.distill,
+    class ↦ 𝑒-class,
+    bridge-input ↦ 𝑒-bridge-input,
+    bridge-output ↦ 𝑒-bridge-output,
+    start ↦ "c-map",
+    accepted ↦ 𝑒-accepted,
+    returned ↦ 𝑒-returned,
+    static ↦ 𝑒-static,
+    state ↦ ⟦
+      𝜏-dup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+      𝜏-load ↦ 𝑒-capture-push,
+      𝜏-box ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokestatic,
+        i2 ↦ "java/lang/Integer",
+        i3 ↦ "valueOf",
+        i4 ↦ "(I)Ljava/lang/Integer;",
+        i5 ↦ Φ.false
+      ⟧,
+      𝜏-add ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokeinterface,
+        i2 ↦ "java/util/List",
+        i3 ↦ "add",
+        i4 ↦ "(Ljava/lang/Object;)Z",
+        i5 ↦ Φ.true
+      ⟧,
+      𝜏-pop ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+      ρ ↦ ∅
+    ⟧,
+    body ↦ ⟦
+      i1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
+      i2 ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokevirtual,
+        i1 ↦ "java/lang/Integer",
+        i2 ↦ "intValue",
+        i3 ↦ "()I",
+        i4 ↦ Φ.false
+      ⟧,
+      i3 ↦ ⟦ φ ↦ Φ.jeo.opcode.swap ⟧,
+      i4 ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokestatic,
+        i1 ↦ 𝑒-target-class,
+        i2 ↦ 𝑒-target-method,
+        i3 ↦ 𝑒-target-signature,
+        i4 ↦ 𝑒-target-is-interface
+      ⟧
+    ⟧
+  ⟧
+where:
+  - meta: 𝜏-dup
+    function: random-tau
+    args: []
+  - meta: 𝜏-load
+    function: random-tau
+    args: ['𝜏-dup']
+  - meta: 𝜏-box
+    function: random-tau
+    args: ['𝜏-dup', '𝜏-load']
+  - meta: 𝜏-add
+    function: random-tau
+    args: ['𝜏-dup', '𝜏-load', '𝜏-box']
+  - meta: 𝜏-pop
+    function: random-tau
+    args: ['𝜏-dup', '𝜏-load', '𝜏-box', '𝜏-add']

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/443-unfused-capturing-map-to-invokedynamic.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/443-unfused-capturing-map-to-invokedynamic.phr
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Reverts a capturing map (folded by 316) that never fused — the exact analogue
+# of 442 for skip. A lone capturing operator gains nothing from the mapMulti
+# machinery (an extra invokedynamic, a wrapper, an ArrayList and a List.get per
+# element) and would be strictly slower than the native Stream.map the JVM
+# already has, so a c-map distill still carrying ONLY its single boxing append
+# and bare auto-body is put back as the original invokedynamic + Stream.map. This
+# matters for the issue-#636 example itself (`map(i -> i + x)` with no neighbour
+# to fuse): it must come out native, never pessimised.
+#
+# Both the state block and the body match below are CLOSED (no 𝐵-rest), so a
+# FUSED c-map — whose state and body carry a second operator's append and
+# guard — is left for 502. The capture-push (𝑒-push) is recovered from the state
+# and replayed before the indy; the target handle is read from the body's
+# invokestatic. The 𝜑-calculus fields the fold dropped (the Function SAM name,
+# the erased lambda-signature, the captured "(I)" interface) are constants for an
+# int-capture Stream<Integer> map, so they are reconstructed literally. The
+# reverted Stream.map carries `reverted ↦ Φ.true`: 112's invokeinterface pattern
+# is closed on the four-operand opcode jeo emits, so the fifth binding stops 112
+# re-lifting this map and the 112 → 316 → 443 cycle cannot spin (jeo ignores the
+# extra binding, exactly as for 442's skip).
+name: unfused-capturing-map-to-invokedynamic
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-distill ↦ ⟦
+      φ ↦ Φ.hone.distill,
+      class ↦ 𝑒-class,
+      bridge-input ↦ 𝑒-bridge-input,
+      bridge-output ↦ 𝑒-bridge-output,
+      start ↦ "c-map",
+      accepted ↦ 𝑒-accepted,
+      returned ↦ 𝑒-returned,
+      static ↦ 𝑒-static,
+      state ↦ ⟦
+        𝜏-dup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+        𝜏-load ↦ 𝑒-push,
+        𝜏-box ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokestatic,
+          i2 ↦ "java/lang/Integer",
+          i3 ↦ "valueOf",
+          i4 ↦ "(I)Ljava/lang/Integer;",
+          i5 ↦ Φ.false
+        ⟧,
+        𝜏-add ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          i2 ↦ "java/util/List",
+          i3 ↦ "add",
+          i4 ↦ "(Ljava/lang/Object;)Z",
+          i5 ↦ Φ.true
+        ⟧,
+        𝜏-pop ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+        ρ ↦ ∅
+      ⟧,
+      body ↦ ⟦
+        𝜏-fetch ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
+        𝜏-unbox ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokevirtual,
+          i1 ↦ "java/lang/Integer",
+          i2 ↦ "intValue",
+          i3 ↦ "()I",
+          i4 ↦ Φ.false
+        ⟧,
+        𝜏-swap ↦ ⟦ φ ↦ Φ.jeo.opcode.swap ⟧,
+        𝜏-call ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokestatic,
+          i1 ↦ 𝑒-target-class,
+          i2 ↦ 𝑒-target-method,
+          i3 ↦ 𝑒-target-signature,
+          i4 ↦ 𝑒-target-is-interface
+        ⟧,
+        ρ ↦ ∅
+      ⟧
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-push-back ↦ 𝑒-push,
+    𝜏-indy ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokedynamic,
+      v0 ↦ "apply",
+      v1 ↦ "(I)Ljava/util/function/Function;",
+      h2 ↦ ⟦
+        φ ↦ Φ.jeo.handle,
+        v0 ↦ 6,
+        v1 ↦ "java/lang/invoke/LambdaMetafactory",
+        v2 ↦ "metafactory",
+        v3 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+        v4 ↦ Φ.false
+      ⟧,
+      t3 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Object;)Ljava/lang/Object;" ⟧,
+      h4 ↦ ⟦
+        φ ↦ Φ.jeo.handle,
+        v0 ↦ 6,
+        v1 ↦ 𝑒-target-class,
+        v2 ↦ 𝑒-target-method,
+        v3 ↦ 𝑒-target-signature,
+        v4 ↦ 𝑒-target-is-interface
+      ⟧,
+      t5 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Integer;)Ljava/lang/Integer;" ⟧
+    ⟧,
+    𝜏-map ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      v0 ↦ "java/util/stream/Stream",
+      v1 ↦ "map",
+      v2 ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;",
+      v3 ↦ Φ.true,
+      reverted ↦ Φ.true
+    ⟧,
+    𝐵-after
+  ⟧
+where:
+  - meta: 𝜏-push-back
+    function: random-tau
+    args: ['𝐵-before', '𝐵-after']
+  - meta: 𝜏-indy
+    function: random-tau
+    args: ['𝐵-before', '𝐵-after', '𝜏-push-back']
+  - meta: 𝜏-map
+    function: random-tau
+    args: ['𝐵-before', '𝐵-after', '𝜏-push-back', '𝜏-indy']

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/443-unfused-capturing-map-to-invokedynamic.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/443-unfused-capturing-map-to-invokedynamic.phr
@@ -7,15 +7,21 @@
 # machinery (an extra invokedynamic, a wrapper, an ArrayList and a List.get per
 # element) and would be strictly slower than the native Stream.map the JVM
 # already has, so a c-map distill still carrying ONLY its single boxing append
-# and bare auto-body is put back as the original invokedynamic + Stream.map. This
+# and the single-capture park/reload body (astore 1; fetch; intValue; aload 1;
+# invokestatic) is put back as the original invokedynamic + Stream.map. This
 # matters for the issue-#636 example itself (`map(i -> i + x)` with no neighbour
 # to fuse): it must come out native, never pessimised.
 #
 # Both the state block and the body match below are CLOSED (no 𝐵-rest), so a
 # FUSED c-map — whose state and body carry a second operator's append and
-# guard — is left for 502. The capture-push (𝑒-push) is recovered from the state
-# and replayed before the indy; the target handle is read from the body's
-# invokestatic. The 𝜑-calculus fields the fold dropped (the Function SAM name,
+# guard — is left for 502. A MULTI-capture lone map (two or more appends, the
+# v1.1 `map(i -> i + x + y)` shape) likewise fails this single-append, single-
+# fetch pattern and is emitted as a standalone mapMulti rather than reverted:
+# correct, only marginally slower than native, and a rarer shape than the lone
+# single-capture map. Reverting it (replaying N pushes and rebuilding the
+# "(I^N)" descriptor) is a follow-up puzzle. The capture-push (𝑒-push) is
+# recovered from the state and replayed before the indy; the target handle is
+# read from the body's invokestatic. The 𝜑-calculus fields the fold dropped (the Function SAM name,
 # the erased lambda-signature, the captured "(I)" interface) are constants for an
 # int-capture Stream<Integer> map, so they are reconstructed literally. The
 # reverted Stream.map carries `reverted ↦ Φ.true`: 112's invokeinterface pattern
@@ -56,6 +62,7 @@ pattern: |
         ρ ↦ ∅
       ⟧,
       body ↦ ⟦
+        𝜏-park ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, i1 ↦ 1 ⟧,
         𝜏-fetch ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
         𝜏-unbox ↦ ⟦
           φ ↦ Φ.jeo.opcode.invokevirtual,
@@ -64,7 +71,7 @@ pattern: |
           i3 ↦ "()I",
           i4 ↦ Φ.false
         ⟧,
-        𝜏-swap ↦ ⟦ φ ↦ Φ.jeo.opcode.swap ⟧,
+        𝜏-reload ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
         𝜏-call ↦ ⟦
           φ ↦ Φ.jeo.opcode.invokestatic,
           i1 ↦ 𝑒-target-class,

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/444-unfused-capturing-filter-to-invokedynamic.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/444-unfused-capturing-filter-to-invokedynamic.phr
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The filter twin of 443. Reverts a capturing primitive-filter (folded by 314)
+# that never fused back to its native invokedynamic + Stream.filter, replaying
+# the capture-push and marking the call `reverted ↦ Φ.true` so 113 cannot
+# re-lift it (its invokeinterface pattern is closed, the same loop-break 442/443
+# rely on). The closed state + body match only an UNFUSED c-filter; a fused one
+# carries a neighbour's guard and is left for 502. The body match includes the
+# leading item-preserve dup and the keep-guard 314 built (fetch; intValue; swap;
+# predicate; ifne; return; label; frame-item), and the Predicate SAM constants
+# are reconstructed literally for the int-capture Stream<Integer> case.
+name: unfused-capturing-filter-to-invokedynamic
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-distill ↦ ⟦
+      φ ↦ Φ.hone.distill,
+      class ↦ 𝑒-class,
+      bridge-input ↦ 𝑒-bridge-input,
+      bridge-output ↦ 𝑒-bridge-output,
+      start ↦ "c-filter",
+      accepted ↦ 𝑒-accepted,
+      returned ↦ 𝑒-returned,
+      static ↦ 𝑒-static,
+      state ↦ ⟦
+        𝜏-dup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+        𝜏-load ↦ 𝑒-push,
+        𝜏-box ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokestatic,
+          i2 ↦ "java/lang/Integer",
+          i3 ↦ "valueOf",
+          i4 ↦ "(I)Ljava/lang/Integer;",
+          i5 ↦ Φ.false
+        ⟧,
+        𝜏-add ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          i2 ↦ "java/util/List",
+          i3 ↦ "add",
+          i4 ↦ "(Ljava/lang/Object;)Z",
+          i5 ↦ Φ.true
+        ⟧,
+        𝜏-pop ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+        ρ ↦ ∅
+      ⟧,
+      body ↦ ⟦
+        𝜏-itemdup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+        𝜏-fetch ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
+        𝜏-unbox ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokevirtual,
+          i1 ↦ "java/lang/Integer",
+          i2 ↦ "intValue",
+          i3 ↦ "()I",
+          i4 ↦ Φ.false
+        ⟧,
+        𝜏-swap ↦ ⟦ φ ↦ Φ.jeo.opcode.swap ⟧,
+        𝜏-call ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokestatic,
+          i1 ↦ 𝑒-target-class,
+          i2 ↦ 𝑒-target-method,
+          i3 ↦ 𝑒-target-signature,
+          i4 ↦ 𝑒-target-is-interface
+        ⟧,
+        𝜏-ifne ↦ ⟦
+          φ ↦ Φ.jeo.opcode.ifne,
+          i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label ⟧
+        ⟧,
+        𝜏-return ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+        𝜏-label ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label ⟧,
+        𝜏-frame ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+        ρ ↦ ∅
+      ⟧
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-push-back ↦ 𝑒-push,
+    𝜏-indy ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokedynamic,
+      v0 ↦ "test",
+      v1 ↦ "(I)Ljava/util/function/Predicate;",
+      h2 ↦ ⟦
+        φ ↦ Φ.jeo.handle,
+        v0 ↦ 6,
+        v1 ↦ "java/lang/invoke/LambdaMetafactory",
+        v2 ↦ "metafactory",
+        v3 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+        v4 ↦ Φ.false
+      ⟧,
+      t3 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Object;)Z" ⟧,
+      h4 ↦ ⟦
+        φ ↦ Φ.jeo.handle,
+        v0 ↦ 6,
+        v1 ↦ 𝑒-target-class,
+        v2 ↦ 𝑒-target-method,
+        v3 ↦ 𝑒-target-signature,
+        v4 ↦ 𝑒-target-is-interface
+      ⟧,
+      t5 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Integer;)Z" ⟧
+    ⟧,
+    𝜏-filter ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      v0 ↦ "java/util/stream/Stream",
+      v1 ↦ "filter",
+      v2 ↦ "(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;",
+      v3 ↦ Φ.true,
+      reverted ↦ Φ.true
+    ⟧,
+    𝐵-after
+  ⟧
+where:
+  - meta: 𝜏-push-back
+    function: random-tau
+    args: ['𝐵-before', '𝐵-after']
+  - meta: 𝜏-indy
+    function: random-tau
+    args: ['𝐵-before', '𝐵-after', '𝜏-push-back']
+  - meta: 𝜏-filter
+    function: random-tau
+    args: ['𝐵-before', '𝐵-after', '𝜏-push-back', '𝜏-indy']

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/444-unfused-capturing-filter-to-invokedynamic.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/444-unfused-capturing-filter-to-invokedynamic.phr
@@ -8,7 +8,7 @@
 # re-lift it (its invokeinterface pattern is closed, the same loop-break 442/443
 # rely on). The closed state + body match only an UNFUSED c-filter; a fused one
 # carries a neighbour's guard and is left for 502. The body match includes the
-# leading item-preserve dup and the keep-guard 314 built (fetch; intValue; swap;
+# leading item-preserving dup and the keep-guard 314 built (fetch; intValue; swap;
 # predicate; ifne; return; label; frame-item), and the Predicate SAM constants
 # are reconstructed literally for the int-capture Stream<Integer> case.
 name: unfused-capturing-filter-to-invokedynamic

--- a/src/test/phino/112-capturing-invokedynamic-to-map.yml
+++ b/src/test/phino/112-capturing-invokedynamic-to-map.yml
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A capturing map invokedynamic — descriptor "(I)L…Function;", a single int
+# capture pushed by the preceding iload, a handle-6 static lambda$ target — is
+# lifted to a Φ.hone.c-map pragma. The iload is GRABBED out of the body (carried
+# as capture-push) so no stray int is left on the stack, and the captured JVM
+# type rides as captured↦"I". 111 declines this indy (its "()" guard wants zero
+# captures), so the two rules partition the indy population.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
+input: |
+  {⟦
+    φ ↦ Φ.jeo.class,
+    version ↦ 68,
+    access ↦ 33,
+    modifiers ↦ ⟦ φ ↦ Φ.jeo.modifiers, static ↦ Φ.false ⟧,
+    name ↦ "Foo",
+    supername ↦ "java/lang/Object",
+    interfaces ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+    m$run ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 8,
+      modifiers ↦ ⟦ φ ↦ Φ.jeo.modifiers, static ↦ Φ.true ⟧,
+      name ↦ "run",
+      descriptor ↦ "(I)J",
+      signature ↦ "",
+      exceptions ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, m1 ↦ 4, m2 ↦ 1 ⟧,
+      params ↦ ⟦ φ ↦ Φ.jeo.params ⟧,
+      annotations ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      body ↦ ⟦
+        i20 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 0 ⟧,
+        i21 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokedynamic,
+          v0 ↦ "apply",
+          v1 ↦ "(I)Ljava/util/function/Function;",
+          h2 ↦ ⟦ φ ↦ Φ.jeo.handle, v0 ↦ 6, v1 ↦ "java/lang/invoke/LambdaMetafactory", v2 ↦ "metafactory", v3 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;", v4 ↦ Φ.false ⟧,
+          t3 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Object;)Ljava/lang/Object;" ⟧,
+          h4 ↦ ⟦ φ ↦ Φ.jeo.handle, v0 ↦ 6, v1 ↦ "Foo", v2 ↦ "lambda$run$0", v3 ↦ "(ILjava/lang/Integer;)Ljava/lang/Integer;", v4 ↦ Φ.false ⟧,
+          t5 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Integer;)Ljava/lang/Integer;" ⟧
+        ⟧,
+        i22 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "map", v2 ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;", v3 ↦ Φ.true ⟧
+      ⟧,
+      trycatchblocks ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      local-variable-table ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.hone.c-map, 𝐵-a, captured ↦ "I", 𝐵-b ⟧
+  - ⟦ φ ↦ Φ.hone.c-map, 𝐵-c, capture-push ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 0 ⟧, 𝐵-d ⟧
+  - ⟦ 𝐵-e, method ↦ "lambda$run$0", signature ↦ "(ILjava/lang/Integer;)Ljava/lang/Integer;", 𝐵-f ⟧

--- a/src/test/phino/112-capturing-invokedynamic-to-map.yml
+++ b/src/test/phino/112-capturing-invokedynamic-to-map.yml
@@ -2,12 +2,15 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-# A capturing map invokedynamic — descriptor "(I)L…Function;", a single int
-# capture pushed by the preceding iload, a handle-6 static lambda$ target — is
-# lifted to a Φ.hone.c-map pragma. The iload is GRABBED out of the body (carried
-# as capture-push) so no stray int is left on the stack, and the captured JVM
-# type rides as captured↦"I". 111 declines this indy (its "()" guard wants zero
-# captures), so the two rules partition the indy population.
+# A MULTI-capturing map invokedynamic — descriptor "(III)L…Function;", three int
+# captures pushed by the preceding iloads, a handle-6 static lambda$ target — is
+# lifted to a Φ.hone.c-map pragma. 112 consumes ONLY the indy and the
+# invokeinterface; it leaves the run of iload pushes inline in front of the c-map
+# (114 gathers them) and seeds two EMPTY accumulators. The target lambda$
+# signature "(IIILjava/lang/Integer;)Ljava/lang/Integer;" rides through verbatim.
+# 111 declines this indy (its "()" guard wants zero captures), so the two rules
+# partition the indy population; the relaxed "\(I+\)" guard also covers the
+# single-int case (one I) the same way.
 rules:
   - src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
 input: |
@@ -24,30 +27,32 @@ input: |
       access ↦ 8,
       modifiers ↦ ⟦ φ ↦ Φ.jeo.modifiers, static ↦ Φ.true ⟧,
       name ↦ "run",
-      descriptor ↦ "(I)J",
+      descriptor ↦ "(III)J",
       signature ↦ "",
       exceptions ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
-      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, m1 ↦ 4, m2 ↦ 1 ⟧,
+      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, m1 ↦ 6, m2 ↦ 3 ⟧,
       params ↦ ⟦ φ ↦ Φ.jeo.params ⟧,
       annotations ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
       body ↦ ⟦
         i20 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 0 ⟧,
-        i21 ↦ ⟦
+        i21 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 1 ⟧,
+        i22 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 2 ⟧,
+        i23 ↦ ⟦
           φ ↦ Φ.jeo.opcode.invokedynamic,
           v0 ↦ "apply",
-          v1 ↦ "(I)Ljava/util/function/Function;",
+          v1 ↦ "(III)Ljava/util/function/Function;",
           h2 ↦ ⟦ φ ↦ Φ.jeo.handle, v0 ↦ 6, v1 ↦ "java/lang/invoke/LambdaMetafactory", v2 ↦ "metafactory", v3 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;", v4 ↦ Φ.false ⟧,
           t3 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Object;)Ljava/lang/Object;" ⟧,
-          h4 ↦ ⟦ φ ↦ Φ.jeo.handle, v0 ↦ 6, v1 ↦ "Foo", v2 ↦ "lambda$run$0", v3 ↦ "(ILjava/lang/Integer;)Ljava/lang/Integer;", v4 ↦ Φ.false ⟧,
+          h4 ↦ ⟦ φ ↦ Φ.jeo.handle, v0 ↦ 6, v1 ↦ "Foo", v2 ↦ "lambda$run$1", v3 ↦ "(IIILjava/lang/Integer;)Ljava/lang/Integer;", v4 ↦ Φ.false ⟧,
           t5 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Integer;)Ljava/lang/Integer;" ⟧
         ⟧,
-        i22 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "map", v2 ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;", v3 ↦ Φ.true ⟧
+        i24 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "map", v2 ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;", v3 ↦ Φ.true ⟧
       ⟧,
       trycatchblocks ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
       local-variable-table ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
     ⟧
   ⟧}
 expected:
-  - ⟦ φ ↦ Φ.hone.c-map, 𝐵-a, captured ↦ "I", 𝐵-b ⟧
-  - ⟦ φ ↦ Φ.hone.c-map, 𝐵-c, capture-push ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 0 ⟧, 𝐵-d ⟧
-  - ⟦ 𝐵-e, method ↦ "lambda$run$0", signature ↦ "(ILjava/lang/Integer;)Ljava/lang/Integer;", 𝐵-f ⟧
+  - ⟦ φ ↦ Φ.hone.c-map, state-acc ↦ ⟦⟧, body-acc ↦ ⟦⟧, 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.hone.c-map, 𝐵-g, target ↦ ⟦ 𝐵-h, signature ↦ "(IIILjava/lang/Integer;)Ljava/lang/Integer;", 𝐵-i ⟧, 𝐵-j ⟧
+  - ⟦ 𝐵-k, 𝜏-last ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 2 ⟧, 𝜏-cm ↦ ⟦ φ ↦ Φ.hone.c-map, 𝐵-l ⟧, 𝐵-m ⟧

--- a/src/test/phino/113-capturing-invokedynamic-to-filter.yml
+++ b/src/test/phino/113-capturing-invokedynamic-to-filter.yml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The filter twin of 112: a capturing primitive-filter invokedynamic —
+# "(I)L…Predicate;", a handle-6 static lambda$ returning Z — is lifted to a
+# Φ.hone.cp-filter pragma with the captured int grabbed out of the body.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/1xx/113-capturing-invokedynamic-to-filter.phr
+input: |
+  {⟦
+    φ ↦ Φ.jeo.class,
+    version ↦ 68,
+    access ↦ 33,
+    modifiers ↦ ⟦ φ ↦ Φ.jeo.modifiers, static ↦ Φ.false ⟧,
+    name ↦ "Foo",
+    supername ↦ "java/lang/Object",
+    interfaces ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+    m$run ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 8,
+      modifiers ↦ ⟦ φ ↦ Φ.jeo.modifiers, static ↦ Φ.true ⟧,
+      name ↦ "run",
+      descriptor ↦ "(I)J",
+      signature ↦ "",
+      exceptions ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, m1 ↦ 4, m2 ↦ 1 ⟧,
+      params ↦ ⟦ φ ↦ Φ.jeo.params ⟧,
+      annotations ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      body ↦ ⟦
+        i20 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 0 ⟧,
+        i21 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokedynamic,
+          v0 ↦ "test",
+          v1 ↦ "(I)Ljava/util/function/Predicate;",
+          h2 ↦ ⟦ φ ↦ Φ.jeo.handle, v0 ↦ 6, v1 ↦ "java/lang/invoke/LambdaMetafactory", v2 ↦ "metafactory", v3 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;", v4 ↦ Φ.false ⟧,
+          t3 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Object;)Z" ⟧,
+          h4 ↦ ⟦ φ ↦ Φ.jeo.handle, v0 ↦ 6, v1 ↦ "Foo", v2 ↦ "lambda$run$0", v3 ↦ "(ILjava/lang/Integer;)Z", v4 ↦ Φ.false ⟧,
+          t5 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Integer;)Z" ⟧
+        ⟧,
+        i22 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "filter", v2 ↦ "(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;", v3 ↦ Φ.true ⟧
+      ⟧,
+      trycatchblocks ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      local-variable-table ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.hone.cp-filter, 𝐵-a, captured ↦ "I", 𝐵-b ⟧
+  - ⟦ φ ↦ Φ.hone.cp-filter, 𝐵-c, capture-push ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 0 ⟧, 𝐵-d ⟧
+  - ⟦ 𝐵-e, method ↦ "lambda$run$0", signature ↦ "(ILjava/lang/Integer;)Z", 𝐵-f ⟧

--- a/src/test/phino/114-c-map-peel-capture.yml
+++ b/src/test/phino/114-c-map-peel-capture.yml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 114 gathers the captures 112 left inline. The input mimics 112's output: a
+# Φ.hone.c-map with two EMPTY accumulators, preceded by two iload pushes (x at
+# slot v0=0, y at slot v0=1) and bounded on the left by the previous operator's
+# invokeinterface. Re-applied at fixpoint, 114 peels the iloads right-to-left
+# (greedy-left binds the LAST one first) and PREPENDS one unit per capture, so
+# state-acc ends up appending x THEN y (slot 0 = x) and body-acc gets two
+# `fetch; intValue` pairs. After it runs, no iload sits between the
+# invokeinterface and the c-map — every capture has moved into the accumulators.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/1xx/114-c-map-peel-capture.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      p ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "map", v2 ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;", v3 ↦ Φ.true ⟧,
+      x ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 0 ⟧,
+      y ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 1 ⟧,
+      cm ↦ ⟦
+        φ ↦ Φ.hone.c-map,
+        state-acc ↦ ⟦⟧,
+        body-acc ↦ ⟦⟧,
+        class ↦ "Foo",
+        bridge-input ↦ "Ljava/lang/Integer;",
+        bridge-output ↦ "Ljava/lang/Integer;",
+        accepted ↦ "Ljava/lang/Integer;",
+        returned ↦ "Ljava/lang/Integer;",
+        static ↦ "true",
+        target ↦ ⟦ handle ↦ 6, class ↦ "Foo", method ↦ "lambda$run$1", signature ↦ "(IILjava/lang/Integer;)Ljava/lang/Integer;", is-interface ↦ Φ.false ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.hone.c-map, state-acc ↦ ⟦ 𝜏-d ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧, 𝜏-l ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 0 ⟧, 𝐵-sr ⟧, 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.hone.c-map, 𝐵-a, body-acc ↦ ⟦ 𝜏-f1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧, 𝜏-iv ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, 𝐵-iv ⟧, 𝜏-f2 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧, 𝐵-br ⟧, 𝐵-c ⟧
+  - ⟦ 𝐵-x, 𝜏-p ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", 𝐵-pr ⟧, 𝜏-cm ↦ ⟦ φ ↦ Φ.hone.c-map, 𝐵-cr ⟧, 𝐵-y ⟧

--- a/src/test/phino/314-cp-filter-to-distill.yml
+++ b/src/test/phino/314-cp-filter-to-distill.yml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 # A capturing primitive-filter pragma (113's output) folds into a stateful
 # Φ.hone.distill: same boxed-capture append as 316, plus a guard body that opens
-# with a `dup` (the item-preserve the predicate consumes) then fetch; intValue;
+# with an item-preserving `dup` (the predicate consumes the item) then fetch; intValue;
 # swap; predicate; ifne keep; return drop. The keep label carries a
 # Φ.hone.frame-item marker that 503 fills once 502 has set captured=List.
 rules:

--- a/src/test/phino/314-cp-filter-to-distill.yml
+++ b/src/test/phino/314-cp-filter-to-distill.yml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A capturing primitive-filter pragma (113's output) folds into a stateful
+# Φ.hone.distill: same boxed-capture append as 316, plus a guard body that opens
+# with a `dup` (the item-preserve the predicate consumes) then fetch; intValue;
+# swap; predicate; ifne keep; return drop. The keep label carries a
+# Φ.hone.frame-item marker that 503 fills once 502 has set captured=List.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/3xx/314-cp-filter-to-distill.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      op ↦ ⟦
+        φ ↦ Φ.hone.cp-filter,
+        class ↦ "Foo",
+        bridge-input ↦ "Ljava/lang/Integer;",
+        bridge-output ↦ "Ljava/lang/Integer;",
+        accepted ↦ "Ljava/lang/Integer;",
+        returned ↦ "Ljava/lang/Integer;",
+        static ↦ "true",
+        captured ↦ "I",
+        capture-push ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 3 ⟧,
+        interface ↦ "(I)Ljava/util/function/Predicate;",
+        method ↦ "test",
+        lambda-signature ↦ "(Ljava/lang/Object;)Z",
+        bridge-signature ↦ "(Ljava/lang/Integer;)Z",
+        target ↦ ⟦ handle ↦ 6, class ↦ "Foo", method ↦ "lambda$run$0", signature ↦ "(ILjava/lang/Integer;)Z", is-interface ↦ Φ.false ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.hone.distill, 𝐵-a, start ↦ "c-filter", 𝐵-b ⟧
+  - ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.swap ⟧
+  - ⟦ φ ↦ Φ.hone.frame-item ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokestatic, 𝐵-c, i2 ↦ "lambda$run$0", i3 ↦ "(ILjava/lang/Integer;)Z", 𝐵-d ⟧

--- a/src/test/phino/316-c-map-to-distill.yml
+++ b/src/test/phino/316-c-map-to-distill.yml
@@ -2,38 +2,49 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-# A capturing map pragma (112's output) folds into a stateful Φ.hone.distill: the
-# captured int is boxed and appended to the shared List in `state`, and the body
-# reads it back with a fetch, unboxes it, SWAPs it below the item and calls the
-# static lambda$. The start label is "c-map" so 431/281 leave it alone.
+# 316 assembles the accumulators 114 has filled into a stateful Φ.hone.distill.
+# The input is a two-capture c-map: state-acc already holds two boxing appends
+# (capture x at v0=0 then y at v0=1) and body-acc two `fetch; intValue` pairs.
+# 316 copies state-acc into the distill `state` verbatim and wraps body-acc into
+# the auto emit-shape `astore 1; <fetches>; aload 1; invokestatic lambda$` — the
+# item parked in its own dead local-1 slot, the unboxed captures left below it
+# exactly as the static lambda$ (int, int, Integer) signature wants. start is
+# "c-map" so 401 fuses it and 443 can find a lone single-capture map.
 rules:
   - src/main/resources/org/eolang/hone/rules/streams/3xx/316-c-map-to-distill.phr
 input: |
   {⟦
-    body ↦ ⟦
-      op ↦ ⟦
-        φ ↦ Φ.hone.c-map,
-        class ↦ "Foo",
-        bridge-input ↦ "Ljava/lang/Integer;",
-        bridge-output ↦ "Ljava/lang/Integer;",
-        accepted ↦ "Ljava/lang/Integer;",
-        returned ↦ "Ljava/lang/Integer;",
-        static ↦ "true",
-        captured ↦ "I",
-        capture-push ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 7 ⟧,
-        interface ↦ "(I)Ljava/util/function/Function;",
-        method ↦ "apply",
-        lambda-signature ↦ "(Ljava/lang/Object;)Ljava/lang/Object;",
-        bridge-signature ↦ "(Ljava/lang/Integer;)Ljava/lang/Integer;",
-        target ↦ ⟦ handle ↦ 6, class ↦ "Foo", method ↦ "lambda$run$0", signature ↦ "(ILjava/lang/Integer;)Ljava/lang/Integer;", is-interface ↦ Φ.false ⟧
-      ⟧,
+    φ ↦ Φ.hone.c-map,
+    state-acc ↦ ⟦
+      s1 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+      s2 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 0 ⟧,
+      s3 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "java/lang/Integer", i3 ↦ "valueOf", i4 ↦ "(I)Ljava/lang/Integer;", i5 ↦ Φ.false ⟧,
+      s4 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/List", i3 ↦ "add", i4 ↦ "(Ljava/lang/Object;)Z", i5 ↦ Φ.true ⟧,
+      s5 ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+      s6 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+      s7 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 1 ⟧,
+      s8 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "java/lang/Integer", i3 ↦ "valueOf", i4 ↦ "(I)Ljava/lang/Integer;", i5 ↦ Φ.false ⟧,
+      s9 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/List", i3 ↦ "add", i4 ↦ "(Ljava/lang/Object;)Z", i5 ↦ Φ.true ⟧,
+      s10 ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
       ρ ↦ ∅
-    ⟧
+    ⟧,
+    body-acc ↦ ⟦
+      b1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
+      b2 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, i1 ↦ "java/lang/Integer", i2 ↦ "intValue", i3 ↦ "()I", i4 ↦ Φ.false ⟧,
+      b3 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
+      b4 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, i1 ↦ "java/lang/Integer", i2 ↦ "intValue", i3 ↦ "()I", i4 ↦ Φ.false ⟧,
+      ρ ↦ ∅
+    ⟧,
+    class ↦ "Foo",
+    bridge-input ↦ "Ljava/lang/Integer;",
+    bridge-output ↦ "Ljava/lang/Integer;",
+    accepted ↦ "Ljava/lang/Integer;",
+    returned ↦ "Ljava/lang/Integer;",
+    static ↦ "true",
+    target ↦ ⟦ handle ↦ 6, class ↦ "Foo", method ↦ "lambda$run$1", signature ↦ "(IILjava/lang/Integer;)Ljava/lang/Integer;", is-interface ↦ Φ.false ⟧
   ⟧}
 expected:
   - ⟦ φ ↦ Φ.hone.distill, 𝐵-a, start ↦ "c-map", 𝐵-b ⟧
-  - ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧
-  - ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 7 ⟧
-  - ⟦ φ ↦ Φ.jeo.opcode.swap ⟧
-  - ⟦ φ ↦ Φ.jeo.opcode.invokestatic, 𝐵-c, i3 ↦ "valueOf", 𝐵-d ⟧
-  - ⟦ φ ↦ Φ.jeo.opcode.invokestatic, 𝐵-e, i2 ↦ "lambda$run$0", 𝐵-f ⟧
+  - ⟦ 𝜏-park ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, i1 ↦ 1 ⟧, 𝜏-f ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧, 𝐵-br ⟧
+  - ⟦ 𝐵-e, 𝜏-reload ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧, 𝜏-call ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i1 ↦ "Foo", i2 ↦ "lambda$run$1", i3 ↦ "(IILjava/lang/Integer;)Ljava/lang/Integer;", i4 ↦ Φ.false ⟧, ρ ↦ ∅ ⟧
+  - ⟦ φ ↦ Φ.hone.distill, 𝐵-f, state ↦ ⟦ 𝜏-d1 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧, 𝜏-l1 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 0 ⟧, 𝐵-sr ⟧, 𝐵-g ⟧

--- a/src/test/phino/316-c-map-to-distill.yml
+++ b/src/test/phino/316-c-map-to-distill.yml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A capturing map pragma (112's output) folds into a stateful Φ.hone.distill: the
+# captured int is boxed and appended to the shared List in `state`, and the body
+# reads it back with a fetch, unboxes it, SWAPs it below the item and calls the
+# static lambda$. The start label is "c-map" so 431/281 leave it alone.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/3xx/316-c-map-to-distill.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      op ↦ ⟦
+        φ ↦ Φ.hone.c-map,
+        class ↦ "Foo",
+        bridge-input ↦ "Ljava/lang/Integer;",
+        bridge-output ↦ "Ljava/lang/Integer;",
+        accepted ↦ "Ljava/lang/Integer;",
+        returned ↦ "Ljava/lang/Integer;",
+        static ↦ "true",
+        captured ↦ "I",
+        capture-push ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 7 ⟧,
+        interface ↦ "(I)Ljava/util/function/Function;",
+        method ↦ "apply",
+        lambda-signature ↦ "(Ljava/lang/Object;)Ljava/lang/Object;",
+        bridge-signature ↦ "(Ljava/lang/Integer;)Ljava/lang/Integer;",
+        target ↦ ⟦ handle ↦ 6, class ↦ "Foo", method ↦ "lambda$run$0", signature ↦ "(ILjava/lang/Integer;)Ljava/lang/Integer;", is-interface ↦ Φ.false ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.hone.distill, 𝐵-a, start ↦ "c-map", 𝐵-b ⟧
+  - ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 7 ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.swap ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokestatic, 𝐵-c, i3 ↦ "valueOf", 𝐵-d ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokestatic, 𝐵-e, i2 ↦ "lambda$run$0", 𝐵-f ⟧

--- a/src/test/phino/443-unfused-capturing-map-to-invokedynamic.yml
+++ b/src/test/phino/443-unfused-capturing-map-to-invokedynamic.yml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A capturing-map distill that never fused (closed state + bare auto-body) is
+# reverted to the native invokedynamic + Stream.map, replaying the captured push
+# (iload 5) and marking the call reverted↦Φ.true so 112 cannot re-lift it. This
+# is the never-pessimise guarantee for a lone `map(i -> i + x)` — the issue-#636
+# example with no neighbour to fuse.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/4xx/443-unfused-capturing-map-to-invokedynamic.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      op ↦ ⟦
+        φ ↦ Φ.hone.distill,
+        class ↦ "Foo",
+        bridge-input ↦ "Ljava/lang/Integer;",
+        bridge-output ↦ "Ljava/lang/Integer;",
+        start ↦ "c-map",
+        accepted ↦ "Ljava/lang/Integer;",
+        returned ↦ "Ljava/lang/Integer;",
+        static ↦ "true",
+        state ↦ ⟦
+          s1 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+          s2 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 5 ⟧,
+          s3 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "java/lang/Integer", i3 ↦ "valueOf", i4 ↦ "(I)Ljava/lang/Integer;", i5 ↦ Φ.false ⟧,
+          s4 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/List", i3 ↦ "add", i4 ↦ "(Ljava/lang/Object;)Z", i5 ↦ Φ.true ⟧,
+          s5 ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+          ρ ↦ ∅
+        ⟧,
+        body ↦ ⟦
+          b1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
+          b2 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, i1 ↦ "java/lang/Integer", i2 ↦ "intValue", i3 ↦ "()I", i4 ↦ Φ.false ⟧,
+          b3 ↦ ⟦ φ ↦ Φ.jeo.opcode.swap ⟧,
+          b4 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i1 ↦ "Foo", i2 ↦ "lambda$run$0", i3 ↦ "(ILjava/lang/Integer;)Ljava/lang/Integer;", i4 ↦ Φ.false ⟧,
+          ρ ↦ ∅
+        ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.jeo.opcode.invokedynamic, 𝐵-a, v1 ↦ "(I)Ljava/util/function/Function;", 𝐵-b ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "map", v2 ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;", v3 ↦ Φ.true, reverted ↦ Φ.true ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 5 ⟧
+  - ⟦ φ ↦ Φ.jeo.handle, 𝐵-e, v2 ↦ "lambda$run$0", 𝐵-f ⟧

--- a/src/test/phino/443-unfused-capturing-map-to-invokedynamic.yml
+++ b/src/test/phino/443-unfused-capturing-map-to-invokedynamic.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-# A capturing-map distill that never fused (closed state + bare auto-body) is
+# A single-capture map distill that never fused (closed state + park/reload body) is
 # reverted to the native invokedynamic + Stream.map, replaying the captured push
 # (iload 5) and marking the call reverted↦Φ.true so 112 cannot re-lift it. This
 # is the never-pessimise guarantee for a lone `map(i -> i + x)` — the issue-#636
@@ -30,9 +30,10 @@ input: |
           ρ ↦ ∅
         ⟧,
         body ↦ ⟦
+          b0 ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, i1 ↦ 1 ⟧,
           b1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
           b2 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, i1 ↦ "java/lang/Integer", i2 ↦ "intValue", i3 ↦ "()I", i4 ↦ Φ.false ⟧,
-          b3 ↦ ⟦ φ ↦ Φ.jeo.opcode.swap ⟧,
+          b3 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
           b4 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i1 ↦ "Foo", i2 ↦ "lambda$run$0", i3 ↦ "(ILjava/lang/Integer;)Ljava/lang/Integer;", i4 ↦ Φ.false ⟧,
           ρ ↦ ∅
         ⟧

--- a/src/test/phino/444-unfused-capturing-filter-to-invokedynamic.yml
+++ b/src/test/phino/444-unfused-capturing-filter-to-invokedynamic.yml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The filter twin of 443: a capturing-filter distill that never fused (closed
+# state + the dup/guard body 314 built) reverts to the native invokedynamic +
+# Stream.filter, replaying the captured push and marking the call reverted so 113
+# cannot re-lift it.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/4xx/444-unfused-capturing-filter-to-invokedynamic.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      op ↦ ⟦
+        φ ↦ Φ.hone.distill,
+        class ↦ "Foo",
+        bridge-input ↦ "Ljava/lang/Integer;",
+        bridge-output ↦ "Ljava/lang/Integer;",
+        start ↦ "c-filter",
+        accepted ↦ "Ljava/lang/Integer;",
+        returned ↦ "Ljava/lang/Integer;",
+        static ↦ "true",
+        state ↦ ⟦
+          s1 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+          s2 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 5 ⟧,
+          s3 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "java/lang/Integer", i3 ↦ "valueOf", i4 ↦ "(I)Ljava/lang/Integer;", i5 ↦ Φ.false ⟧,
+          s4 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/List", i3 ↦ "add", i4 ↦ "(Ljava/lang/Object;)Z", i5 ↦ Φ.true ⟧,
+          s5 ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+          ρ ↦ ∅
+        ⟧,
+        body ↦ ⟦
+          b0 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+          b1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
+          b2 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, i1 ↦ "java/lang/Integer", i2 ↦ "intValue", i3 ↦ "()I", i4 ↦ Φ.false ⟧,
+          b3 ↦ ⟦ φ ↦ Φ.jeo.opcode.swap ⟧,
+          b4 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i1 ↦ "Foo", i2 ↦ "lambda$run$0", i3 ↦ "(ILjava/lang/Integer;)Z", i4 ↦ Φ.false ⟧,
+          b5 ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L9" ⟧ ⟧,
+          b6 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+          b7 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L9" ⟧,
+          b8 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+          ρ ↦ ∅
+        ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.jeo.opcode.invokedynamic, 𝐵-a, v1 ↦ "(I)Ljava/util/function/Predicate;", 𝐵-b ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "filter", v2 ↦ "(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;", v3 ↦ Φ.true, reverted ↦ Φ.true ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 5 ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams-closure-fusion.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-closure-fusion.yml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Focused end-to-end proof of capturing-lambda fusion (issue #636). Two
+# methods exercise both halves of the v1 behaviour:
+#
+#   fused : a capturing filter feeding a capturing map — the headline win.
+#           javac emits two capturing invokedynamics (filter "(I)L…Predicate;",
+#           map "(I)L…Function;") plus the mapToInt method-ref indy. 113/112
+#           lift them, 314/316 fold them into one stateful distill (the captured
+#           threshold and offset both ride the shared List), 401 fuses the pair
+#           and 502/512/521/601 emit a single Stream.mapMulti — so the two
+#           capturing indys collapse into one. The trailing mapToInt stays
+#           native (a stateful distill does not fuse a boundary unbox).
+#   lone  : a single capturing map with no neighbour. It cannot fuse, so 443
+#           reverts it to the native Stream.map invokedynamic — never the slower
+#           ArrayList+mapMulti. This is the issue's literal `map(i -> i + x)`
+#           example: correct AND not pessimised.
+#
+# invokedynamic count: before = filter + map + mapToInt (fused) + map (lone) = 4;
+# after = mapMulti + mapToInt (fused) + reverted map (lone) = 3. The single
+# dropped indy is the proof the two capturing operators fused into one dispatch.
+# The runtime line proves the captured values reach the lambda in the right
+# order (the body's swap): fused(3,100) keeps {4,5,6}, maps to {104,105,106},
+# sums to 315; lone(100) maps {1..5} and counts 5.
+java: |
+  package fusion;
+  import java.util.stream.*;
+  public class X {
+    static int fused(int threshold, int offset) {
+      return Stream.of(1, 2, 3, 4, 5, 6)
+        .filter(n -> n > threshold)
+        .map(n -> n + offset)
+        .mapToInt(Integer::intValue)
+        .sum();
+    }
+    static long lone(int offset) {
+      return Stream.of(1, 2, 3, 4, 5).map(n -> n + offset).count();
+    }
+    public static void main(String[] args) {
+      System.out.printf("The result is %d %d%n", fused(3, 100), lone(100));
+    }
+  }
+before:
+  invokedynamic: 4
+after:
+  invokedynamic: 3
+log:
+  - "BUILD SUCCESS"
+  - "The result is 315 5"

--- a/src/test/resources/org/eolang/hone/optimize/streams-closure-multicapture.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams-closure-multicapture.yml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# End-to-end proof of MULTI-capture closure fusion (issue #636, v1.1). This is
+# the case the issue's reporter raised as still unfusable after v1:
+#
+#   Stream.of(...).map(i -> i + 1).map(i -> i + x + y + z)...
+#
+# The second map captures THREE effectively-final ints, so javac compiles its
+# factory descriptor as "(III)L…Function;" and pushes the captures with a run of
+# three iloads before the indy. 112 lifts it (its relaxed "\(I+\)" guard admits
+# any number of int captures), 114 peels the three pushes one at a time into the
+# c-map's accumulators — right-to-left, so the captures land in the shared state
+# List in left-to-right order (slot 0 = x) — and 316 assembles a stateful distill
+# whose body parks the item, reads the three captures back, then reloads the item
+# on top for the static lambda$(int, int, int, Integer). 401 fuses it with the
+# preceding NON-capturing map (which has empty state), and 502/512/521 emit one
+# Stream.mapMulti whose wrapper reads the three captures from the captured List.
+#
+# invokedynamic: before = map(+1) + map(+x+y+z) + mapToInt(Integer::intValue) = 3;
+# after = the single fused mapMulti + the native mapToInt = 2. The dropped indy is
+# the proof the two maps collapsed into one dispatch (the trailing mapToInt stays
+# native — a stateful distill does not fuse a boundary unbox). The runtime line
+# proves the three captures reach the lambda in the right order (the body parks
+# and reloads the item): {1..6} -> map(+1) -> {2..7} -> map(+60) -> {62..67} ->
+# sum = 387.
+java: |
+  package fusion;
+  import java.util.stream.*;
+  public class M {
+    static int fused(int x, int y, int z) {
+      return Stream.of(1, 2, 3, 4, 5, 6)
+        .map(i -> i + 1)
+        .map(i -> i + x + y + z)
+        .mapToInt(Integer::intValue)
+        .sum();
+    }
+    public static void main(String[] args) {
+      System.out.printf("The result is %d%n", fused(10, 20, 30));
+    }
+  }
+before:
+  invokedynamic: 3
+after:
+  invokedynamic: 2
+log:
+  - "BUILD SUCCESS"
+  - "The result is 387"


### PR DESCRIPTION
Stream pipelines that used a capturing lambda — `map(i -> i + x)`, `filter(n -> n > t)`, or `map(i -> i + x + y + z)` over effectively-final locals — never fused. javac compiles each captured value as an extra argument on the lambda factory, so the `invokedynamic` descriptor is `(I)L…Function;` (or `(III)…` for three captures) rather than the zero-capture `()L…Function;`, and rule 111's zero-capture guard skipped it. The operators were invisible to the whole 2xx→7xx pipeline.

The fix treats a capture as a pointwise operator that owns one slot in the shared state List that `distinct`/`skip` already thread per-element state through, so capturing operators reuse the existing fuse and emit machinery (401/502/512/521/503/504/601) untouched. They ride new pragma names (`c-map`, `cp-filter`) so no existing recogniser, fold, or revert is affected. New rules 112/113 lift the capturing indy, 314/316 fold it into a stateful distill, and 443/444 revert a lone unfused operator back to its native call so a single capturing op is never pessimised.

The second commit extends the map side to any number of int captures: 112's guard is relaxed to `(I+)`, a new rule 114 peels the run of pushes into the state List one at a time (right-to-left, so they land in source order), and 316 parks the incoming item in its own dead local slot and reloads it after the captures, so one and many captures share a single body shape.

Scope is object streams with int captures — map handles any number, filter one. Reference captures, type-transforming maps, category-2 captures, a multi-capture filter, and `this`-field captures stay native and are noted as follow-ups in the rule headers and CLAUDE.md. Verified with `mvn -Pdeep test` (the full OptimizeMojoTest pack-and-fixture suite is green) and by running the optimised bytecode under `-Xverify:all`.

Closes #636