### PR TITLE
#649 narrow Object item before boxed()/mapToX tail of a distinct/skip pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,16 +264,22 @@ the trailing mapToX folds into the stateful distill too and the whole stateful
 pipeline collapses to ONE `Stream.mapMultiToX` (see `stateful-boxed-tail.yml`
 and `full-non-terminal.yml`, now 9 → 1) — closing #570 for the stateful path.
 
-One stateful boxed() shape is still unsupported and is a separate puzzle: a
-pipeline that *begins* with `distinct()`/`skip()` (before any typed
+A pipeline that *begins* with `distinct()`/`skip()` (before any typed
 `map`/`filter`) has `bridge-input ↦ Ljava/lang/Object;`, because distinct/skip
 erase the element type. A boxing tail whose desugared `lambda$` expects a
 specific wrapper (e.g. `Integer::doubleValue`, an `(Ljava/lang/Integer;)D`
-handle) then VerifyErrors — the object item is not assignable to `Integer`
-without a `checkcast`. This is pre-existing (it predates and is independent of
-the trailing-mapToX fusion) and is dodged by every fixture by leading with a
-typed operator; lifting it (insert a `checkcast` when `bridge-input` is
-`Object` and the body's first invoke wants a narrower type) is future work.
+handle) used to VerifyError — the object item is not assignable to `Integer`
+without a `checkcast`. `505-distill-state-item-cast` (issue #649) closes this:
+after `503` resolves the guard's keep-label `frame-item` into a `Φ.jeo.frame`,
+the very next opcode is that first typed `invokestatic`, so `505` splices a
+`checkcast <wrapper>` between the frame and the invoke whenever `bridge-input`
+is `Object` and the invoke takes a single non-`Object` reference argument. The
+cast runs *after* the frame, which still rightly declares `Object`, so `503` is
+unchanged. It reaches the first typed op directly after the (last) guard — the
+boxed()/mapToX-after-distinct/skip shape; a `filter`/`peek` wedged between the
+guard and the boxing tail opens its body with a `dup`, breaking the
+`frame → invokestatic` adjacency, so narrowing through that interleaving is a
+follow-up puzzle (see `stateful-object-tail.yml`).
 
 A method reference (`Integer::intValue`, `String::toUpperCase`, `X::keep`, …)
 is **desugared into a lambda** up front so the rest of the pipeline picks it
@@ -430,11 +436,14 @@ Limitations: the INPUT item is object-only (`512` loads it with a fixed
 `aload 1`); the OUTPUT may now be a primitive — when `451` fuses a trailing
 mapToX into the stateful distill, `512`'s closing dup / `XConsumer.accept`
 follow the output consumer exactly as `511` does, so a distinct/skip pipeline
-ending in a mapToX lowers to one `Stream.mapMultiToX`. Still future work: a
-primitive INPUT item; `503` reading the frame type off `bridge-input` (correct
-only while every operator before the distinct preserves the element type); and
-the `Object`-`bridge-input` boxed() case noted under "boxed() round-trips"
-(a pipeline that begins with distinct/skip).
+ending in a mapToX lowers to one `Stream.mapMultiToX`. The `Object`-`bridge-input`
+boxed() case (a pipeline that *begins* with distinct/skip) is now handled by
+`505-distill-state-item-cast`, which narrows the Object item with a `checkcast`
+before the boxing tail's first typed invoke (see "boxed() round-trips" above and
+#649). Still future work: a primitive INPUT item; `503` reading the frame type
+off `bridge-input` (correct only while every operator before the distinct
+preserves the element type); and narrowing through a `filter`/`peek` wedged
+between the guard and the boxing tail.
 
 ### Capturing operators (closures)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -439,11 +439,11 @@ follow the output consumer exactly as `511` does, so a distinct/skip pipeline
 ending in a mapToX lowers to one `Stream.mapMultiToX`. The `Object`-`bridge-input`
 boxed() case (a pipeline that *begins* with distinct/skip) is now handled by
 `505-distill-state-item-cast`, which narrows the Object item with a `checkcast`
-before the boxing tail's first typed invoke (see "boxed() round-trips" above and
-#649). Still future work: a primitive INPUT item; `503` reading the frame type
-off `bridge-input` (correct only while every operator before the distinct
-preserves the element type); and narrowing through a `filter`/`peek` wedged
-between the guard and the boxing tail.
+before the boxing tail's first typed invoke (issue #649; see "boxed()
+round-trips" above). Still future work: a primitive INPUT item; `503` reading
+the frame type off `bridge-input` (correct only while every operator before the
+distinct preserves the element type); and narrowing through a `filter`/`peek`
+wedged between the guard and the boxing tail.
 
 ### Capturing operators (closures)
 

--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/505-distill-state-item-cast.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/505-distill-state-item-cast.phr
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Narrows the Object item a distinct()/skip()-led pipeline carries before the
+# first body opcode that consumes it as a specific wrapper (#649). distinct and
+# skip erase the element type, so the fused stateful distill they head carries
+# bridge-input ↦ Ljava/lang/Object; — 512 loads the item with a fixed aload 1
+# and 503 frames it as Object. When a boxed() round-trip or a trailing mapToX
+# rides such a pipeline, the boxing / unbox body opens with an invokestatic onto
+# a desugared lambda$ wrapper whose parameter is a NARROWER reference (e.g.
+# Integer::doubleValue desugars to a (Ljava/lang/Integer;)D handle). The item on
+# the operand stack is still Object and is never narrowed, so the verifier
+# rejects the wrapper with "Bad type on operand stack: Type 'java/lang/Object'
+# is not assignable to 'java/lang/Integer'". It stays latent because every other
+# fixture leads with a typed map/filter, which pins bridge-input to the wrapper.
+#
+# The stateful guard (307 / 308) keeps the item at a keep-label whose stackmap
+# frame 503 fills (correctly) as Object; the very next opcode is that first
+# typed invokestatic. This rule anchors on the Φ.jeo.frame → invokestatic
+# adjacency and splices a `checkcast <wrapper>` between them, so the item is
+# narrowed exactly where it is first needed — the guard above ran on the Object
+# item through HashSet.add(Object) / the skip counter, neither of which needs a
+# narrower type. Because the cast runs AFTER the frame, the frame still rightly
+# declares Object, so 503 is left unchanged.
+#
+# It fires only when bridge-input is Object (the distinct/skip element-erasure
+# signature) and the following invokestatic takes a SINGLE non-Object reference
+# argument: a symmetric distinct/skip (no typed tail — the frame is the last
+# opcode, nothing follows) and an Object-accepting body are both left alone, and
+# the single-arg guard skips a captured lambda$ (which takes the List plus the
+# item). It runs after 503 (which turns the keep-label's frame-item into a
+# Φ.jeo.frame) and before 512 (which wraps the distill-lambda body into a
+# method), applied at fixpoint — a checkcast it already inserted now sits
+# between the frame and the invoke, so the adjacency does not re-match.
+#
+# Limitation: only the FIRST typed op directly after the (last) guard is
+# reached, which is exactly the boxed()/mapToX-after-distinct/skip shape #649
+# reports. A filter or peek wedged between the guard and the boxing tail opens
+# its body with a dup, breaking the frame → invokestatic adjacency; narrowing
+# through that interleaving is a follow-up puzzle on the same shared-state
+# channel.
+name: distill-state-item-cast
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ 𝑒-static,
+    bridge-input ↦ "Ljava/lang/Object;",
+    consumer ↦ 𝑒-consumer,
+    target-method ↦ 𝑒-target-method,
+    captured ↦ 𝑒-captured,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-frame ↦ ⟦ φ ↦ Φ.jeo.frame, 𝐵-frame-rest ⟧,
+      𝜏-invoke ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokestatic,
+        i2 ↦ 𝑒-invoke-class,
+        i3 ↦ 𝑒-invoke-method,
+        i4 ↦ 𝑒-invoke-signature,
+        i5 ↦ 𝑒-invoke-is-interface
+      ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ 𝑒-static,
+    bridge-input ↦ "Ljava/lang/Object;",
+    consumer ↦ 𝑒-consumer,
+    target-method ↦ 𝑒-target-method,
+    captured ↦ 𝑒-captured,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-frame ↦ ⟦ φ ↦ Φ.jeo.frame, 𝐵-frame-rest ⟧,
+      𝜏-cast ↦ ⟦ φ ↦ Φ.jeo.opcode.checkcast, i1 ↦ 𝑒-cast-class ⟧,
+      𝜏-invoke ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokestatic,
+        i2 ↦ 𝑒-invoke-class,
+        i3 ↦ 𝑒-invoke-method,
+        i4 ↦ 𝑒-invoke-signature,
+        i5 ↦ 𝑒-invoke-is-interface
+      ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+when:
+  and:
+    - matches: ['^\(L[^;]+;\)', 𝑒-invoke-signature]
+    - not:
+        matches: ['^\(Ljava/lang/Object;\)', 𝑒-invoke-signature]
+where:
+  - meta: 𝜏-cast
+    function: random-tau
+  - meta: 𝑒-cast-class
+    function: sed
+    args:
+      - 𝑒-invoke-signature
+      - '"s/^\\(L([^;]+);.*/$1/g"'

--- a/src/test/phino/505-distill-state-item-cast.yml
+++ b/src/test/phino/505-distill-state-item-cast.yml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 505 narrows the Object item a distinct/skip-led stateful distill carries
+# (bridge-input ↦ Ljava/lang/Object;) right before the first body opcode that
+# consumes it as a wrapper. After 503 resolves the guard's keep-label frame-item
+# into a Φ.jeo.frame, the very next opcode is the boxing / unbox invokestatic
+# onto a desugared lambda$ whose parameter is the narrower wrapper
+# (Ljava/lang/Integer;). The verifier would reject the Object on the stack, so
+# this rule splices a `checkcast java/lang/Integer` between the frame and the
+# invoke. The frame itself is untouched (it correctly still declares Object —
+# the cast runs after it) — see #649.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-state-frame.phr
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/505-distill-state-item-cast.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      op1 ↦ ⟦
+        φ ↦ Φ.hone.distill-lambda,
+        static ↦ "true",
+        bridge-input ↦ "Ljava/lang/Object;",
+        consumer ↦ "Ljava/util/function/DoubleConsumer;",
+        target-method ↦ "distill_0",
+        captured ↦ "Ljava/util/List;",
+        body ↦ ⟦
+          g1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/util/HashSet" ⟧,
+          g2 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+          g3 ↦ ⟦
+            φ ↦ Φ.jeo.opcode.invokestatic,
+            i2 ↦ "A",
+            i3 ↦ "lambda$main$0",
+            i4 ↦ "(Ljava/lang/Integer;)D",
+            i5 ↦ Φ.false
+          ⟧,
+          ρ ↦ ∅
+        ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.jeo.opcode.checkcast, i1 ↦ "java/lang/Integer" ⟧
+  - ⟦ 𝐵-p, 𝜏-f ↦ ⟦ φ ↦ Φ.jeo.frame, 𝐵-fr ⟧, 𝜏-c ↦ ⟦ φ ↦ Φ.jeo.opcode.checkcast, i1 ↦ "java/lang/Integer" ⟧, 𝜏-i ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, 𝐵-x, i3 ↦ "lambda$main$0", 𝐵-y ⟧, 𝐵-q ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/stateful-object-tail.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/stateful-object-tail.yml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A pipeline that BEGINS with distinct() — before any typed map/filter — and
+# then carries a boxed() round-trip and a trailing mapToX. distinct erases the
+# element type, so the fused stateful distill carries bridge-input ↦
+# Ljava/lang/Object; rather than the wrapper, and the synthesised wrapper loads
+# the item with a fixed aload 1 framed as Object. The boxing body's first opcode
+# invokes the desugared Integer::doubleValue lambda$, an (Ljava/lang/Integer;)D
+# handle, so before this fix the optimized class failed JVM verification with
+# "Bad type on operand stack: Type 'java/lang/Object' is not assignable to
+# 'java/lang/Integer'". 505 now splices a `checkcast java/lang/Integer` right
+# after the guard's keep-label frame, narrowing the item exactly where the
+# boxing tail first needs it — closing #649.
+#
+# distinct + the boxed() round-trip + the trailing mapToDouble all fold into ONE
+# stateful distill (one HashSet in the captured List) and lower to a single
+# Stream.mapMultiToDouble: the two method-ref invokedynamics javac emits collapse
+# to one. of(5,3,8,5,2,7).distinct() = 5,3,8,2,7; doubleValue/boxed/doubleValue
+# is the identity on the values; sum = 25.
+java: |
+  package statefulobjecttail;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      double r = Stream.of(5, 3, 8, 5, 2, 7)
+        .distinct()
+        .mapToDouble(Integer::doubleValue)
+        .boxed()
+        .mapToDouble(Double::doubleValue)
+        .sum();
+      System.out.printf("The result is %d\n", (int) r);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 25"
+before:
+  invokedynamic: 2
+after:
+  invokedynamic: 1


### PR DESCRIPTION
Fixes #649.

## Problem

A stream pipeline that *begins* with `distinct()`/`skip()` (before any typed `map`/`filter`) and then carries a `boxed()` round-trip or a trailing `mapToX` optimized to a class that failed JVM verification:

```
Bad type on operand stack: Type 'java/lang/Object' is not assignable to 'java/lang/Integer'
```

`distinct`/`skip` erase the element type, so the fused stateful distill carries `bridge-input ↦ Ljava/lang/Object;`. The synthesized `distill_N(List, Object, XConsumer)` wrapper loads the item with a fixed `aload 1` and frames it as Object, but the boxing body's first opcode invokes the desugared method-ref `lambda$` (e.g. for `Integer::doubleValue`, an `(Ljava/lang/Integer;)D` handle) — and the item is never narrowed.

Repro that threw `VerifyError` after optimization:

```java
Stream.of(5, 3, 8, 5, 2, 7)
  .distinct()
  .mapToDouble(Integer::doubleValue)
  .boxed()
  .mapToDouble(Double::doubleValue)
  .sum();
```

## Fix

New rule `505-distill-state-item-cast.phr`. The stateful guard (307/308) keeps the item at a keep-label whose stackmap frame `503` resolves into a `Φ.jeo.frame`; the very next opcode is that first typed `invokestatic`. `505` anchors on the `Φ.jeo.frame → invokestatic` adjacency and splices a `checkcast <wrapper>` between them, narrowing the item exactly where the boxing tail first needs it. The cast runs **after** the frame, which still rightly declares Object, so `503` is unchanged.

It fires only when:
- `bridge-input` is `Ljava/lang/Object;` (the distinct/skip element-erasure signature), and
- the following `invokestatic` takes a **single non-Object reference** argument (so a symmetric distinct/skip and an Object-accepting body are left alone, and a captured `lambda$` — which takes the List plus the item — is skipped).

It runs after `503` (frame-item → frame) and before `512` (wraps the distill-lambda into a method), applied at fixpoint — a checkcast it already inserted now sits between frame and invoke, so the adjacency does not re-match.

### Limitation (documented, follow-up)

Only the first typed op directly after the (last) guard is reached — exactly the boxed()/mapToX-after-distinct/skip shape #649 reports. A `filter`/`peek` wedged between the guard and the boxing tail opens its body with a `dup`, breaking the adjacency; narrowing through that interleaving remains future work.

## Tests

- `src/test/phino/505-distill-state-item-cast.yml` — single-rule unit pack: feeds a distill-lambda with an Object bridge-input and a guard keep-label frame followed by an `(Ljava/lang/Integer;)D` invoke, asserts a `checkcast java/lang/Integer` lands between the frame and the invoke.
- `src/test/resources/org/eolang/hone/optimize/streams/stateful-object-tail.yml` — end-to-end fixture for the issue's exact repro: builds successfully, prints `The result is 25`, and collapses two method-ref `invokedynamic`s to one `Stream.mapMultiToDouble`.
- `CLAUDE.md` updated: the "boxed() round-trips" and stateful "Limitations" sections now document the fix instead of flagging it as future work.

> [!NOTE]
> The e2e/unit packs are `@Tag("deep")` and require the `phino` binary, which is not available in this environment — they were not run locally. The `before`/`after` `invokedynamic` counts and runtime assertion should be confirmed by CI (`mvn -Pdeep test`).


---
_Generated by [Claude Code](https://claude.ai/code/session_017XqayByhvKMPj7MvSBSNNu)_