### PR TITLE
Fuse a trailing mapToX into a stateful distill (one mapMultiToX)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,7 @@ dup, transform, type, filter, map → 301..306 → Φ.hone.distill (auto body)
 load `this` into a pre-distill   → 311 → flips Φ.hone.pre-distill to distill
 box-distill-unbox collapse       → 411 → primitive-typed distill
 trailing mapToX into a distill   → 451 → type-transition distill
+                                    (empty-state OR stateful; preserves state)
 transform-distill normalisation  → 421, 422
 dup before a filter distill      → 431
 distinct                         → 216 → 307 → state distill;
@@ -195,12 +196,17 @@ unbox only ever folded when a following `.boxed()` paired with it (`221`,
 `411`); a boundary mapToX just sat idle and `603` lowered it back to a
 native call. `451-fuse-distill-unbox` closes that gap: it runs after the
 `4xx` fuse pass and splices the unbox's target invocation onto the tail of
-the single *pointwise* distill in front of it, widening that distill into a
+the single distill in front of it, widening that distill into a
 **type-transition** distill — `bridge-input` stays the object element type
-but `bridge-output` becomes the primitive (`I`/`J`/`D`). It deliberately
-matches only empty-state distills, so a stateful predecessor
-(distinct/skip) keeps its native mapToX, and a mapToX with no distill in
-front of it never matches and stays native via `603` — the same
+but `bridge-output` becomes the primitive (`I`/`J`/`D`). It captures and
+**preserves the predecessor's `state` block** (`𝐵-state`), so it fires for
+an empty-state pointwise distill AND for a stateful one (distinct/skip,
+possibly with a `boxed()` round-trip already fused in): a trailing mapToX
+that ends a distinct/skip pipeline folds into the same stateful distill
+rather than staying native, collapsing the whole pipeline to ONE
+`Stream.mapMultiToX` (this is #570 reaching the stateful path; see
+`stateful-boxed-tail.yml` and `full-non-terminal.yml`). A mapToX with no
+distill in front of it never matches and stays native via `603` — the same
 "do not pessimise a lone operator" stance as the `441`/`442` reverts.
 
 Because a transition distill has `bridge-input ≠ bridge-output`, the emit
@@ -209,9 +215,15 @@ pass is **output-aware**: `Stream.mapMultiToX` takes a plain
 samMethodType still follow the INPUT (exactly as an ordinary mapMulti),
 while the `consumer` the body drives, the resulting stream class and the
 method name (`mapMulti` vs `mapMultiToInt`/`…Long`/`…Double`) follow the
-OUTPUT. `501`/`511`/`601` thread two extra pragma fields — `stream-method`
-and `result-stream-class` — to carry that split (a symmetric distill sets
-them to its input-side values, so nothing changes there).
+OUTPUT. Both emit flavours thread two extra pragma fields — `stream-method`
+and `result-stream-class` — to carry that split: `501`/`511`/`601` for an
+empty-state distill, and their stateful twins `502`/`512` (which compute
+the same input/output split and drive the closing dup / `XConsumer.accept`
+off the OUTPUT consumer, exactly as `511` does). A symmetric distill sets
+both fields to its input-side values, so nothing changes there. `503`/`504`
+still fill the guard keep-frame off `bridge-input` (the item there is the
+object element, before the trailing transition runs), so they need no
+change.
 
 ### boxed() round-trips (mapToX().boxed())
 
@@ -242,11 +254,26 @@ collapses `211`'s synthetic pairs as before. (`209`'s `lambda$` target guard is
 belt-and-suspenders — every `205` unbox targets a lambda$ anyway.)
 
 This fuses a *pointwise* boxed() chain to one mapMulti (see
-`boxed-roundtrip.yml`). A type-changing boxed() distill is NOT fused into a
-stateful (distinct/skip) distill — the object-only stateful emit cannot take a
-primitive/wrapper intermediate — so a stateful pipeline with a boxed() tail
-collapses to TWO mapMultis, not one (see `full-non-terminal.yml`). Lifting that
-to a single mapMulti is the remaining work tracked by #570.
+`boxed-roundtrip.yml`). A type-changing boxed() distill that re-boxes to a
+wrapper stays object→object and `401` already fuses it into a stateful
+(distinct/skip) distill — that part always worked. What used to break the run
+into TWO mapMultis was the *trailing* mapToX (object→primitive) at the end of
+the boxing tail: the old empty-state-only `451` left it native. `451` now
+preserves the predecessor's `state` block and `502`/`512` are output-aware, so
+the trailing mapToX folds into the stateful distill too and the whole stateful
+pipeline collapses to ONE `Stream.mapMultiToX` (see `stateful-boxed-tail.yml`
+and `full-non-terminal.yml`, now 9 → 1) — closing #570 for the stateful path.
+
+One stateful boxed() shape is still unsupported and is a separate puzzle: a
+pipeline that *begins* with `distinct()`/`skip()` (before any typed
+`map`/`filter`) has `bridge-input ↦ Ljava/lang/Object;`, because distinct/skip
+erase the element type. A boxing tail whose desugared `lambda$` expects a
+specific wrapper (e.g. `Integer::doubleValue`, an `(Ljava/lang/Integer;)D`
+handle) then VerifyErrors — the object item is not assignable to `Integer`
+without a `checkcast`. This is pre-existing (it predates and is independent of
+the trailing-mapToX fusion) and is dodged by every fixture by leading with a
+typed operator; lifting it (insert a `checkcast` when `bridge-input` is
+`Object` and the body's first invoke wants a narrower type) is future work.
 
 A method reference (`Integer::intValue`, `String::toUpperCase`, `X::keep`, …)
 is **desugared into a lambda** up front so the rest of the pipeline picks it
@@ -399,10 +426,15 @@ no special gating. A filter that follows a `distinct`/`skip` needs its own
 predecessor, so `283-insert-dup-before-filter-after-stateful` covers the
 stateful-predecessor case.
 
-Limitations (v1): object streams only (`512` hardcodes the `Object` item
-shape); and `503` reads the frame type off `bridge-input`, correct while
-every operator before the distinct preserves the element type. Lifting
-these is future work.
+Limitations: the INPUT item is object-only (`512` loads it with a fixed
+`aload 1`); the OUTPUT may now be a primitive — when `451` fuses a trailing
+mapToX into the stateful distill, `512`'s closing dup / `XConsumer.accept`
+follow the output consumer exactly as `511` does, so a distinct/skip pipeline
+ending in a mapToX lowers to one `Stream.mapMultiToX`. Still future work: a
+primitive INPUT item; `503` reading the frame type off `bridge-input` (correct
+only while every operator before the distinct preserves the element type); and
+the `Object`-`bridge-input` boxed() case noted under "boxed() round-trips"
+(a pipeline that begins with distinct/skip).
 
 ### Capturing operators (closures)
 

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/451-fuse-distill-unbox.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/451-fuse-distill-unbox.phr
@@ -19,9 +19,17 @@
 # the distill's output to the primitive the unbox produces, turning the
 # distill into a type-transition distill: object item in, primitive out.
 # 401 already joins on bridge types blindly, so any further object distill
-# in front fuses in too. The emit pass (501/511/601) reads the now-distinct
-# bridge-input (object) and bridge-output (primitive) and lowers the whole
-# chain to one Stream.mapMultiToX call.
+# in front fuses in too.
+#
+# The preceding distill's `state` block is captured and preserved verbatim
+# (𝐵-state), so this fires for an empty-state pointwise distill AND for a
+# stateful one (distinct / skip, possibly with a boxed() round-trip already
+# fused in). A trailing mapToX that ends a distinct/skip pipeline therefore
+# folds into the same stateful distill rather than staying native, and the
+# whole chain lowers to ONE Stream.mapMultiToX. The emit pass is output-aware
+# in both flavours: 501/511 for empty state, 502/512 for stateful state, each
+# reading the now-distinct bridge-input (object) and bridge-output (primitive)
+# while 601 threads result-stream-class / stream-method.
 #
 # A mapToX with no distill in front of it never matches here, so it keeps
 # its native form via 603 — exactly the "do not pessimise a lone mapToX"
@@ -39,7 +47,7 @@ pattern: |
       accepted ↦ 𝑒-accepted,
       returned ↦ 𝑒-returned,
       static ↦ 𝑒-distill-static,
-      state ↦ ⟦ ρ ↦ ∅ ⟧,
+      state ↦ ⟦ 𝐵-state, ρ ↦ ∅ ⟧,
       body ↦ ⟦ 𝐵-body, ρ ↦ ∅ ⟧
     ⟧,
     𝜏-unbox ↦ ⟦
@@ -70,7 +78,7 @@ result: |
       accepted ↦ 𝑒-accepted,
       returned ↦ 𝑒-unbox-output,
       static ↦ 𝑒-result-static,
-      state ↦ ⟦ ρ ↦ ∅ ⟧,
+      state ↦ ⟦ 𝐵-state, ρ ↦ ∅ ⟧,
       body ↦ ⟦
         𝐵-body,
         𝜏-unbox-op ↦ ⟦

--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/502-distill-state-to-mapMulti.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/502-distill-state-to-mapMulti.phr
@@ -91,8 +91,8 @@ result: |
           lambda-signature ↦ 𝑒-lambda-signature,
           consumer ↦ 𝑒-consumer,
           stream-class ↦ 𝑒-stream-class,
-          result-stream-class ↦ 𝑒-stream-class,
-          stream-method ↦ "mapMulti",
+          result-stream-class ↦ 𝑒-result-stream-class,
+          stream-method ↦ 𝑒-stream-method,
           static ↦ "true",
           is-interface ↦ 𝑒-is-interface,
           captured ↦ "Ljava/util/List;"
@@ -141,10 +141,19 @@ where:
       - '"s/^D$/(DLjava\\/util\\/function\\/DoubleConsumer;)V/g"'
       - '"s/^I$/(ILjava\\/util\\/function\\/IntConsumer;)V/g"'
       - '"s/^J$/(JLjava\\/util\\/function\\/LongConsumer;)V/g"'
+  # As in 501, Stream.mapMultiToX takes a plain BiConsumer<T, XConsumer>, so
+  # the SAM type, its erased samMethodType and the source stream follow the
+  # INPUT (an object element for every stateful operator today), while the
+  # XConsumer the body drives, the resulting stream and the method name follow
+  # the OUTPUT. For a symmetric distill (input == output, e.g. a plain
+  # distinct/skip) every value coincides with the input derivation; for a
+  # stateful type-transition distill (object in, primitive out, produced when
+  # 451 fuses a trailing mapToX into a stateful distill) the consumer / result
+  # / method split off and the chain lowers to Stream.mapMultiToX.
   - meta: 𝑒-consumer
     function: sed
     args:
-      - 𝑒-bridge-input
+      - 𝑒-bridge-output
       - '"s/^L.+;$/Ljava\\/util\\/function\\/Consumer;/g"'
       - '"s/^D$/Ljava\\/util\\/function\\/DoubleConsumer;/g"'
       - '"s/^I$/Ljava\\/util\\/function\\/IntConsumer;/g"'
@@ -157,3 +166,35 @@ where:
       - '"s/^D$/java\\/util\\/stream\\/DoubleStream/g"'
       - '"s/^I$/java\\/util\\/stream\\/IntStream/g"'
       - '"s/^J$/java\\/util\\/stream\\/LongStream/g"'
+  - meta: 𝑒-result-stream-class
+    function: sed
+    args:
+      - 𝑒-bridge-output
+      - '"s/^L.+;$/java\\/util\\/stream\\/Stream/g"'
+      - '"s/^D$/java\\/util\\/stream\\/DoubleStream/g"'
+      - '"s/^I$/java\\/util\\/stream\\/IntStream/g"'
+      - '"s/^J$/java\\/util\\/stream\\/LongStream/g"'
+  - meta: 𝑒-in-cat
+    function: sed
+    args:
+      - 𝑒-bridge-input
+      - '"s/^L.+;$/O/g"'
+  - meta: 𝑒-out-cat
+    function: sed
+    args:
+      - 𝑒-bridge-output
+      - '"s/^L.+;$/O/g"'
+  - meta: 𝑒-io
+    function: concat
+    args: [𝑒-in-cat, 𝑒-out-cat]
+  - meta: 𝑒-stream-method
+    function: sed
+    args:
+      - 𝑒-io
+      - '"s/^OO$/mapMulti/g"'
+      - '"s/^II$/mapMulti/g"'
+      - '"s/^JJ$/mapMulti/g"'
+      - '"s/^DD$/mapMulti/g"'
+      - '"s/^OI$/mapMultiToInt/g"'
+      - '"s/^OJ$/mapMultiToLong/g"'
+      - '"s/^OD$/mapMultiToDouble/g"'

--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/512-distill-state-lambda-to-method.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/512-distill-state-lambda-to-method.phr
@@ -13,9 +13,12 @@
 # each fetch marker into List.get(counter); iinc so the N fetches walk the
 # List in body order — guard k reads state var k.
 #
-# v1 handles the object-stream shape only (distinct is Stream<T>); the
-# item is a reference, hence aload / dup_x1 / Consumer.accept. Primitive
-# stateful operators would generalise this the way 511 does.
+# The INPUT item is always a reference (v1 stateful operators are object
+# streams — distinct is Stream<T>), so the leading load is a fixed aload 1.
+# The OUTPUT may differ: when 451 fuses a trailing mapToX into this stateful
+# distill the body ends on a primitive, so the closing dup / Consumer.accept
+# follow the consumer type (Int/Long/DoubleConsumer), exactly as 511 does for
+# a stateless type-transition distill. A primitive INPUT item is future work.
 name: distill-state-lambda-to-method
 pattern: |
   ⟦
@@ -51,13 +54,13 @@ result: |
       i-load-item ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
       𝐵-body,
       i-load-consumer ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 2 ⟧,
-      i-dup-x ↦ ⟦ φ ↦ Φ.jeo.opcode.dup_x1 ⟧,
+      i-dup-x ↦ ⟦ φ ↦ Φ.jeo.opcode.𝜏-dup-x ⟧,
       i-pop ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
       i-invoke ↦ ⟦
         φ ↦ Φ.jeo.opcode.invokeinterface,
         i2 ↦ 𝑒-consumer-class,
         i3 ↦ "accept",
-        i4 ↦ "(Ljava/lang/Object;)V",
+        i4 ↦ 𝑒-invokeinterface-signature,
         i5 ↦ Φ.true
       ⟧,
       i-return ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
@@ -79,3 +82,32 @@ where:
     args:
       - 𝑒-consumer
       - '"s/L(.+);/$1/g"'
+  # The value the body leaves on the stack before the emit is the OUTPUT type,
+  # so (exactly as 511) the stack-arrangement dup and the consumer.accept
+  # argument follow the consumer: an Int/Long/DoubleConsumer for a stateful
+  # type-transition distill (object in, primitive out, produced when 451 fuses
+  # a trailing mapToX into a stateful distill), or the object Consumer for a
+  # symmetric distinct/skip. The item is always an object (v1 stateful limit),
+  # so the leading aload 1 is unchanged.
+  - meta: 𝑒-dup-x
+    function: sed
+    args:
+      - 𝑒-consumer
+      - '"s/^Ljava\\/util\\/function\\/DoubleConsumer;$/dup_x2/g"'
+      - '"s/^Ljava\\/util\\/function\\/LongConsumer;$/dup_x2/g"'
+      - '"s/^Ljava\\/util\\/function\\/IntConsumer;$/dup_x1/g"'
+      - '"s/^Ljava\\/util\\/function\\/Consumer;$/dup_x1/g"'
+  - meta: 𝜏-dup-x
+    function: tau
+    args: [𝑒-dup-x]
+  - meta: 𝑒-invokeinterface-input
+    function: sed
+    args:
+      - 𝑒-consumer
+      - '"s/^Ljava\\/util\\/function\\/Consumer;$/Ljava\\/lang\\/Object;/g"'
+      - '"s/^Ljava\\/util\\/function\\/IntConsumer;$/I/g"'
+      - '"s/^Ljava\\/util\\/function\\/LongConsumer;$/J/g"'
+      - '"s/^Ljava\\/util\\/function\\/DoubleConsumer;$/D/g"'
+  - meta: 𝑒-invokeinterface-signature
+    function: concat
+    args: ['"("', 𝑒-invokeinterface-input, '")V"']

--- a/src/test/phino/451-fuse-distill-unbox-stateful.yml
+++ b/src/test/phino/451-fuse-distill-unbox-stateful.yml
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Sibling of 451-fuse-distill-unbox: a boundary mapToX (a Φ.hone.unbox, object
+# in / primitive out) sitting right after a STATEFUL distill (one whose `state`
+# block is non-empty — here a distinct that appends a java/util/HashSet) must
+# fuse into it just like into an empty-state distill. 451 captures and PRESERVES
+# the predecessor's state block (𝐵-state), splices the unbox's target invocation
+# onto the tail of the body, and widens bridge-output / returned from the object
+# wrapper to the primitive "D". The result is a stateful type-transition distill
+# that 502/512/601 lower to one Stream.mapMultiToDouble. This is the fusion that
+# closes #570 for the stateful path: without state preservation the trailing
+# mapToX stayed native (a second invokedynamic).
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/4xx/451-fuse-distill-unbox.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      op1 ↦ ⟦
+        φ ↦ Φ.hone.distill,
+        class ↦ "A",
+        bridge-input ↦ "Ljava/lang/Object;",
+        bridge-output ↦ "Ljava/lang/Double;",
+        start ↦ "distinct",
+        accepted ↦ "Ljava/lang/Object;",
+        returned ↦ "Ljava/lang/Double;",
+        static ↦ "true",
+        state ↦ ⟦
+          s1 ↦ ⟦ φ ↦ Φ.jeo.opcode.new, i1 ↦ "java/util/HashSet" ⟧,
+          ρ ↦ ∅
+        ⟧,
+        body ↦ ⟦
+          g1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/util/HashSet" ⟧,
+          g2 ↦ ⟦
+            φ ↦ Φ.jeo.opcode.invokestatic,
+            i2 ↦ "A",
+            i3 ↦ "lambda$f$0",
+            i4 ↦ "(Ljava/lang/Double;)Ljava/lang/Double;",
+            i5 ↦ Φ.false
+          ⟧,
+          ρ ↦ ∅
+        ⟧
+      ⟧,
+      op2 ↦ ⟦
+        φ ↦ Φ.hone.unbox,
+        opcode ↦ "invokestatic",
+        class ↦ "A",
+        bridge-signature ↦ "(Ljava/lang/Double;)D",
+        static ↦ "true",
+        target ↦ ⟦
+          handle ↦ 6,
+          class ↦ "A",
+          method ↦ "lambda$f$1",
+          signature ↦ "(Ljava/lang/Double;)D",
+          is-interface ↦ Φ.false
+        ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧}
+expected:
+  - ⟦ 𝐵-a, φ ↦ Φ.hone.distill, 𝐵-b, bridge-output ↦ "D", 𝐵-c, state ↦ ⟦ 𝐵-s1, 𝜏-new ↦ ⟦ φ ↦ Φ.jeo.opcode.new, i1 ↦ "java/util/HashSet" ⟧, 𝐵-s2 ⟧, 𝐵-d ⟧
+  - ⟦ 𝐵-p, 𝜏-g ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, 𝐵-x, i3 ↦ "lambda$f$0", 𝐵-y ⟧, 𝜏-u ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, 𝐵-z, i3 ↦ "lambda$f$1", 𝐵-w ⟧, 𝐵-q ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/boxed-roundtrip.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/boxed-roundtrip.yml
@@ -13,10 +13,10 @@
 # 501/511 lower the whole chain to a SINGLE Stream.mapMultiToDouble dispatch.
 #
 # This is the case issue #570 reported as unfused for a pure pointwise pipeline:
-# every operator collapses to one mapMulti, dropping invokedynamic 5 -> 1. (A
-# stateful prefix — distinct/skip — keeps the boxing native, see
-# full-non-terminal.yml, because the object-only stateful emit cannot take a
-# type-changing intermediate.)
+# every operator collapses to one mapMulti, dropping invokedynamic 5 -> 1. A
+# stateful prefix — distinct/skip — now collapses its boxing tail into the same
+# single mapMulti too (the stateful emit became output-aware), see
+# full-non-terminal.yml.
 java: |
   package boxedroundtrip;
   import java.util.stream.Stream;

--- a/src/test/resources/org/eolang/hone/optimize/streams/closures.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/closures.yml
@@ -7,13 +7,18 @@
 # are asserted. The runtime result: the pipeline must never corrupt a
 # roundtrip nor pessimise a lone operator, so a correct printout proves every
 # path lowered to runnable bytecode. And the invokedynamic tally: it drops
-# from 41 to 32 as the capturing and non-capturing operators collapse into 10
-# Stream.mapMulti dispatches. The indys that remain are the string-concat
+# from 41 to 29 as the capturing and non-capturing operators collapse into 10
+# Stream.mapMulti dispatches — 3 stay an object mapMulti and 7 become a
+# mapMultiToInt, because a trailing mapToInt(Integer::intValue) now folds into
+# the distill in front of it whether that distill is empty-state OR
+# stateful/capturing (the generalized 451 preserves the predecessor's state,
+# so capLoc / multiCap / loneMulti each absorb their trailing mapToInt instead
+# of leaving it native). The indys that remain are the string-concat
 # (makeConcatWithConstants in decorate / the reduce) and the genuinely native
-# or reverted cases (capObj, capArr, capFld, lone, named, the trailing
-# mapToInt unboxes, …); the nine that disappear are the fusion win. Which indy
-# collapses into which mapMulti is proven per-rule by the src/test/phino/
-# packs — this fixture proves the rules COMPOSE on a real class.
+# or reverted cases (capObj, capArr, capFld, lone, named, multiFil, …); the
+# twelve that disappear are the fusion win. Which indy collapses into which
+# mapMulti is proven per-rule by the src/test/phino/ packs — this fixture
+# proves the rules COMPOSE on a real class.
 #
 # Native roundtrip shapes — must survive untouched:
 #   bound   : String::length             unbound-instance method ref
@@ -141,7 +146,7 @@ java: |
 before:
   invokedynamic: 41
 after:
-  invokedynamic: 32
+  invokedynamic: 29
 log:
   - "BUILD SUCCESS"
   - "The result is 14 200 14 84 315 >2>3>4 36 27 3006 87 24 387 5 54 12"

--- a/src/test/resources/org/eolang/hone/optimize/streams/full-non-terminal.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/full-non-terminal.yml
@@ -22,17 +22,19 @@
 # Both distincts and both skips are stateful, and the two distinct/skip
 # pairs sit adjacent (distinct().skip()), so this is the case that proves
 # stateful distills fuse: all nine object-stream operators (peek included)
-# collapse into a single mapMulti backed by one captured java/util/List
-# holding the two HashSets and two long[1] counters. The primitive-conversion
-# tail (mapToInt().boxed().mapToLong().boxed().mapToDouble().boxed() + the
-# final mapToInt) is itself a run of user boxed() round-trips, which 209 folds
-# and 401 fuses into a SECOND mapMulti, so the whole method drops invokedynamic
-# 9 -> 2. The two mapMultis do not merge into one: the boxing tail changes the
-# element type (Integer -> Long -> Double), and a type-changing distill is not
-# fused into the object-only stateful emit (502/512/503) — the documented
-# stateful limitation, and why #570's "everything into one mapMulti" stays
-# open. A purely pointwise boxed() chain does collapse to one, see
-# boxed-roundtrip.yml.
+# collapse into a single stateful distill backed by one captured
+# java/util/List holding the two HashSets and two long[1] counters. The
+# primitive-conversion tail (mapToInt().boxed().mapToLong().boxed().
+# mapToDouble().boxed()) is a run of user boxed() round-trips, which 209
+# folds and 401 fuses into that SAME stateful distill (it stays object ->
+# Double, since each boxed() re-boxes to a wrapper). The final mapToInt
+# is a trailing type-transition mapToX: 451 (which now preserves the
+# predecessor's state block) fuses it in too, widening the one stateful
+# distill to object -> int. The output-aware stateful emit (502/512, the
+# stateful twins of 501/511) then lowers the WHOLE method to a single
+# Stream.mapMultiToInt — invokedynamic 9 -> 1. This is #570's "everything
+# into one mapMulti" reaching the stateful path; a purely pointwise boxed()
+# chain has always collapsed to one, see boxed-roundtrip.yml.
 java: |
   package allnonterminal;
   import java.util.stream.Stream;
@@ -67,4 +69,4 @@ log:
 before:
   invokedynamic: 9
 after:
-  invokedynamic: 2
+  invokedynamic: 1

--- a/src/test/resources/org/eolang/hone/optimize/streams/stateful-boxed-tail.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/stateful-boxed-tail.yml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A stateful pipeline (distinct + skip) followed by a boxed() round-trip and a
+# trailing mapToX must collapse into a SINGLE Stream.mapMultiToX — the case
+# #570 left open for the stateful path. The leading map fixes the element type
+# at Integer (a chain that began with distinct would expose the separate
+# Object-bridge-input limitation, out of scope here). distinct and skip fold to
+# one stateful distill (two state vars in one captured List); the
+# mapToLong(Integer::longValue).boxed() round-trip folds via 209 and 401 fuses
+# it into that same stateful distill (still object -> Long, a wrapper); finally
+# the trailing mapToDouble(Long::doubleValue) is a type-transition mapToX that
+# 451 — now preserving the predecessor's state block — fuses in too, widening
+# the one stateful distill to object -> double. The output-aware stateful emit
+# (502/512, twins of 501/511) lowers the whole method to one
+# Stream.mapMultiToDouble, dropping invokedynamic 3 -> 1. Were the trailing
+# mapToX left native (the old empty-state-only 451) this would be 2.
+#
+# of(5,3,8,5,2,7).map(+1) = 6,4,9,6,3,8; distinct = 6,4,9,3,8; skip(1) =
+# 4,9,3,8; sum as double = 24.
+java: |
+  package statefulboxedtail;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      double r = Stream.of(5, 3, 8, 5, 2, 7)
+        .map(n -> n + 1)
+        .distinct()
+        .skip(1L)
+        .mapToLong(Integer::longValue)
+        .boxed()
+        .mapToDouble(Long::doubleValue)
+        .sum();
+      System.out.printf("The result is %d\n", (int) r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 24"
+before:
+  invokedynamic: 3
+after:
+  invokedynamic: 1


### PR DESCRIPTION
A `distinct()`/`skip()` (or capturing) stream pipeline that ends in a trailing `mapToInt`/`mapToLong`/`mapToDouble` — including a `mapToX().boxed()` tail — now collapses to a single `Stream.mapMultiToX`, instead of leaving the trailing `mapToX` native as a second `invokedynamic`. This is #570's "everything into one mapMulti" reaching the stateful path; the pointwise path already collapsed.

It turned out the blocker was narrower than "two mapMultis to merge": `401` already fuses the stateful distill with every `boxed()` round-trip into one object→wrapper distill. The only leftover was the trailing object→primitive unbox, which the empty-state-only `451` refused to fold into a stateful distill, and which `502`/`512` couldn't emit. So the fix is three small changes that mirror the existing `501`/`511` design into their stateful twins: `451` now captures and preserves the predecessor's `state` block (so it fuses a trailing mapToX into a stateful distill too), and `502`/`512` became output-aware — `consumer`, `result-stream-class`, `stream-method` and the closing `dup`/`XConsumer.accept` follow `bridge-output`. `503`/`504`/`521`/`601` are unchanged.

`full-non-terminal` drops `invokedynamic` 9 → 1 and `closures` 41 → 29 (trailing mapToInts after capturing operators now fold in too); `all-ops` is unchanged. Adds a `stateful-boxed-tail` e2e fixture and a stateful `451` phino pack. Verified across the 32 phino packs and all 16 optimize e2e fixtures (host phino 0.0.0.73 and Docker), each still running with correct output.

One separate, pre-existing limitation stays open and is documented in CLAUDE.md: a pipeline that *begins* with `distinct`/`skip` has `bridge-input = Object` (those operators erase the element type), so a boxing `lambda$` expecting a specific wrapper (e.g. `Integer::doubleValue`) VerifyErrors without a `checkcast`. It predates this change and is dodged by leading with a typed `map`/`filter`; lifting it is future work.