### PR TITLE
Generalise capturing-map fusion to a single reference capture (#647)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,9 +174,10 @@ distinct                         → 216 → 307 → state distill;
 skip                             → 220 → 308 → state distill;
                                     442 reverts it (count and call)
                                     to invokeinterface if it never fused
-capturing map (N ints)           → 112 → 114 → 316 → c-map state distill;
-                                    443 reverts a lone single-capture map if
-                                    unfused (multi-capture stays mapMulti)
+capturing map (N ints OR 1 ref)  → 112 → 114 (int peeler) / 115 (ref peeler)
+                                    → 316 → c-map state distill; 443 reverts a
+                                    lone single-int-capture map if unfused
+                                    (multi-capture and lone-ref stay mapMulti)
 capturing filter (one int)       → 113 → 314 → c-filter state distill;
                                     444 reverts it to invokedynamic if unfused
 ```
@@ -464,27 +465,32 @@ any type-preserving reference element type, filter one capture over Integer):
 - `112` / `113` lift a capturing map / primitive-filter indy to
   `Φ.hone.c-map` / `Φ.hone.cp-filter`. `113` (single capture) still **grabs the
   one `iload k` push** and carries it as `capture-push`. `112` is now arity-
-  agnostic: its guard is `\(I+\)L…Function;` (one OR MORE ints) and it grabs
-  **no** push — it leaves the whole run of `iload`s inline in front of the
+  agnostic: its guard is `\(I+\)L…Function;` (one OR MORE ints) OR
+  `\(L…;\)L…Function;` (a SINGLE reference), and it grabs **no** push — it
+  leaves the whole run of `iload`s / the lone `aload` inline in front of the
   c-map and seeds two EMPTY accumulators (`state-acc`, `body-acc`). They
   partition the indy space with `111`: `\(\)` matches zero captures, `\(I…\)`
-  matches int captures, a handle-6 static `lambda$` target, and a
-  **type-preserving** instantiated type — matched as `(LX;)LX;` for any
-  reference `X` via a backreference guard (Integer, String, …), with `X`
-  sed-extracted into the four bridge fields. A reference capture (push is
-  `aload`), category-2 (`J`/`D`), `this`-capture (handle 5), a
+  matches int captures, `\(L…;\)` a single reference capture, a handle-6 static
+  `lambda$` target, and a **type-preserving** instantiated type — matched as
+  `(LX;)LX;` for any reference `X` via a backreference guard (Integer, String,
+  …), with `X` sed-extracted into the four bridge fields. Category-2 (`J`/`D`),
+  a MULTI-reference / mixed-with-reference run, `this`-capture (handle 5), a
   **type-transforming** map (`(LX;)LY;`, declined by the backreference and left
   to the unbox/box machinery), computed/field push — all stay native.
-- `114` gathers `112`'s inline pushes into the c-map, one per firing,
-  re-applying at fixpoint (the same self-iteration `521` uses). It matches the
-  single `iload` **directly in front of** the c-map; phino's leading group is
-  greedy, so the bound push is always the LAST one and the rule peels
-  right-to-left. Each peel PREPENDS one boxing append
+- `114` (int) / `115` (reference) gather `112`'s inline pushes into the c-map,
+  one per firing, re-applying at fixpoint (the same self-iteration `521` uses).
+  Each matches its push opcode **directly in front of** the c-map; phino's
+  leading group is greedy, so the bound push is always the LAST one and the rule
+  peels right-to-left. `114` PREPENDS one boxing append
   (`dup; iload k; Integer.valueOf; List.add; pop`) to `state-acc` and one
   `fetch; intValue` to `body-acc`, so the captures end up appended in
-  left-to-right (x, y, z) order — slot 0 = x, guard *k* reads capture *k*. The
-  run is bounded on the left by the previous operator's invokeinterface, never
-  another iload, so peeling stops cleanly.
+  left-to-right (x, y, z) order — slot 0 = x, guard *k* reads capture *k*. `115`
+  is the same shape minus the box/unbox: a reference is already an Object, so it
+  appends `dup; aload k; List.add; pop` and a bare `fetch` typed with the
+  capture's class (sed-extracted from `target.signature`'s first L-type, which
+  is why only a SINGLE reference capture is admitted). The run is bounded on the
+  left by the previous operator's invokeinterface, never another push, so
+  peeling stops cleanly.
 - `316` / `314` fold into a stateful `Φ.hone.distill`. `316` copies the filled
   `state-acc` into `state` and wraps `body-acc` into the auto emit-shape
   `astore 1; <fetch; intValue>×N; aload 1; invokestatic lambda$`: the item is
@@ -525,10 +531,20 @@ type (`Stream<String>`, …), and `443` rebuilds the reverted SAM type from the
 distill's bridge fields so a lone such map still comes out native — see the
 `streams/closure-string.yml` end-to-end fixture.
 
+A SINGLE reference capture is **done** (issue #647): `112`'s `(L…;)` guard
+branch lifts `map(n -> n + base.size())` over a captured `List`, `115` peels the
+`aload` into the shared List with no box/unbox, and the whole stateful emit path
+(`316`/`401`/`502`/`512`/`521`/`601`) lowers it to one `Stream.mapMulti` — see
+the `streams/closure-reference.yml` end-to-end fixture. A lone reference-capture
+map is not reverted by `443` (closed on the int box/unbox shape), so it is
+emitted as a standalone `mapMulti` — correct, like the lone-multi-capture map.
+
 Deferred puzzles (each extends the same shared-List channel): a multi-capture
-FILTER and the lone-multi-capture-map revert (both above); reference captures
-(drop the box/unbox); category-2 captures; `this`-field captures; and capturing
-`peek`/`mapToX`. See the puzzle marker in `112`'s header.
+FILTER and the lone-multi-capture-map revert (both above); category-2 (`J`/`D`)
+captures (whose relocated 2-slot append needs a caller max-stack bump); a
+MULTI-reference / mixed-with-reference capture run and a lone-reference-map
+revert; `this`-field captures; and capturing `peek`/`mapToX`. See the puzzle
+marker in `112`'s header.
 
 ## phino: the only rewrite engine
 

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
@@ -23,24 +23,32 @@
 # state List" is what lets N captures (and any number of fused capturing
 # operators) reuse the distinct/skip machinery (502/512/521/601) verbatim.
 #
-# v1.2 scope (issues #636, #640): one OR MORE category-1 INT captures, a
-# type-PRESERVING map over ANY reference element type — the SAM instantiated type
-# is matched as "(LX;)LX;" for any reference X (Integer, String, …) via a
-# backreference guard, and the element type X is sed-extracted into 𝑒-bridge and
-# threaded into all four bridge fields. A handle-6 static lambda$ target, every
-# push a constant-index iload. So `map(s -> s.repeat(k))` on a Stream<String>
-# (int capture k) now fuses exactly like the original Stream<Integer> case.
+# v1.3 scope (issues #636, #640, #647): the captures admitted are either
+# one OR MORE category-1 INT captures (factory descriptor "(I+)L…Function;",
+# every push a constant-index iload, gathered by 114) OR a SINGLE reference
+# capture (factory descriptor "(L…;)L…Function;", push an aload, gathered by the
+# reference branch 115) — the two are partitioned by the `or` in the interface
+# guard. In both cases the map is type-PRESERVING over ANY reference element type:
+# the SAM instantiated type is matched as "(LX;)LX;" for any reference X (Integer,
+# String, …) via a backreference guard, and the element type X is sed-extracted
+# into 𝑒-bridge and threaded into all four bridge fields. The lambda$ target is a
+# handle-6 static method. So `map(s -> s.repeat(k))` on a Stream<String> (int
+# capture k) and `map(n -> n + base.size())` capturing a List (reference capture)
+# both fuse exactly like the original Stream<Integer> case.
 #
 # Type-TRANSFORMING maps stay native: the "(LX;)LX;" backreference declines an
 # instantiated type whose input and output differ (e.g. "(LString;)LInteger;"),
 # so those keep flowing through the unbox/box machinery untouched.
 #
-# @todo #640:60min Generalise the CAPTURE type beyond category-1 ints: a reference
-#  capture (push is `aload`, drop the box/unbox in 114/316 — needs a reference
-#  branch in the peeler), and category-2 (J/D) captures (push is `lload`/`dload`,
-#  box via Long/Double.valueOf, unbox via longValue/doubleValue). Each extends the
-#  same shared-List channel; a multi-capture FILTER (113/314) is the nearest
-#  unfinished twin. The element-type half (Stream<X>) is already done here.
+# @todo #647:45min Generalise the CAPTURE type further: category-2 (J/D) captures
+#  (push is `lload`/`dload`, box via Long/Double.valueOf, unbox via
+#  longValue/doubleValue) — the peeler branch is a near-copy of 114 but the
+#  relocated 2-slot append peaks one slot higher in the caller, so it needs a
+#  caller max-stack bump (jeo never recomputes maxs). Also a MIXED multi-capture
+#  run that contains a reference (only a SINGLE lone reference is admitted today,
+#  because 115 reads the capture type out of target.signature's first L-type) and
+#  a multi-capture FILTER (113/314), the nearest unfinished twin. Each extends the
+#  same shared-List channel.
 name: capturing-invokedynamic-to-map
 pattern: |
   ⟦
@@ -177,9 +185,13 @@ when:
     - matches:
         - 'lambda\$.+'
         - 𝑒-target-method
-    - matches:
-        - '\(I+\)Ljava/util/function/Function;'
-        - 𝑒-interface
+    - or:
+        - matches:
+            - '\(I+\)Ljava/util/function/Function;'
+            - 𝑒-interface
+        - matches:
+            - '\(L[^;]+;\)Ljava/util/function/Function;'
+            - 𝑒-interface
     - matches:
         - '\((L[^;]+;)\)\1'
         - 𝑒-instantiated

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/115-c-map-peel-reference.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/115-c-map-peel-reference.phr
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The reference-capture twin of 114. 112 admits a SINGLE reference capture
+# (factory descriptor "(L…;)L…Function;", e.g. `map(n -> n + base.size())` over a
+# captured List) and leaves the lone `aload k` push inline in front of the c-map
+# with two EMPTY accumulators; this rule folds it into the operator's shared-List
+# state, exactly as 114 does for an `iload` int push — only the boxing and the
+# unboxing drop out, because a reference is already an Object.
+#
+# state-acc gains `dup; aload k; List.add; pop` (no Integer.valueOf — the captured
+# reference goes straight into the List; the append begins and ends at [list],
+# peak 3, identical to 114's int append, so it joins any number of fused
+# neighbours without growing the caller's stack). body-acc gains a single
+# `fetch` whose `type` is the captured object's class (521 turns the fetch into
+# List.get(counter++) and a checkcast to that class; no unbox follows). The class
+# is sed-extracted from the c-map's target.signature — the lambda$ descriptor is
+# "(Lcapture;Lelement;)Lelement;", so its first L-type IS the capture type. This
+# is why only a SINGLE reference capture is supported: with one capture arg the
+# first L-type is unambiguous.
+#
+# 316 then wraps body-acc into the auto emit-shape `astore 1; <fetch>; aload 1;
+# invokestatic lambda$`, so the reloaded reference sits below the parked item
+# exactly as the (Lcapture;Lelement;)Lelement; signature wants. The "c-map" start
+# label and the whole 502/512/521/601 stateful emit path are reused verbatim.
+name: c-map-peel-reference
+pattern: |
+  ⟦
+    𝐵-h,
+    𝜏-al ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, 𝐵-alr ⟧,
+    𝜏-cm ↦ ⟦
+      φ ↦ Φ.hone.c-map,
+      state-acc ↦ ⟦ 𝐵-sacc, ρ ↦ ∅ ⟧,
+      body-acc ↦ ⟦ 𝐵-bacc, ρ ↦ ∅ ⟧,
+      𝐵-cm-mid,
+      target ↦ ⟦ 𝐵-tgt-head, signature ↦ 𝑒-sig, 𝐵-tgt-tail ⟧,
+      𝐵-cm-tail
+    ⟧,
+    𝐵-t
+  ⟧
+result: |
+  ⟦
+    𝐵-h,
+    𝜏-cm ↦ ⟦
+      φ ↦ Φ.hone.c-map,
+      state-acc ↦ ⟦
+        𝜏-dup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+        𝜏-load ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, 𝐵-alr ⟧,
+        𝜏-add ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          i2 ↦ "java/util/List",
+          i3 ↦ "add",
+          i4 ↦ "(Ljava/lang/Object;)Z",
+          i5 ↦ Φ.true
+        ⟧,
+        𝜏-pop ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+        𝐵-sacc,
+        ρ ↦ ∅
+      ⟧,
+      body-acc ↦ ⟦
+        𝜏-fetch ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ 𝑒-captype ⟧,
+        𝐵-bacc,
+        ρ ↦ ∅
+      ⟧,
+      𝐵-cm-mid,
+      target ↦ ⟦ 𝐵-tgt-head, signature ↦ 𝑒-sig, 𝐵-tgt-tail ⟧,
+      𝐵-cm-tail
+    ⟧,
+    𝐵-t
+  ⟧
+where:
+  - meta: 𝑒-captype
+    function: sed
+    args:
+      - 𝑒-sig
+      - '"s/[(]L//"'
+      - '"s/;.*//"'
+  - meta: 𝜏-dup
+    function: random-tau
+  - meta: 𝜏-load
+    function: random-tau
+  - meta: 𝜏-add
+    function: random-tau
+  - meta: 𝜏-pop
+    function: random-tau
+  - meta: 𝜏-fetch
+    function: random-tau

--- a/src/test/phino/112-capturing-invokedynamic-to-map-reference.yml
+++ b/src/test/phino/112-capturing-invokedynamic-to-map-reference.yml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A SINGLE reference-capturing map invokedynamic — descriptor
+# "(Ljava/util/List;)L…Function;", the captured List pushed by the preceding
+# aload, a handle-6 static lambda$ target whose signature is
+# "(Ljava/util/List;Ljava/lang/Integer;)Ljava/lang/Integer;" — is lifted to a
+# Φ.hone.c-map. The instantiated type "(Ljava/lang/Integer;)Ljava/lang/Integer;"
+# is type-preserving, so 112's "(LX;)LX;" backreference admits it. 112 consumes
+# ONLY the indy and the invokeinterface; it leaves the aload push inline (115
+# gathers it) and seeds two EMPTY accumulators. 111 declines this indy (its "()"
+# guard wants zero captures); the new "(L…;)" branch of 112's interface guard is
+# what catches a single reference capture.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
+input: |
+  {⟦
+    φ ↦ Φ.jeo.class,
+    version ↦ 68,
+    access ↦ 33,
+    modifiers ↦ ⟦ φ ↦ Φ.jeo.modifiers, static ↦ Φ.false ⟧,
+    name ↦ "Foo",
+    supername ↦ "java/lang/Object",
+    interfaces ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+    m$run ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 8,
+      modifiers ↦ ⟦ φ ↦ Φ.jeo.modifiers, static ↦ Φ.true ⟧,
+      name ↦ "run",
+      descriptor ↦ "(Ljava/util/List;)I",
+      signature ↦ "",
+      exceptions ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, m1 ↦ 6, m2 ↦ 3 ⟧,
+      params ↦ ⟦ φ ↦ Φ.jeo.params ⟧,
+      annotations ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      body ↦ ⟦
+        i20 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 0 ⟧,
+        i23 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokedynamic,
+          v0 ↦ "apply",
+          v1 ↦ "(Ljava/util/List;)Ljava/util/function/Function;",
+          h2 ↦ ⟦ φ ↦ Φ.jeo.handle, v0 ↦ 6, v1 ↦ "java/lang/invoke/LambdaMetafactory", v2 ↦ "metafactory", v3 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;", v4 ↦ Φ.false ⟧,
+          t3 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Object;)Ljava/lang/Object;" ⟧,
+          h4 ↦ ⟦ φ ↦ Φ.jeo.handle, v0 ↦ 6, v1 ↦ "Foo", v2 ↦ "lambda$run$0", v3 ↦ "(Ljava/util/List;Ljava/lang/Integer;)Ljava/lang/Integer;", v4 ↦ Φ.false ⟧,
+          t5 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Integer;)Ljava/lang/Integer;" ⟧
+        ⟧,
+        i24 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "map", v2 ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;", v3 ↦ Φ.true ⟧
+      ⟧,
+      trycatchblocks ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      local-variable-table ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.hone.c-map, state-acc ↦ ⟦⟧, body-acc ↦ ⟦⟧, 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.hone.c-map, 𝐵-g, target ↦ ⟦ 𝐵-h, signature ↦ "(Ljava/util/List;Ljava/lang/Integer;)Ljava/lang/Integer;", 𝐵-i ⟧, 𝐵-j ⟧
+  - ⟦ 𝐵-k, 𝜏-push ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 0 ⟧, 𝜏-cm ↦ ⟦ φ ↦ Φ.hone.c-map, 𝐵-l ⟧, 𝐵-m ⟧

--- a/src/test/phino/115-c-map-peel-reference.yml
+++ b/src/test/phino/115-c-map-peel-reference.yml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 115 gathers the SINGLE reference capture that 112 left inline. The input mimics
+# 112's output for `map(n -> n + base.size())`: a Φ.hone.c-map with two EMPTY
+# accumulators, preceded by one `aload 0` push (the captured List) and bounded on
+# the left by the previous operator's invokeinterface. The c-map's target
+# signature "(Ljava/util/List;Ljava/lang/Integer;)Ljava/lang/Integer;" carries
+# the capture type in its first L-slot. After 115 runs to fixpoint, state-acc
+# appends the reference verbatim (dup; aload 0; List.add; pop — NO Integer.valueOf
+# box), body-acc gets one `fetch` typed java/util/List (NO unbox), and no aload
+# sits between the invokeinterface and the c-map.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/1xx/115-c-map-peel-reference.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      p ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "map", v2 ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;", v3 ↦ Φ.true ⟧,
+      a ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 0 ⟧,
+      cm ↦ ⟦
+        φ ↦ Φ.hone.c-map,
+        state-acc ↦ ⟦⟧,
+        body-acc ↦ ⟦⟧,
+        class ↦ "Foo",
+        bridge-input ↦ "Ljava/lang/Integer;",
+        bridge-output ↦ "Ljava/lang/Integer;",
+        accepted ↦ "Ljava/lang/Integer;",
+        returned ↦ "Ljava/lang/Integer;",
+        static ↦ "true",
+        target ↦ ⟦ handle ↦ 6, class ↦ "Foo", method ↦ "lambda$run$0", signature ↦ "(Ljava/util/List;Ljava/lang/Integer;)Ljava/lang/Integer;", is-interface ↦ Φ.false ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.hone.c-map, state-acc ↦ ⟦ 𝜏-d ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧, 𝜏-l ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 0 ⟧, 𝐵-sr ⟧, 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.hone.c-map, 𝐵-a, body-acc ↦ ⟦ 𝜏-f ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/util/List" ⟧, 𝐵-br ⟧, 𝐵-c ⟧
+  - ⟦ 𝐵-x, 𝜏-p ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", 𝐵-pr ⟧, 𝜏-cm ↦ ⟦ φ ↦ Φ.hone.c-map, 𝐵-cr ⟧, 𝐵-y ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/closure-reference.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/closure-reference.yml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# End-to-end proof that capturing-lambda fusion is no longer pinned to category-1
+# int captures (issue #647). The captured value here is a REFERENCE — an
+# effectively-final List<Integer> — read inside the first map:
+#
+#   Stream.of(...).map(n -> n + base.size()).map(n -> n * 2).reduce(0, ...)
+#
+# The first map captures `base`, so javac compiles its factory descriptor as
+# "(Ljava/util/List;)L…Function;" and its SAM instantiated type as the
+# type-preserving "(Ljava/lang/Integer;)Ljava/lang/Integer;". 112's new "(L…;)"
+# interface-guard branch admits the single reference capture and lifts it to a
+# Φ.hone.c-map; 115 peels the lone `aload` push, appending the List to the shared
+# state List WITHOUT a box (a reference is already an Object) and reading it back
+# via a `fetch` typed java/util/List (no unbox). 316 folds a stateful distill and
+# 401 fuses it with the following NON-capturing map (n -> n * 2, empty state).
+# 502/512/521/601 emit one Stream.mapMulti whose wrapper reads the captured List
+# back and calls List.size() per element — the whole stateful machinery reused
+# verbatim, only the append/fetch lose their box/unbox.
+#
+# invokedynamic: before = map(capturing) + map + reduce-accumulator lambda = 3;
+# after = the single fused mapMulti + the untouched reduce lambda = 2. The dropped
+# indy is the proof the two maps collapsed into one dispatch. The runtime line
+# proves the captured List reaches the lambda correctly: base.size() == 3, so
+# {1,2,3,4,5} -> n+3 -> {4,5,6,7,8} -> *2 -> {8,10,12,14,16} -> sum == 60.
+java: |
+  package fusion;
+  import java.util.*;
+  import java.util.stream.*;
+  public class C {
+    static int run(List<Integer> base) {
+      return Stream.of(1, 2, 3, 4, 5)
+        .map(n -> n + base.size())
+        .map(n -> n * 2)
+        .reduce(0, (a, b) -> a + b);
+    }
+    public static void main(String[] args) {
+      System.out.printf("The result is %d%n", run(Arrays.asList(7, 8, 9)));
+    }
+  }
+before:
+  invokedynamic: 3
+after:
+  invokedynamic: 2
+log:
+  - "BUILD SUCCESS"
+  - "The result is 60"


### PR DESCRIPTION
Resolves the `@todo #640` puzzle in `112-capturing-invokedynamic-to-map.phr` (issue #647), which asked to generalise the capture type beyond category-1 ints.

## What changed

A capturing map over a **single effectively-final reference** — e.g. `map(n -> n + base.size())` over a captured `List` — now fuses through the same shared-List stateful machinery the int captures already use:

- **`112`** broadens its factory-descriptor guard with an `or` branch so a `(L…;)L…Function;` single-reference capture is lifted to a `Φ.hone.c-map`, alongside the existing `(I+)L…Function;` int captures. The type-preserving `(LX;)LX;` instantiated-type guard is unchanged.
- **New rule `115-c-map-peel-reference`** peels the lone `aload` push into the shared state `List` with **no box/unbox** (a reference is already an `Object`), and reads it back via a `fetch` typed with the capture's class — sed-extracted from the `lambda$` target signature's first `L`-type (which is why only a *single* reference capture is admitted for now).
- `316` / `401` / `502` / `512` / `521` / `601` are reused **verbatim**; the run lowers to one `Stream.mapMulti`.

## Verification

Driven through the real pipeline (`jeo:disassemble` → `phino` → `jeo:assemble`) with the pinned `phino 0.0.0.73` and JVM verification:

| fixture | invokedynamic | runtime | status |
| --- | --- | --- | --- |
| `closure-reference.yml` (**new**, ref capture) | 3 → 2 | `The result is 60` | ✅ JVM-verified |
| `closure-string.yml` (int capture) | 2 → 1 | unchanged | ✅ no regression |
| `closures.yml` (big mixed suite) | 41 → 29 | unchanged | ✅ no regression |

All **34** `src/test/phino/*` unit packs pass in the deep harness (`OptimizeMojoTest#appliesPhinoRulesAsSpecifiedInYamlPack`: 34 tests, 0 failures/errors), including the two new packs `115-c-map-peel-reference.yml` and `112-capturing-invokedynamic-to-map-reference.yml`.

## Follow-up

The remaining generalisations are re-filed as a narrower `@todo #647` puzzle in `112`'s header: category-2 (`J`/`D`) captures (need a caller max-stack bump for the 2-slot append), multi/mixed reference captures plus a lone-reference-map revert, the multi-capture filter, `this`-field captures, and capturing `peek`/`mapToX`.

`CLAUDE.md` is updated to document the new reference-capture path and the revised deferred-puzzle list.

https://claude.ai/code/session_017GQCsJSxT6kL5PKJce4pav

---
_Generated by [Claude Code](https://claude.ai/code/session_017GQCsJSxT6kL5PKJce4pav)_