### PR TITLE
Fuse mapToX().boxed() round-trips into one mapMulti

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,8 @@ that same order. The `NNN-` prefix is *the* mechanism that defines the
 pipeline stages:
 
 ```text
-1xx  prep         strip line-numbers, desugar method refs to lambdas
+1xx  prep         strip line-numbers (102 before a Stream op, 106 before a
+                  primitive-stream .boxed()), desugar method refs to lambdas
                   (103 unbound, 104 static, 105 peek/return-drop), lower
                   invokedynamic to Φ.hone.lambda; lift a capturing map/filter
                   indy to Φ.hone.{c-map,cp-filter} (112, 113), peel a
@@ -155,6 +156,9 @@ filter, map (object + primitive) → 201..204 → Φ.hone.{filter,map}
 peek                             → 207 → 309 → Φ.hone.peek → distill
 boxed/unbox, box                 → 205, 206  → Φ.hone.{unbox,box}
 box/unbox cleanup + collapse     → 211, 221, 231, 232 → fold back to map/filter
+user mapToX().boxed() roundtrip  → 106 (anchor) → 205,206 → 209 → 2-opcode
+                                    object→wrapper distill (fuses + emits one
+                                    mapMulti); see "boxed() round-trips" below
 type / transform adjustments     → 241..243, 251..261, 271, 272
 dup insertion (for filter)       → 281, 282, 283 (after distinct/skip)
 dup, transform, type, filter, map → 301..306 → Φ.hone.distill (auto body)
@@ -208,6 +212,41 @@ method name (`mapMulti` vs `mapMultiToInt`/`…Long`/`…Double`) follow the
 OUTPUT. `501`/`511`/`601` thread two extra pragma fields — `stream-method`
 and `result-stream-class` — to carry that split (a symmetric distill sets
 them to its input-side values, so nothing changes there).
+
+### boxed() round-trips (mapToX().boxed())
+
+A user `mapToInt/Long/Double(...).boxed()` is the dual of a trailing mapToX:
+the element is unboxed to a primitive and immediately re-boxed to its wrapper,
+a net object→object pointwise step (e.g. `Integer → long → Long`). `205`
+recognises the mapToX as a `Φ.hone.unbox` and `206` the boxed() as a
+`Φ.hone.box`; `106-remove-boxed-label` first strips the line-number anchor
+javac -g wedges before boxed (sibling of `102`, which only reaches a `Stream`
+op — boxed is an invokeinterface on `Int/Long/DoubleStream`), leaving the pair
+adjacent. `209-unbox-box-to-distill` then folds that pair into a single
+empty-state distill whose body is **two** opcodes — the mapper invocation that
+yields the primitive and the `Wrapper.valueOf` that re-boxes it — with
+`bridge-output` the wrapper type. Because it is an ordinary empty-state
+object→object distill, `401` fuses it with adjacent pointwise distills and
+`501`/`511` lower the run to one `Stream.mapMulti`, exactly as for a map.
+
+The subtle part is **ordering, not gating**. `209` MUST run before `211`. An
+`unbox(lambda$), box` adjacency is a genuine user round-trip ONLY before `211`
+splits a primitive `IntStream.filter/map` into `box + boxed-primitive-func +
+unbox`: after that split, a user `mapToInt(ref)` that feeds a primitive op
+(e.g. `mapToInt(Integer::intValue).filter(p)`) shows the SAME adjacency — but
+its box is `211`'s compensating head-box for the next primitive op, and folding
+it as a boxed() splices a stray `Integer.valueOf` into the primitive chain and
+fails verification. Running `209` before `211` guarantees every box it sees is
+a real `206` boxed(); `221-unbox-box-to-map` (after `211`, unchanged) then
+collapses `211`'s synthetic pairs as before. (`209`'s `lambda$` target guard is
+belt-and-suspenders — every `205` unbox targets a lambda$ anyway.)
+
+This fuses a *pointwise* boxed() chain to one mapMulti (see
+`boxed-roundtrip.yml`). A type-changing boxed() distill is NOT fused into a
+stateful (distinct/skip) distill — the object-only stateful emit cannot take a
+primitive/wrapper intermediate — so a stateful pipeline with a boxed() tail
+collapses to TWO mapMultis, not one (see `full-non-terminal.yml`). Lifting that
+to a single mapMulti is the remaining work tracked by #570.
 
 A method reference (`Integer::intValue`, `String::toUpperCase`, `X::keep`, …)
 is **desugared into a lambda** up front so the rest of the pipeline picks it

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/106-remove-boxed-label.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/106-remove-boxed-label.phr
@@ -8,7 +8,7 @@
 # IntStream / LongStream / DoubleStream (it converts a primitive stream back to
 # Stream<Wrapper>), so 102's hardcoded `Stream` owner leaves the boxed anchor in
 # place. That surviving label wedges between the recognised Φ.hone.unbox (the
-# preceding mapToX) and Φ.hone.box (the boxed), breaking the adjacency 310 needs
+# preceding mapToX) and Φ.hone.box (the boxed), breaking the adjacency 209 needs
 # to fold the round-trip into a distill.
 #
 # The safety argument is 102's, unchanged: the label removed here is the one

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/106-remove-boxed-label.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/106-remove-boxed-label.phr
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Sibling of 102, for the one operator 102 cannot reach. 102 strips the
+# line-number-anchor label javac -g wedges before a bare `invokeinterface
+# java/util/stream/Stream` call, but `.boxed()` is an `invokeinterface` on
+# IntStream / LongStream / DoubleStream (it converts a primitive stream back to
+# Stream<Wrapper>), so 102's hardcoded `Stream` owner leaves the boxed anchor in
+# place. That surviving label wedges between the recognised Φ.hone.unbox (the
+# preceding mapToX) and Φ.hone.box (the boxed), breaking the adjacency 310 needs
+# to fold the round-trip into a distill.
+#
+# The safety argument is 102's, unchanged: the label removed here is the one
+# whose ONLY reference is the line-number entry that immediately follows it (the
+# shared `𝑒-label-value` forces that pairing), sitting right before the call. A
+# jump target carries a stackmap frame, not a bare line-number, so this never
+# matches a branch target, and no statement boundary, try-region edge or
+# variable scope falls between a mapToX and its boxed. The gate is tighter than
+# 102's: the call must be `boxed` specifically, so a primitive-stream
+# `filter`/`map`/`sum` anchor is left untouched. Run before 151 so the
+# line-number is still present to witness the pairing.
+name: remove-boxed-label
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-label ↦ ⟦
+      φ ↦ Φ.jeo.label,
+      𝜏-label-value ↦ 𝑒-label-value,
+      ρ ↦ ∅
+    ⟧,
+    𝜏-line-number ↦ ⟦
+      φ ↦ Φ.jeo.line-number,
+      number ↦ 𝑒-line-number,
+      𝜏-ln-label ↦ ⟦
+        φ ↦ Φ.jeo.label,
+        𝜏-ln-label-value ↦ 𝑒-label-value,
+        ρ ↦ ∅
+      ⟧,
+      ρ ↦ ∅
+    ⟧,
+    𝜏-call ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      𝜏1 ↦ 𝑒-owner,
+      𝜏2 ↦ "boxed",
+      𝜏3 ↦ "()Ljava/util/stream/Stream;",
+      𝜏4 ↦ Φ.true,
+      ρ ↦ ∅
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-call ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      𝜏1 ↦ 𝑒-owner,
+      𝜏2 ↦ "boxed",
+      𝜏3 ↦ "()Ljava/util/stream/Stream;",
+      𝜏4 ↦ Φ.true,
+      ρ ↦ ∅
+    ⟧,
+    𝐵-after
+  ⟧
+when:
+  or:
+    - eq: [𝑒-owner, '"java/util/stream/IntStream"']
+    - eq: [𝑒-owner, '"java/util/stream/LongStream"']
+    - eq: [𝑒-owner, '"java/util/stream/DoubleStream"']

--- a/src/main/resources/org/eolang/hone/rules/streams/2xx/209-unbox-box-to-distill.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/2xx/209-unbox-box-to-distill.phr
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A user `mapToInt/Long/Double(...).boxed()` round-trip — an object element
+# unboxed to a primitive and immediately re-boxed to its wrapper — is a
+# pointwise object->object operation (e.g. Integer -> long -> Long). 205
+# recognises the mapToX as a Φ.hone.unbox and 206 the boxed() as a Φ.hone.box,
+# leaving them adjacent (106 strips the line-number anchor javac -g wedges
+# before boxed). This rule folds that pair into a single empty-state distill
+# whose body is TWO opcodes — the mapper invocation that produces the primitive
+# and the `Wrapper.valueOf` that re-boxes it — so 401 can fuse it with any
+# adjacent pointwise distill and 501/511 lower the whole chain to one
+# Stream.mapMulti dispatch. (A distill folded here in the 2xx phase is inert to
+# the 3xx folders, which only touch map/filter/lambda pragmas, and 401 fuses it
+# in the 4xx phase like any other.)
+#
+# ORDER MATTERS: this rule MUST run before 211. An unbox/box adjacency is a
+# user round-trip ONLY before 211 splits the primitive IntStream.filter/map
+# operators into box + boxed-primitive-func + unbox. After that split, a user
+# `mapToInt(ref)` feeding a primitive op (e.g. `mapToInt(Integer::intValue)
+# .filter(p)`) ALSO shows an `unbox(lambda$), box` adjacency — but that box is
+# 211's compensating head-box for the next primitive op, not a real boxed(),
+# and folding it here would splice a stray `Integer.valueOf` into the primitive
+# chain and fail verification. Running before 211 guarantees every box present
+# is a genuine 206 boxed(); 221 (which runs after 211, ungated) then collapses
+# the synthetic 211 pairs as before. The `lambda$` target gate is belt-and-
+# suspenders: every 205 unbox targets a lambda$ anyway, but the gate makes the
+# "user pair only" intent explicit and survives any future reordering.
+name: unbox-box-to-distill
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-unbox ↦ ⟦
+      φ ↦ Φ.hone.unbox,
+      opcode ↦ 𝑒-opcode,
+      class ↦ 𝑒-class,
+      bridge-signature ↦ 𝑒-bridge-signature,
+      static ↦ 𝑒-static,
+      target ↦ ⟦
+        handle ↦ 𝑒-target-handle,
+        class ↦ 𝑒-target-class,
+        method ↦ 𝑒-target-method,
+        signature ↦ 𝑒-target-signature,
+        is-interface ↦ 𝑒-target-is-interface
+      ⟧
+    ⟧,
+    𝜏-box ↦ ⟦
+      φ ↦ Φ.hone.box,
+      stream-class ↦ 𝑒-stream-class
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-unbox ↦ ⟦
+      φ ↦ Φ.hone.𝜏-distill,
+      class ↦ 𝑒-class,
+      bridge-input ↦ 𝑒-bridge-input,
+      bridge-output ↦ 𝑒-wrapper,
+      start ↦ "map",
+      accepted ↦ 𝑒-bridge-input,
+      returned ↦ 𝑒-wrapper,
+      static ↦ 𝑒-static,
+      state ↦ ⟦ ρ ↦ ∅ ⟧,
+      body ↦ ⟦
+        b1 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.𝜏-opcode,
+          i2 ↦ 𝑒-target-class,
+          i3 ↦ 𝑒-target-method,
+          i4 ↦ 𝑒-target-signature,
+          i5 ↦ 𝑒-target-is-interface
+        ⟧,
+        b2 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokestatic,
+          i2 ↦ 𝑒-wrapper-class,
+          i3 ↦ "valueOf",
+          i4 ↦ 𝑒-value-of-signature,
+          i5 ↦ Φ.false
+        ⟧
+      ⟧
+    ⟧,
+    𝐵-after
+  ⟧
+when:
+  and:
+    - matches: ['lambda\$.+', 𝑒-target-method]
+    - or:
+        - and:
+            - matches: ['\(.*\)I', 𝑒-bridge-signature]
+            - eq: [𝑒-stream-class, '"java/util/stream/IntStream"']
+        - and:
+            - matches: ['\(.*\)J', 𝑒-bridge-signature]
+            - eq: [𝑒-stream-class, '"java/util/stream/LongStream"']
+        - and:
+            - matches: ['\(.*\)D', 𝑒-bridge-signature]
+            - eq: [𝑒-stream-class, '"java/util/stream/DoubleStream"']
+where:
+  - meta: 𝜏-opcode
+    function: tau
+    args: [𝑒-opcode]
+  - meta: 𝑒-distill
+    function: sed
+    args:
+      - 𝑒-static
+      - '"s/true/distill/g"'
+      - '"s/false/pre-distill/g"'
+  - meta: 𝜏-distill
+    function: tau
+    args: [𝑒-distill]
+  - meta: 𝑒-bridge-input
+    function: sed
+    args:
+      - 𝑒-bridge-signature
+      - '"s/\\((.*)\\).*/$1/g"'
+  - meta: 𝑒-primitive
+    function: sed
+    args:
+      - 𝑒-bridge-signature
+      - '"s/\\(.*\\)(.+)/$1/g"'
+  - meta: 𝑒-wrapper
+    function: sed
+    args:
+      - 𝑒-primitive
+      - '"s/I/Ljava\\/lang\\/Integer;/g"'
+      - '"s/J/Ljava\\/lang\\/Long;/g"'
+      - '"s/D/Ljava\\/lang\\/Double;/g"'
+  - meta: 𝑒-wrapper-class
+    function: sed
+    args:
+      - 𝑒-primitive
+      - '"s/I/java\\/lang\\/Integer/g"'
+      - '"s/J/java\\/lang\\/Long/g"'
+      - '"s/D/java\\/lang\\/Double/g"'
+  - meta: 𝑒-value-of-signature
+    function: concat
+    args: ['"("', 𝑒-primitive, '")"', 𝑒-wrapper]

--- a/src/main/resources/org/eolang/hone/rules/streams/2xx/221-unbox-box-to-map.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/2xx/221-unbox-box-to-map.phr
@@ -2,6 +2,16 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
+# Collapses an unbox immediately followed by a box back into a single object
+# map. This is the cleanup for the box/unbox pair 211 synthesises when it
+# splits a primitive IntStream.filter/map chain (box + boxed-primitive-func +
+# unbox): where two split ops meet, the tail unbox of one and the head box of
+# the next cancel, and so does the head box 211 wedges right after a user
+# `mapToInt(ref)` that feeds a primitive op. By the time this rule runs every
+# genuine user `mapToX(...).boxed()` round-trip has already been folded into a
+# distill by 209 (which runs before 211 precisely so it never confuses a real
+# boxed() with 211's compensating box), so the only unbox/box adjacencies left
+# here are 211's synthetic ones — safe to collapse to a plain one-opcode map.
 name: unbox-box-to-map
 pattern: |
   ⟦

--- a/src/test/phino/106-remove-boxed-label.yml
+++ b/src/test/phino/106-remove-boxed-label.yml
@@ -7,7 +7,7 @@
 # invokeinterface on LongStream (here), so 102 leaves it and it wedges between
 # the mapToLong and the boxed. This rule drops the dead label and its
 # line-number, leaving the two stream calls adjacent so 205/206 recognise an
-# adjacent unbox/box pair for 310 to fold.
+# adjacent unbox/box pair for 209 to fold.
 rules:
   - src/main/resources/org/eolang/hone/rules/streams/1xx/106-remove-boxed-label.phr
 input: |

--- a/src/test/phino/106-remove-boxed-label.yml
+++ b/src/test/phino/106-remove-boxed-label.yml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# javac -g wedges a line-number-anchor label before a `.boxed()` written on its
+# own source line. 102 only strips that anchor for a `Stream` op; boxed is an
+# invokeinterface on LongStream (here), so 102 leaves it and it wedges between
+# the mapToLong and the boxed. This rule drops the dead label and its
+# line-number, leaving the two stream calls adjacent so 205/206 recognise an
+# adjacent unbox/box pair for 310 to fold.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/1xx/106-remove-boxed-label.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      prev ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "mapToLong", v2 ↦ "(Ljava/util/function/ToLongFunction;)Ljava/util/stream/LongStream;", v3 ↦ Φ.true ⟧,
+      lbl ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ "L7" ⟧,
+      ln ↦ ⟦
+        φ ↦ Φ.jeo.line-number,
+        number ↦ 7,
+        l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ "L7" ⟧
+      ⟧,
+      call ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/LongStream", v1 ↦ "boxed", v2 ↦ "()Ljava/util/stream/Stream;", v3 ↦ Φ.true ⟧
+    ⟧
+  ⟧}
+expected:
+  - ⟦ body ↦ ⟦ 𝜏-prev ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "mapToLong", 𝐵-p ⟧, 𝜏-call ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/LongStream", v1 ↦ "boxed", 𝐵-c ⟧, ρ ↦ ∅ ⟧ ⟧

--- a/src/test/phino/209-unbox-box-to-distill.yml
+++ b/src/test/phino/209-unbox-box-to-distill.yml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A user mapToLong(...).boxed() round-trip is recognised as an adjacent
+# Φ.hone.unbox (object in, primitive out, target a synthetic lambda$) and
+# Φ.hone.box. This rule folds the pair into one empty-state object->object
+# distill (Integer -> Long) whose body is two opcodes: the mapper invocation
+# producing the primitive and the Wrapper.valueOf re-boxing it. It runs before
+# 211, so every unbox/box adjacency it sees is a genuine boxed() round-trip and
+# never 211's compensating box around a primitive operator.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/2xx/209-unbox-box-to-distill.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      op1 ↦ ⟦
+        φ ↦ Φ.hone.unbox,
+        opcode ↦ "invokestatic",
+        class ↦ "A",
+        bridge-signature ↦ "(Ljava/lang/Integer;)J",
+        static ↦ "true",
+        target ↦ ⟦
+          handle ↦ 6,
+          class ↦ "A",
+          method ↦ "lambda$main$0",
+          signature ↦ "(Ljava/lang/Integer;)J",
+          is-interface ↦ Φ.false
+        ⟧
+      ⟧,
+      op2 ↦ ⟦
+        φ ↦ Φ.hone.box,
+        stream-class ↦ "java/util/stream/LongStream"
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧}
+expected:
+  - ⟦ 𝐵-a, φ ↦ Φ.hone.distill, 𝐵-b, bridge-input ↦ "Ljava/lang/Integer;", 𝐵-c, bridge-output ↦ "Ljava/lang/Long;", 𝐵-d ⟧
+  - ⟦ 𝐵-a, φ ↦ Φ.hone.distill, 𝐵-b, accepted ↦ "Ljava/lang/Integer;", 𝐵-c, returned ↦ "Ljava/lang/Long;", 𝐵-d, state ↦ ⟦ ρ ↦ ∅ ⟧, 𝐵-e ⟧
+  - ⟦ 𝐵-p, 𝜏-mapper ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, 𝐵-x, i3 ↦ "lambda$main$0", 𝐵-y ⟧, 𝜏-valueof ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, 𝐵-z, i2 ↦ "java/lang/Long", i3 ↦ "valueOf", i4 ↦ "(J)Ljava/lang/Long;", 𝐵-w ⟧, 𝐵-q ⟧

--- a/src/test/phino/221-unbox-box-to-map.yml
+++ b/src/test/phino/221-unbox-box-to-map.yml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 211 splits a primitive IntStream.filter/map chain into box + boxed-func +
+# unbox; where two split ops meet, the tail unbox of one and the head box of
+# the next are redundant and 221 collapses them back to a single object map.
+# This pack exercises that collapse on a 211-style longValue pair. A user
+# mapToX(...).boxed() round-trip would look identical here, but by the time 221
+# runs every such pair has already been folded into a distill by 209 (which
+# runs before 211), so 221 only ever meets 211's own synthetic pairs.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/2xx/221-unbox-box-to-map.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      op1 ↦ ⟦
+        φ ↦ Φ.hone.unbox,
+        opcode ↦ "invokevirtual",
+        class ↦ "A",
+        bridge-signature ↦ "(Ljava/lang/Long;)J",
+        static ↦ "true",
+        target ↦ ⟦
+          handle ↦ 5,
+          class ↦ "java/lang/Long",
+          method ↦ "longValue",
+          signature ↦ "()J",
+          is-interface ↦ Φ.false
+        ⟧
+      ⟧,
+      op2 ↦ ⟦
+        φ ↦ Φ.hone.box,
+        stream-class ↦ "java/util/stream/LongStream"
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧}
+expected:
+  - ⟦ 𝐵-a, φ ↦ Φ.hone.map, 𝐵-b ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/all-ops.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/all-ops.yml
@@ -53,7 +53,7 @@ before:
   return: 7
 after:
   invokespecial: 3
-  invokestatic: 20
-  invokevirtual: 12
-  invokedynamic: 15
-  return: 10
+  invokestatic: 24
+  invokevirtual: 14
+  invokedynamic: 14
+  return: 11

--- a/src/test/resources/org/eolang/hone/optimize/streams/boxed-roundtrip.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/boxed-roundtrip.yml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A pointwise mapToX(...).boxed() round-trip — an object element unboxed to a
+# primitive and immediately re-boxed to its wrapper — must fuse into the
+# operators around it rather than survive as a native mapToX + boxed pair. 205
+# recognises each mapToX as a Φ.hone.unbox and 206 each boxed() as a Φ.hone.box
+# (106 strips the line-number anchor javac -g wedges before boxed); 209 then
+# folds each adjacent unbox/box pair into one empty-state object->object distill
+# whose body is two opcodes (the mapper invocation producing the primitive and
+# the Wrapper.valueOf re-boxing it). 401 fuses those boxing distills with the
+# leading filter+map distill, the trailing mapToDouble folds in via 451, and
+# 501/511 lower the whole chain to a SINGLE Stream.mapMultiToDouble dispatch.
+#
+# This is the case issue #570 reported as unfused for a pure pointwise pipeline:
+# every operator collapses to one mapMulti, dropping invokedynamic 5 -> 1. (A
+# stateful prefix — distinct/skip — keeps the boxing native, see
+# full-non-terminal.yml, because the object-only stateful emit cannot take a
+# type-changing intermediate.)
+java: |
+  package boxedroundtrip;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      double r = Stream.of(5, 3, 8, 2, 7)
+        .filter(n -> n > 0)
+        .map(n -> n + 1)
+        .mapToLong(Integer::longValue)
+        .boxed()
+        .mapToDouble(Long::doubleValue)
+        .boxed()
+        .mapToDouble(Double::doubleValue)
+        .sum();
+      System.out.printf("The result is %d\n", (int) r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 30"
+before:
+  invokedynamic: 5
+after:
+  invokedynamic: 1

--- a/src/test/resources/org/eolang/hone/optimize/streams/full-non-terminal.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/full-non-terminal.yml
@@ -23,8 +23,16 @@
 # pairs sit adjacent (distinct().skip()), so this is the case that proves
 # stateful distills fuse: all nine object-stream operators (peek included)
 # collapse into a single mapMulti backed by one captured java/util/List
-# holding the two HashSets and two long[1] counters, dropping invokedynamic
-# 9 -> 5 (the remaining four come from the primitive-conversion tail).
+# holding the two HashSets and two long[1] counters. The primitive-conversion
+# tail (mapToInt().boxed().mapToLong().boxed().mapToDouble().boxed() + the
+# final mapToInt) is itself a run of user boxed() round-trips, which 209 folds
+# and 401 fuses into a SECOND mapMulti, so the whole method drops invokedynamic
+# 9 -> 2. The two mapMultis do not merge into one: the boxing tail changes the
+# element type (Integer -> Long -> Double), and a type-changing distill is not
+# fused into the object-only stateful emit (502/512/503) — the documented
+# stateful limitation, and why #570's "everything into one mapMulti" stays
+# open. A purely pointwise boxed() chain does collapse to one, see
+# boxed-roundtrip.yml.
 java: |
   package allnonterminal;
   import java.util.stream.Stream;
@@ -59,4 +67,4 @@ log:
 before:
   invokedynamic: 9
 after:
-  invokedynamic: 5
+  invokedynamic: 2


### PR DESCRIPTION
This teaches the stream pipeline to fuse a `mapToInt/Long/Double(...).boxed()` round-trip — an element unboxed to a primitive and immediately re-boxed to its wrapper, e.g. `Integer -> long -> Long`. Two new rules do it: `106-remove-boxed-label` strips the line-number anchor `javac -g` wedges before `.boxed()` on a primitive stream (102 only reaches `Stream` ops), and `209-unbox-box-to-distill` folds the now-adjacent unbox/box pair into one two-opcode object→wrapper distill that 401 fuses and 501/511 emit as a single `mapMulti`. A purely pointwise chain now collapses to one `mapMulti` instead of staying native.

The fiddly part is ordering, and it's why 209 sits at 2xx rather than later. An `unbox(lambda$), box` adjacency is only guaranteed to be a real `boxed()` before 211 splits a primitive `filter`/`map` into `box + boxed-func + unbox`: after that split, a user `mapToInt(ref)` feeding a primitive op shows the same adjacency, but its box is 211's compensating head-box, not a boxed(). Folding that as a round-trip splices a stray `Integer.valueOf` into the primitive chain and fails verification. Running 209 before 211 sidesteps the ambiguity entirely, so 221 stays unchanged (only an explanatory header added) and keeps collapsing 211's own pairs.

This covers the pointwise part of #570. A stateful-prefixed pipeline (distinct/skip then a boxed tail) still collapses to two `mapMulti`s rather than one — full-non-terminal drops invokedynamic 5→2 — because a type-changing distill is not fused into the object-only stateful emit; that remains open. New phino unit packs (106/209/221) and a pointwise e2e fixture (`boxed-roundtrip.yml`) cover the change, the `all-ops` and `full-non-terminal` after-counts are updated, and CLAUDE.md gets a "boxed() round-trips" section. Verified against the full `-Pdeep` suite.