### PR TITLE
#640: generalize capturing map to any type-preserving element type

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -387,7 +387,8 @@ edits to any existing rule**. They ride a parallel set of pragma names
 `"c-filter"`) so no existing recogniser, fold, dup-inserter or revert ever
 touches them.
 
-The path (object streams, int captures; map handles any number, filter one):
+The path (object streams, int captures; map handles any number of captures over
+any type-preserving reference element type, filter one capture over Integer):
 
 - `112` / `113` lift a capturing map / primitive-filter indy to
   `Φ.hone.c-map` / `Φ.hone.cp-filter`. `113` (single capture) still **grabs the
@@ -397,10 +398,12 @@ The path (object streams, int captures; map handles any number, filter one):
   c-map and seeds two EMPTY accumulators (`state-acc`, `body-acc`). They
   partition the indy space with `111`: `\(\)` matches zero captures, `\(I…\)`
   matches int captures, a handle-6 static `lambda$` target, and a
-  `Stream<Integer>` instantiated type (the SAM type is capture-independent, so
-  it is unchanged by arity). A reference capture (push is `aload`), category-2
-  (`J`/`D`), `this`-capture (handle 5), type-transforming map, computed/field
-  push — all stay native.
+  **type-preserving** instantiated type — matched as `(LX;)LX;` for any
+  reference `X` via a backreference guard (Integer, String, …), with `X`
+  sed-extracted into the four bridge fields. A reference capture (push is
+  `aload`), category-2 (`J`/`D`), `this`-capture (handle 5), a
+  **type-transforming** map (`(LX;)LY;`, declined by the backreference and left
+  to the unbox/box machinery), computed/field push — all stay native.
 - `114` gathers `112`'s inline pushes into the c-map, one per firing,
   re-applying at fixpoint (the same self-iteration `521` uses). It matches the
   single `iload` **directly in front of** the c-map; phino's leading group is
@@ -445,11 +448,15 @@ The path (object streams, int captures; map handles any number, filter one):
   reverting it (replaying N pushes, rebuilding the `(I^N)` descriptor) is a
   follow-up puzzle.
 
+Other type-preserving element types are **done** (issue #640): `112`'s
+`(LX;)LX;` backreference guard admits a capturing map over any reference element
+type (`Stream<String>`, …), and `443` rebuilds the reverted SAM type from the
+distill's bridge fields so a lone such map still comes out native — see the
+`streams/closure-string.yml` end-to-end fixture.
+
 Deferred puzzles (each extends the same shared-List channel): a multi-capture
 FILTER and the lone-multi-capture-map revert (both above); reference captures
-(drop the box/unbox); other type-preserving element types (relax the literal
-`Stream<Integer>` instantiated type to a `bridge-input == bridge-output`
-guard); category-2 captures; `this`-field captures; and capturing
+(drop the box/unbox); category-2 captures; `this`-field captures; and capturing
 `peek`/`mapToX`. See the puzzle marker in `112`'s header.
 
 ## phino: the only rewrite engine

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
@@ -23,17 +23,24 @@
 # state List" is what lets N captures (and any number of fused capturing
 # operators) reuse the distinct/skip machinery (502/512/521/601) verbatim.
 #
-# v1.1 scope (issue #636): one OR MORE category-1 INT captures, a type-preserving
-# Stream<Integer> map (instantiated type "(Ljava/lang/Integer;)Ljava/lang/Integer;"),
-# a handle-6 static lambda$ target, every push a constant-index iload. Reference
-# captures, other element types, type-transforming maps and category-2 captures
-# are declined here (left native) and tracked as follow-up puzzles.
+# v1.2 scope (issues #636, #640): one OR MORE category-1 INT captures, a
+# type-PRESERVING map over ANY reference element type — the SAM instantiated type
+# is matched as "(LX;)LX;" for any reference X (Integer, String, …) via a
+# backreference guard, and the element type X is sed-extracted into 𝑒-bridge and
+# threaded into all four bridge fields. A handle-6 static lambda$ target, every
+# push a constant-index iload. So `map(s -> s.repeat(k))` on a Stream<String>
+# (int capture k) now fuses exactly like the original Stream<Integer> case.
 #
-# @todo #636:60min Generalise the capture beyond ints on a Stream<Integer> map:
-#  a reference capture (drop the box/unbox), other type-preserving element types
-#  (relax the literal instantiated-type guard to a bridge-input==bridge-output
-#  guard), and category-2 (J/D) captures. Each extends the same shared-List
-#  channel; a multi-capture FILTER (113/314) is the nearest unfinished twin.
+# Type-TRANSFORMING maps stay native: the "(LX;)LX;" backreference declines an
+# instantiated type whose input and output differ (e.g. "(LString;)LInteger;"),
+# so those keep flowing through the unbox/box machinery untouched.
+#
+# @todo #640:60min Generalise the CAPTURE type beyond category-1 ints: a reference
+#  capture (push is `aload`, drop the box/unbox in 114/316 — needs a reference
+#  branch in the peeler), and category-2 (J/D) captures (push is `lload`/`dload`,
+#  box via Long/Double.valueOf, unbox via longValue/doubleValue). Each extends the
+#  same shared-List channel; a multi-capture FILTER (113/314) is the nearest
+#  unfinished twin. The element-type half (Stream<X>) is already done here.
 name: capturing-invokedynamic-to-map
 pattern: |
   ⟦
@@ -91,7 +98,7 @@ pattern: |
           ⟧,
           𝜏19 ↦ ⟦
             φ ↦ Φ.jeo.type,
-            𝜏21 ↦ "(Ljava/lang/Integer;)Ljava/lang/Integer;",
+            𝜏21 ↦ 𝑒-instantiated,
             ρ ↦ ∅
           ⟧,
           ρ ↦ ∅
@@ -144,10 +151,10 @@ result: |
           state-acc ↦ ⟦ ρ ↦ ∅ ⟧,
           body-acc ↦ ⟦ ρ ↦ ∅ ⟧,
           class ↦ 𝑒-class,
-          bridge-input ↦ "Ljava/lang/Integer;",
-          bridge-output ↦ "Ljava/lang/Integer;",
-          accepted ↦ "Ljava/lang/Integer;",
-          returned ↦ "Ljava/lang/Integer;",
+          bridge-input ↦ 𝑒-bridge,
+          bridge-output ↦ 𝑒-bridge,
+          accepted ↦ 𝑒-bridge,
+          returned ↦ 𝑒-bridge,
           static ↦ "true",
           target ↦ ⟦
             handle ↦ 6,
@@ -173,6 +180,15 @@ when:
     - matches:
         - '\(I+\)Ljava/util/function/Function;'
         - 𝑒-interface
+    - matches:
+        - '\((L[^;]+;)\)\1'
+        - 𝑒-instantiated
 where:
+  - meta: 𝑒-bridge
+    function: sed
+    args:
+      - 𝑒-instantiated
+      - '"s/[(]//"'
+      - '"s/[)].*//"'
   - meta: 𝜏-c-map
     function: random-tau

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/443-unfused-capturing-map-to-invokedynamic.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/443-unfused-capturing-map-to-invokedynamic.phr
@@ -23,7 +23,10 @@
 # recovered from the state and replayed before the indy; the target handle is
 # read from the body's invokestatic. The 𝜑-calculus fields the fold dropped (the Function SAM name,
 # the erased lambda-signature, the captured "(I)" interface) are constants for an
-# int-capture Stream<Integer> map, so they are reconstructed literally. The
+# int-capture map over any reference element type, so they are reconstructed
+# literally; the SAM instantiated type "(LX;)LX;" is rebuilt from the distill's
+# bridge-input/bridge-output (Integer for a Stream<Integer>, String for a
+# Stream<String>, …), matching 112's element-type-agnostic lift. The
 # reverted Stream.map carries `reverted ↦ Φ.true`: 112's invokeinterface pattern
 # is closed on the four-operand opcode jeo emits, so the fifth binding stops 112
 # re-lifting this map and the 112 → 316 → 443 cycle cannot spin (jeo ignores the
@@ -109,7 +112,7 @@ result: |
         v3 ↦ 𝑒-target-signature,
         v4 ↦ 𝑒-target-is-interface
       ⟧,
-      t5 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Integer;)Ljava/lang/Integer;" ⟧
+      t5 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ 𝑒-instantiated ⟧
     ⟧,
     𝜏-map ↦ ⟦
       φ ↦ Φ.jeo.opcode.invokeinterface,
@@ -122,6 +125,13 @@ result: |
     𝐵-after
   ⟧
 where:
+  - meta: 𝑒-instantiated
+    function: concat
+    args:
+      - '"("'
+      - 𝑒-bridge-input
+      - '")"'
+      - 𝑒-bridge-output
   - meta: 𝜏-push-back
     function: random-tau
   - meta: 𝜏-indy

--- a/src/test/phino/112-capturing-invokedynamic-to-map-string.yml
+++ b/src/test/phino/112-capturing-invokedynamic-to-map-string.yml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A capturing map over a Stream<String> — `map(s -> s.repeat(k))` with one int
+# capture `k`, factory descriptor "(I)L…Function;", SAM instantiated type
+# "(Ljava/lang/String;)Ljava/lang/String;" — is lifted to a Φ.hone.c-map exactly
+# like the original Stream<Integer> case (issue #640). 112's instantiated-type
+# guard is a "(LX;)LX;" backreference, so it admits ANY type-preserving reference
+# element; the element type is sed-extracted into the four bridge fields, so the
+# c-map carries "Ljava/lang/String;" rather than the hardcoded Integer. The
+# captured int still rides as one factory argument (114 boxes it via Integer),
+# and the target lambda$ signature "(ILjava/lang/String;)Ljava/lang/String;"
+# passes through verbatim.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
+input: |
+  {⟦
+    φ ↦ Φ.jeo.class,
+    version ↦ 68,
+    access ↦ 33,
+    modifiers ↦ ⟦ φ ↦ Φ.jeo.modifiers, static ↦ Φ.false ⟧,
+    name ↦ "Foo",
+    supername ↦ "java/lang/Object",
+    interfaces ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+    m$run ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 8,
+      modifiers ↦ ⟦ φ ↦ Φ.jeo.modifiers, static ↦ Φ.true ⟧,
+      name ↦ "run",
+      descriptor ↦ "(I)V",
+      signature ↦ "",
+      exceptions ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, m1 ↦ 6, m2 ↦ 3 ⟧,
+      params ↦ ⟦ φ ↦ Φ.jeo.params ⟧,
+      annotations ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      body ↦ ⟦
+        i22 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 0 ⟧,
+        i23 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokedynamic,
+          v0 ↦ "apply",
+          v1 ↦ "(I)Ljava/util/function/Function;",
+          h2 ↦ ⟦ φ ↦ Φ.jeo.handle, v0 ↦ 6, v1 ↦ "java/lang/invoke/LambdaMetafactory", v2 ↦ "metafactory", v3 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;", v4 ↦ Φ.false ⟧,
+          t3 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Object;)Ljava/lang/Object;" ⟧,
+          h4 ↦ ⟦ φ ↦ Φ.jeo.handle, v0 ↦ 6, v1 ↦ "Foo", v2 ↦ "lambda$run$0", v3 ↦ "(ILjava/lang/String;)Ljava/lang/String;", v4 ↦ Φ.false ⟧,
+          t5 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/String;)Ljava/lang/String;" ⟧
+        ⟧,
+        i24 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "map", v2 ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;", v3 ↦ Φ.true ⟧
+      ⟧,
+      trycatchblocks ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      local-variable-table ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.hone.c-map, state-acc ↦ ⟦⟧, body-acc ↦ ⟦⟧, 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.hone.c-map, 𝐵-a, bridge-input ↦ "Ljava/lang/String;", 𝐵-b ⟧
+  - ⟦ φ ↦ Φ.hone.c-map, 𝐵-c, bridge-output ↦ "Ljava/lang/String;", 𝐵-d ⟧
+  - ⟦ φ ↦ Φ.hone.c-map, 𝐵-g, target ↦ ⟦ 𝐵-h, signature ↦ "(ILjava/lang/String;)Ljava/lang/String;", 𝐵-i ⟧, 𝐵-j ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/closure-string.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/closure-string.yml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# End-to-end proof that capturing-lambda fusion is no longer pinned to
+# Stream<Integer> (issue #640). The stream element type here is String, and the
+# captured value is still a category-1 int:
+#
+#   Stream.of(...).map(s -> s.repeat(k)).map(s -> s.toUpperCase())...
+#
+# The first map captures the effectively-final int `k`, so javac compiles its
+# factory descriptor as "(I)L…Function;" and its SAM instantiated type as
+# "(Ljava/lang/String;)Ljava/lang/String;". 112's element-type-agnostic
+# "(LX;)LX;" backreference guard now admits this type-preserving String map (it
+# used to be declined because the instantiated type was not the literal
+# Integer→Integer), sed-extracts the element type into the four bridge fields,
+# and lifts it to a Φ.hone.c-map. 114 peels the single int push, 316 folds a
+# stateful distill, and 401 fuses it with the following NON-capturing
+# String→String map (s -> s.toUpperCase(), empty state). 502/512/521/601 emit one
+# Stream.mapMulti whose wrapper reads the captured int back from the List — the
+# whole machinery is reused verbatim, only the bridge type string differs.
+#
+# invokedynamic: before = map(repeat,capturing) + map(toUpperCase) = 2;
+# after = the single fused mapMulti = 1. The dropped indy is the proof the two
+# String maps collapsed into one dispatch. The runtime line proves the capture
+# reaches the lambda correctly: {"a","bb","ccc"} -> repeat(2) ->
+# {"aa","bbbb","cccccc"} -> toUpperCase -> {"AA","BBBB","CCCCCC"} -> joined.
+java: |
+  package fusion;
+  import java.util.stream.*;
+  public class T {
+    static String fused(int k) {
+      return Stream.of("a", "bb", "ccc")
+        .map(s -> s.repeat(k))
+        .map(s -> s.toUpperCase())
+        .collect(Collectors.joining());
+    }
+    public static void main(String[] args) {
+      System.out.printf("The result is %s%n", fused(2));
+    }
+  }
+before:
+  invokedynamic: 2
+after:
+  invokedynamic: 1
+log:
+  - "BUILD SUCCESS"
+  - "The result is AABBBBCCCCCC"


### PR DESCRIPTION
Resolves the `#636` puzzle embedded in `112-capturing-invokedynamic-to-map.phr` (issue #640).

## What

A capturing int map (`map(i -> i + x)` and friends) was only lifted into the
`Φ.hone.c-map` fusion machinery when the **stream element type was `Integer`** —
112 hardcoded the SAM instantiated type to `"(Ljava/lang/Integer;)Ljava/lang/Integer;"`
and the four bridge fields to `Ljava/lang/Integer;`.

This PR generalizes the **element type** (the "on a `Stream<Integer>` map" half of
the puzzle):

- **`112`** now matches the SAM instantiated type with a `(LX;)LX;` backreference
  guard, admitting any **type-preserving** reference element type (`Stream<String>`,
  …), and `sed`-extracts the element type `X` into the four bridge fields. A
  **type-transforming** map (`(LX;)LY;`, input ≠ output) is declined by the
  backreference and stays native (the unbox/box path), exactly as before.
- **`443`** (the lone-map revert) now rebuilds the reverted SAM instantiated type
  from the distill's `bridge-input`/`bridge-output` via `concat`, instead of
  hardcoding `Integer`, so a lone capturing map over any element type still reverts
  to correct native bytecode — never pessimised.

The capture itself remains a category-1 `int` (114/316 box/unbox via `Integer`),
so no other rule needed changing; the emit path (502/512/521/601) was already
bridge-driven.

The original `#636` puzzle text is removed. A **narrower** follow-up `@todo #640`
remains in 112 for the still-open *capture-type* generalizations (reference
captures and category-2 `J`/`D` captures).

## Tests

- New single-rule pack `src/test/phino/112-capturing-invokedynamic-to-map-string.yml`
  (a `Stream<String>` `map(s -> s.repeat(k))` lift).
- New end-to-end fixture `src/test/resources/org/eolang/hone/optimize/streams/closure-string.yml`.
- `mvn -Pdeep test -Dtest=OptimizeMojoTest#appliesPhinoRulesAsSpecifiedInYamlPack`
  → 28/28 green.
- Verified end-to-end on the **real host pipeline** (phino 0.0.0.73, jeo 0.15.1):
  - `map(s -> s.repeat(k)).map(s -> s.toUpperCase())` fuses into a single
    `Stream.mapMulti` (invokedynamic **2 → 1**) and prints `AABBBBCCCCCC`.
  - A lone capturing `String` map reverts to native `Stream.map` and runs correctly.
  - Integer multicapture / lone cases unchanged (`387 5`, invokedynamic 4 → 3).

https://claude.ai/code/session_01CYqjD6eBmWgvXY3dnKbg6V

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYqjD6eBmWgvXY3dnKbg6V)_