### PR TITLE
#652 Fuse capturing maps with category-2 (long/double) captures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,10 +174,11 @@ distinct                         → 216 → 307 → state distill;
 skip                             → 220 → 308 → state distill;
                                     442 reverts it (count and call)
                                     to invokeinterface if it never fused
-capturing map (N ints OR 1 ref)  → 112 → 114 (int peeler) / 115 (ref peeler)
-                                    → 316 → c-map state distill; 443 reverts a
-                                    lone single-int-capture map if unfused
-                                    (multi-capture and lone-ref stay mapMulti)
+capturing map (N prim OR 1 ref)  → 112 → 114 (int) / 116 (long) / 117 (double)
+                                    / 115 (ref peeler) → 316 → c-map state
+                                    distill; 443 reverts a lone single-int-capture
+                                    map if unfused (multi-capture, category-2 and
+                                    lone-ref stay mapMulti)
 capturing filter (one int)       → 113 → 314 → c-filter state distill;
                                     444 reverts it to invokedynamic if unfused
 ```
@@ -468,34 +469,42 @@ edits to any existing rule**. They ride a parallel set of pragma names
 `"c-filter"`) so no existing recogniser, fold, dup-inserter or revert ever
 touches them.
 
-The path (object streams, int captures; map handles any number of captures over
-any type-preserving reference element type, filter one capture over Integer):
+The path (object streams; map handles any number of category-1/2 primitive
+captures over any type-preserving reference element type, filter one int capture
+over Integer):
 
 - `112` / `113` lift a capturing map / primitive-filter indy to
   `Φ.hone.c-map` / `Φ.hone.cp-filter`. `113` (single capture) still **grabs the
   one `iload k` push** and carries it as `capture-push`. `112` is now arity-
-  agnostic: its guard is `\(I+\)L…Function;` (one OR MORE ints) OR
-  `\(L…;\)L…Function;` (a SINGLE reference), and it grabs **no** push — it
-  leaves the whole run of `iload`s / the lone `aload` inline in front of the
-  c-map and seeds two EMPTY accumulators (`state-acc`, `body-acc`). They
-  partition the indy space with `111`: `\(\)` matches zero captures, `\(I…\)`
-  matches int captures, `\(L…;\)` a single reference capture, a handle-6 static
-  `lambda$` target, and a **type-preserving** instantiated type — matched as
-  `(LX;)LX;` for any reference `X` via a backreference guard (Integer, String,
-  …), with `X` sed-extracted into the four bridge fields. Category-2 (`J`/`D`),
-  a MULTI-reference / mixed-with-reference run, `this`-capture (handle 5), a
+  agnostic: its guard is `\([IJD]+\)L…Function;` (one OR MORE category-1/2
+  primitives) OR `\(L…;\)L…Function;` (a SINGLE reference), and it grabs **no**
+  push — it leaves the whole run of `iload`/`lload`/`dload`s / the lone `aload`
+  inline in front of the c-map and seeds two EMPTY accumulators (`state-acc`,
+  `body-acc`). They partition the indy space with `111`: `\(\)` matches zero
+  captures, `\([IJD]…\)` matches primitive captures, `\(L…;\)` a single reference
+  capture, a handle-6 static `lambda$` target, and a **type-preserving**
+  instantiated type — matched as `(LX;)LX;` for any reference `X` via a
+  backreference guard (Integer, String, …), with `X` sed-extracted into the four
+  bridge fields. When a `J`/`D` capture is present `112` also BUMPS the caller
+  `max-stack` by 2 (the two-slot boxing append `116`/`117` relocate peaks one slot
+  higher than an int's; the two maxs values ride generated binding names, so they
+  are matched positionally with `𝜏-max-stack`/`𝜏-max-locals`). A
+  MULTI-reference / mixed-with-reference run, `this`-capture (handle 5), a
   **type-transforming** map (`(LX;)LY;`, declined by the backreference and left
   to the unbox/box machinery), computed/field push — all stay native.
-- `114` (int) / `115` (reference) gather `112`'s inline pushes into the c-map,
-  one per firing, re-applying at fixpoint (the same self-iteration `521` uses).
-  Each matches its push opcode **directly in front of** the c-map; phino's
-  leading group is greedy, so the bound push is always the LAST one and the rule
-  peels right-to-left. `114` PREPENDS one boxing append
-  (`dup; iload k; Integer.valueOf; List.add; pop`) to `state-acc` and one
+- `114` (int) / `116` (long) / `117` (double) / `115` (reference) gather `112`'s
+  inline pushes into the c-map, one per firing, re-applying at fixpoint (the same
+  self-iteration `521` uses). Each matches its own push opcode **directly in front
+  of** the c-map; phino's leading group is greedy, so the bound push is always the
+  LAST one and the rule peels right-to-left — a mixed int/long/double run is
+  gathered by the three primitive peelers interleaving. `114` PREPENDS one boxing
+  append (`dup; iload k; Integer.valueOf; List.add; pop`) to `state-acc` and one
   `fetch; intValue` to `body-acc`, so the captures end up appended in
-  left-to-right (x, y, z) order — slot 0 = x, guard *k* reads capture *k*. `115`
-  is the same shape minus the box/unbox: a reference is already an Object, so it
-  appends `dup; aload k; List.add; pop` and a bare `fetch` typed with the
+  left-to-right (x, y, z) order — slot 0 = x, guard *k* reads capture *k*. `116` /
+  `117` are byte-for-byte twins that box via `Long`/`Double.valueOf` and unbox via
+  `longValue`/`doubleValue` (their two-slot append is why `112` bumps max-stack).
+  `115` is the same shape minus the box/unbox: a reference is already an Object, so
+  it appends `dup; aload k; List.add; pop` and a bare `fetch` typed with the
   capture's class (sed-extracted from `target.signature`'s first L-type, which
   is why only a SINGLE reference capture is admitted). The run is bounded on the
   left by the previous operator's invokeinterface, never another push, so
@@ -548,12 +557,19 @@ the `streams/closure-reference.yml` end-to-end fixture. A lone reference-capture
 map is not reverted by `443` (closed on the int box/unbox shape), so it is
 emitted as a standalone `mapMulti` — correct, like the lone-multi-capture map.
 
+Category-2 (`J`/`D`) captures are **done** (issue #652): `112`'s `\([IJD]+\)`
+guard admits one or more long/double captures (and mixed int/long/double runs),
+`116`/`117` peel the `lload`/`dload` pushes with `Long`/`Double` box/unbox, and
+`112` bumps the caller max-stack by 2 to absorb the two-slot append — see the
+`streams/closure-long.yml` end-to-end fixture. A lone single long/double-capture
+map is not reverted by `443` (closed on the int box/unbox shape), so it is emitted
+as a standalone `mapMulti`, like the lone-reference and lone-multi-capture maps.
+
 Deferred puzzles (each extends the same shared-List channel): a multi-capture
-FILTER and the lone-multi-capture-map revert (both above); category-2 (`J`/`D`)
-captures (whose relocated 2-slot append needs a caller max-stack bump); a
-MULTI-reference / mixed-with-reference capture run and a lone-reference-map
-revert; `this`-field captures; and capturing `peek`/`mapToX`. See the puzzle
-marker in `112`'s header.
+FILTER and the lone-multi-capture-map revert (both above); a MULTI-reference /
+mixed-with-reference capture run (needs positional capture-type extraction) and a
+lone-reference-map revert; `this`-field captures; and capturing `peek`/`mapToX`.
+See the puzzle marker in `112`'s header.
 
 ## phino: the only rewrite engine
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -500,11 +500,12 @@ over Integer):
   gathered by the three primitive peelers interleaving. `114` PREPENDS one boxing
   append (`dup; iload k; Integer.valueOf; List.add; pop`) to `state-acc` and one
   `fetch; intValue` to `body-acc`, so the captures end up appended in
-  left-to-right (x, y, z) order — slot 0 = x, guard *k* reads capture *k*. `116` /
-  `117` are byte-for-byte twins that box via `Long`/`Double.valueOf` and unbox via
-  `longValue`/`doubleValue` (their two-slot append is why `112` bumps max-stack).
-  `115` is the same shape minus the box/unbox: a reference is already an Object, so
-  it appends `dup; aload k; List.add; pop` and a bare `fetch` typed with the
+  left-to-right (x, y, z) order — slot 0 = x, guard *k* reads capture *k*.
+  `116` / `117` are byte-for-byte twins that box via `Long`/`Double.valueOf`
+  and unbox via `longValue`/`doubleValue` (their two-slot append is why `112`
+  bumps max-stack). `115` is the same shape minus the box/unbox: a reference is
+  already an Object, so it appends `dup; aload k; List.add; pop` and a bare
+  `fetch` typed with the
   capture's class (sed-extracted from `target.signature`'s first L-type, which
   is why only a SINGLE reference capture is admitted). The run is bounded on the
   left by the previous operator's invokeinterface, never another push, so
@@ -567,8 +568,8 @@ as a standalone `mapMulti`, like the lone-reference and lone-multi-capture maps.
 
 Deferred puzzles (each extends the same shared-List channel): a multi-capture
 FILTER and the lone-multi-capture-map revert (both above); a MULTI-reference /
-mixed-with-reference capture run (needs positional capture-type extraction) and a
-lone-reference-map revert; `this`-field captures; and capturing `peek`/`mapToX`.
+mixed-with-reference capture run (needs positional capture-type extraction) and
+a lone-reference-map revert; `this`-field captures; and capturing `peek`/`mapToX`.
 See the puzzle marker in `112`'s header.
 
 ## phino: the only rewrite engine

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
@@ -23,32 +23,41 @@
 # state List" is what lets N captures (and any number of fused capturing
 # operators) reuse the distinct/skip machinery (502/512/521/601) verbatim.
 #
-# v1.3 scope (issues #636, #640, #647): the captures admitted are either
-# one OR MORE category-1 INT captures (factory descriptor "(I+)L…Function;",
-# every push a constant-index iload, gathered by 114) OR a SINGLE reference
-# capture (factory descriptor "(L…;)L…Function;", push an aload, gathered by the
-# reference branch 115) — the two are partitioned by the `or` in the interface
-# guard. In both cases the map is type-PRESERVING over ANY reference element type:
+# v1.4 scope (issues #636, #640, #647, #652): the captures admitted are either
+# one OR MORE category-1/2 PRIMITIVE captures (factory descriptor "([IJD]+)L…Function;",
+# every push a constant-index iload/lload/dload, gathered by 114 for int and by
+# its category-2 twins 116/117 for long/double) OR a SINGLE reference capture
+# (factory descriptor "(L…;)L…Function;", push an aload, gathered by the reference
+# branch 115) — the two are partitioned by the `or` in the interface guard, and a
+# mixed int/long/double run is gathered by 114/116/117 interleaving on their own
+# opcode. In both cases the map is type-PRESERVING over ANY reference element type:
 # the SAM instantiated type is matched as "(LX;)LX;" for any reference X (Integer,
 # String, …) via a backreference guard, and the element type X is sed-extracted
 # into 𝑒-bridge and threaded into all four bridge fields. The lambda$ target is a
 # handle-6 static method. So `map(s -> s.repeat(k))` on a Stream<String> (int
-# capture k) and `map(n -> n + base.size())` capturing a List (reference capture)
-# both fuse exactly like the original Stream<Integer> case.
+# capture k), `map(n -> (int)(n + x))` capturing a long, and `map(n -> n +
+# base.size())` capturing a List (reference capture) all fuse exactly like the
+# original Stream<Integer> case.
+#
+# A category-2 (J/D) capture occupies two stack slots, so the boxing append 116/117
+# relocate into the caller (502) — `dup; lload k; Long.valueOf; List.add; pop` —
+# peaks one slot higher than the int append. jeo never recomputes maxs, so this
+# rule BUMPS the enclosing method's max-stack by 2 (a safe over-allocation) whenever
+# the factory descriptor carries a J or D primitive capture; an int-only or a
+# reference capture leaves max-stack untouched. The two maxs values ride generated
+# binding names (jeo emits e.g. "v295 ↦ 5"), so they are matched positionally with
+# 𝜏-max-stack / 𝜏-max-locals (max-stack first, then max-locals).
 #
 # Type-TRANSFORMING maps stay native: the "(LX;)LX;" backreference declines an
 # instantiated type whose input and output differ (e.g. "(LString;)LInteger;"),
 # so those keep flowing through the unbox/box machinery untouched.
 #
-# @todo #647:45min Generalise the CAPTURE type further: category-2 (J/D) captures
-#  (push is `lload`/`dload`, box via Long/Double.valueOf, unbox via
-#  longValue/doubleValue) — the peeler branch is a near-copy of 114 but the
-#  relocated 2-slot append peaks one slot higher in the caller, so it needs a
-#  caller max-stack bump (jeo never recomputes maxs). Also a MIXED multi-capture
+# @todo #652:45min Generalise the CAPTURE channel further: a MIXED multi-capture
 #  run that contains a reference (only a SINGLE lone reference is admitted today,
-#  because 115 reads the capture type out of target.signature's first L-type) and
-#  a multi-capture FILTER (113/314), the nearest unfinished twin. Each extends the
-#  same shared-List channel.
+#  because 115 reads the capture type out of target.signature's first L-type — a
+#  multi-reference run needs positional type extraction), and a multi-capture
+#  FILTER (113/314), the nearest unfinished twin (its park/reload body must also
+#  defer the keep-frame). Each extends the same shared-List channel.
 name: capturing-invokedynamic-to-map
 pattern: |
   ⟦
@@ -72,7 +81,11 @@ pattern: |
       descriptor ↦ 𝑒-method-descriptor,
       signature ↦ 𝑒-method-signature,
       exceptions ↦ 𝑒-method-exceptions,
-      maxs ↦ 𝑒-method-maxs,
+      maxs ↦ ⟦
+        φ ↦ Φ.jeo.maxs,
+        𝜏-max-stack ↦ 𝑒-max-stack,
+        𝜏-max-locals ↦ 𝑒-max-locals
+      ⟧,
       params ↦ 𝑒-method-params,
       annotations ↦ 𝑒-annotations,
       body ↦ ⟦
@@ -149,7 +162,11 @@ result: |
       descriptor ↦ 𝑒-method-descriptor,
       signature ↦ 𝑒-method-signature,
       exceptions ↦ 𝑒-method-exceptions,
-      maxs ↦ 𝑒-method-maxs,
+      maxs ↦ ⟦
+        φ ↦ Φ.jeo.maxs,
+        𝜏-max-stack ↦ 𝑒-bumped-stack,
+        𝜏-max-locals ↦ 𝑒-max-locals
+      ⟧,
       params ↦ 𝑒-method-params,
       annotations ↦ 𝑒-annotations,
       body ↦ ⟦
@@ -187,7 +204,7 @@ when:
         - 𝑒-target-method
     - or:
         - matches:
-            - '\(I+\)Ljava/util/function/Function;'
+            - '\([IJD]+\)Ljava/util/function/Function;'
             - 𝑒-interface
         - matches:
             - '\(L[^;]+;\)Ljava/util/function/Function;'
@@ -202,5 +219,31 @@ where:
       - 𝑒-instantiated
       - '"s/[(]//"'
       - '"s/[)].*//"'
+  # Bump the caller max-stack by 2 when a category-2 (J/D) primitive capture is
+  # present (its relocated 2-slot boxing append, 116/117, peaks one slot higher
+  # than an int append); an int-only or reference capture bumps by 0. 𝑒-cap-params
+  # isolates the factory descriptor's parameter codes and drops every object type
+  # ("L…;"), leaving only the primitive capture codes, so a J or D there means a
+  # category-2 capture; over-allocating max-stack is always verifier-safe.
+  - meta: 𝑒-cap-params
+    function: sed
+    args:
+      - 𝑒-interface
+      - '"s/[(]//"'
+      - '"s/[)].*//"'
+      - '"s/L[^;]*;//g"'
+  - meta: 𝑒-bump-str
+    function: sed
+    args:
+      - 𝑒-cap-params
+      - '"s/.*[JD].*/2/"'
+      - '"s/^[^2].*$/0/"'
+      - '"s/^$/0/"'
+  - meta: 𝑒-bump
+    function: number
+    args: [𝑒-bump-str]
+  - meta: 𝑒-bumped-stack
+    function: sum
+    args: [𝑒-max-stack, 𝑒-bump]
   - meta: 𝜏-c-map
     function: random-tau

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/116-c-map-peel-long.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/116-c-map-peel-long.phr
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The category-2 LONG twin of 114 (issue #652). 112 admits a factory descriptor
+# carrying one or more "[IJD]" primitive captures and leaves the run of pushes
+# inline in front of the c-map with two EMPTY accumulators; 114 peels the int
+# (`iload`) pushes, this rule peels the long (`lload`) pushes. The two (and 117
+# for double) interleave at fixpoint, each matching only its own opcode, so a
+# mixed int/long/double capture run is gathered in the right left-to-right order
+# exactly as 114 documents for a pure-int run.
+#
+# state-acc gains one boxing append `dup; lload k; Long.valueOf; List.add; pop`.
+# A long is two slots, so this append peaks one slot higher than 114's int
+# append; 112 already bumped the caller max-stack by 2 to absorb it. body-acc
+# gains one `fetch; longValue` (521 turns the fetch into List.get(counter++);
+# checkcast java/lang/Long at emit, the longValue unboxes it). 316 wraps the
+# finished body-acc as `astore 1; <fetches>; aload 1; invokestatic lambda$`, so
+# the unboxed long sits below the parked item exactly as the static lambda$
+# (long…, Integer) signature wants.
+name: c-map-peel-long
+pattern: |
+  ⟦
+    𝐵-h,
+    𝜏-ll ↦ ⟦ φ ↦ Φ.jeo.opcode.lload, 𝐵-llr ⟧,
+    𝜏-cm ↦ ⟦
+      φ ↦ Φ.hone.c-map,
+      state-acc ↦ ⟦ 𝐵-sacc, ρ ↦ ∅ ⟧,
+      body-acc ↦ ⟦ 𝐵-bacc, ρ ↦ ∅ ⟧,
+      𝐵-cm-tail
+    ⟧,
+    𝐵-t
+  ⟧
+result: |
+  ⟦
+    𝐵-h,
+    𝜏-cm ↦ ⟦
+      φ ↦ Φ.hone.c-map,
+      state-acc ↦ ⟦
+        𝜏-dup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+        𝜏-load ↦ ⟦ φ ↦ Φ.jeo.opcode.lload, 𝐵-llr ⟧,
+        𝜏-box ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokestatic,
+          i2 ↦ "java/lang/Long",
+          i3 ↦ "valueOf",
+          i4 ↦ "(J)Ljava/lang/Long;",
+          i5 ↦ Φ.false
+        ⟧,
+        𝜏-add ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          i2 ↦ "java/util/List",
+          i3 ↦ "add",
+          i4 ↦ "(Ljava/lang/Object;)Z",
+          i5 ↦ Φ.true
+        ⟧,
+        𝜏-pop ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+        𝐵-sacc,
+        ρ ↦ ∅
+      ⟧,
+      body-acc ↦ ⟦
+        𝜏-fetch ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Long" ⟧,
+        𝜏-lv ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokevirtual,
+          i1 ↦ "java/lang/Long",
+          i2 ↦ "longValue",
+          i3 ↦ "()J",
+          i4 ↦ Φ.false
+        ⟧,
+        𝐵-bacc,
+        ρ ↦ ∅
+      ⟧,
+      𝐵-cm-tail
+    ⟧,
+    𝐵-t
+  ⟧
+where:
+  - meta: 𝜏-dup
+    function: random-tau
+  - meta: 𝜏-load
+    function: random-tau
+  - meta: 𝜏-box
+    function: random-tau
+  - meta: 𝜏-add
+    function: random-tau
+  - meta: 𝜏-pop
+    function: random-tau
+  - meta: 𝜏-fetch
+    function: random-tau
+  - meta: 𝜏-lv
+    function: random-tau

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/117-c-map-peel-double.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/117-c-map-peel-double.phr
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The category-2 DOUBLE twin of 114/116 (issue #652). Peels a captured double
+# (`dload`) push off a Φ.hone.c-map, exactly as 116 peels a long, swapping the
+# boxing to Double.valueOf and the unboxing to doubleValue. 114 (int), 116 (long)
+# and this rule interleave at fixpoint on their own opcode, so a mixed
+# int/long/double capture run is gathered in left-to-right order.
+#
+# state-acc gains `dup; dload k; Double.valueOf; List.add; pop` (a double is two
+# slots, so the append peaks one slot higher than 114's int append; 112 already
+# bumped the caller max-stack by 2). body-acc gains `fetch; doubleValue` (521
+# resolves the fetch to List.get(counter++); checkcast java/lang/Double; the
+# doubleValue unboxes it). 316 wraps it as `astore 1; <fetches>; aload 1;
+# invokestatic lambda$`, leaving the unboxed double below the parked item exactly
+# as the static lambda$ (double…, Integer) signature wants.
+name: c-map-peel-double
+pattern: |
+  ⟦
+    𝐵-h,
+    𝜏-dl ↦ ⟦ φ ↦ Φ.jeo.opcode.dload, 𝐵-dlr ⟧,
+    𝜏-cm ↦ ⟦
+      φ ↦ Φ.hone.c-map,
+      state-acc ↦ ⟦ 𝐵-sacc, ρ ↦ ∅ ⟧,
+      body-acc ↦ ⟦ 𝐵-bacc, ρ ↦ ∅ ⟧,
+      𝐵-cm-tail
+    ⟧,
+    𝐵-t
+  ⟧
+result: |
+  ⟦
+    𝐵-h,
+    𝜏-cm ↦ ⟦
+      φ ↦ Φ.hone.c-map,
+      state-acc ↦ ⟦
+        𝜏-dup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+        𝜏-load ↦ ⟦ φ ↦ Φ.jeo.opcode.dload, 𝐵-dlr ⟧,
+        𝜏-box ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokestatic,
+          i2 ↦ "java/lang/Double",
+          i3 ↦ "valueOf",
+          i4 ↦ "(D)Ljava/lang/Double;",
+          i5 ↦ Φ.false
+        ⟧,
+        𝜏-add ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          i2 ↦ "java/util/List",
+          i3 ↦ "add",
+          i4 ↦ "(Ljava/lang/Object;)Z",
+          i5 ↦ Φ.true
+        ⟧,
+        𝜏-pop ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+        𝐵-sacc,
+        ρ ↦ ∅
+      ⟧,
+      body-acc ↦ ⟦
+        𝜏-fetch ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Double" ⟧,
+        𝜏-dv ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokevirtual,
+          i1 ↦ "java/lang/Double",
+          i2 ↦ "doubleValue",
+          i3 ↦ "()D",
+          i4 ↦ Φ.false
+        ⟧,
+        𝐵-bacc,
+        ρ ↦ ∅
+      ⟧,
+      𝐵-cm-tail
+    ⟧,
+    𝐵-t
+  ⟧
+where:
+  - meta: 𝜏-dup
+    function: random-tau
+  - meta: 𝜏-load
+    function: random-tau
+  - meta: 𝜏-box
+    function: random-tau
+  - meta: 𝜏-add
+    function: random-tau
+  - meta: 𝜏-pop
+    function: random-tau
+  - meta: 𝜏-fetch
+    function: random-tau
+  - meta: 𝜏-dv
+    function: random-tau

--- a/src/test/phino/112-capturing-invokedynamic-to-map-long.yml
+++ b/src/test/phino/112-capturing-invokedynamic-to-map-long.yml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A category-2 LONG-capturing map invokedynamic — descriptor "(J)L…Function;", the
+# captured long pushed by the preceding lload, a handle-6 static lambda$ target
+# whose signature is "(JLjava/lang/Integer;)Ljava/lang/Integer;" — is lifted to a
+# Φ.hone.c-map (116 later peels the lload). The instantiated type
+# "(Ljava/lang/Integer;)Ljava/lang/Integer;" is type-preserving, so 112's
+# "(LX;)LX;" backreference admits it; the relaxed "\([IJD]+\)" interface guard now
+# admits the J capture. Because a J/D capture is present, 112 BUMPS the method's
+# max-stack by 2 (6 -> 8) to make room for the two-slot boxing append 116 will
+# relocate into the caller; max-locals (3) is untouched, and the generated maxs
+# binding names ride through unchanged.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
+input: |
+  {⟦
+    φ ↦ Φ.jeo.class,
+    version ↦ 68,
+    access ↦ 33,
+    modifiers ↦ ⟦ φ ↦ Φ.jeo.modifiers, static ↦ Φ.false ⟧,
+    name ↦ "Foo",
+    supername ↦ "java/lang/Object",
+    interfaces ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+    m$run ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 8,
+      modifiers ↦ ⟦ φ ↦ Φ.jeo.modifiers, static ↦ Φ.true ⟧,
+      name ↦ "run",
+      descriptor ↦ "(J)I",
+      signature ↦ "",
+      exceptions ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, m1 ↦ 6, m2 ↦ 3 ⟧,
+      params ↦ ⟦ φ ↦ Φ.jeo.params ⟧,
+      annotations ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      body ↦ ⟦
+        i20 ↦ ⟦ φ ↦ Φ.jeo.opcode.lload, v0 ↦ 0 ⟧,
+        i23 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokedynamic,
+          v0 ↦ "apply",
+          v1 ↦ "(J)Ljava/util/function/Function;",
+          h2 ↦ ⟦ φ ↦ Φ.jeo.handle, v0 ↦ 6, v1 ↦ "java/lang/invoke/LambdaMetafactory", v2 ↦ "metafactory", v3 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;", v4 ↦ Φ.false ⟧,
+          t3 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Object;)Ljava/lang/Object;" ⟧,
+          h4 ↦ ⟦ φ ↦ Φ.jeo.handle, v0 ↦ 6, v1 ↦ "Foo", v2 ↦ "lambda$run$0", v3 ↦ "(JLjava/lang/Integer;)Ljava/lang/Integer;", v4 ↦ Φ.false ⟧,
+          t5 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Integer;)Ljava/lang/Integer;" ⟧
+        ⟧,
+        i24 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "map", v2 ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;", v3 ↦ Φ.true ⟧
+      ⟧,
+      trycatchblocks ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      local-variable-table ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.hone.c-map, state-acc ↦ ⟦⟧, body-acc ↦ ⟦⟧, 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.hone.c-map, 𝐵-g, target ↦ ⟦ 𝐵-h, signature ↦ "(JLjava/lang/Integer;)Ljava/lang/Integer;", 𝐵-i ⟧, 𝐵-j ⟧
+  - ⟦ φ ↦ Φ.jeo.maxs, 𝜏-ms ↦ 8, 𝜏-ml ↦ 3 ⟧
+  - ⟦ 𝐵-k, 𝜏-push ↦ ⟦ φ ↦ Φ.jeo.opcode.lload, v0 ↦ 0 ⟧, 𝜏-cm ↦ ⟦ φ ↦ Φ.hone.c-map, 𝐵-l ⟧, 𝐵-m ⟧

--- a/src/test/phino/116-c-map-peel-long.yml
+++ b/src/test/phino/116-c-map-peel-long.yml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 116 is the category-2 LONG twin of 114. The input mimics 112's output: a
+# Φ.hone.c-map with two EMPTY accumulators, preceded by two lload pushes (x at
+# slot v0=0, y at slot v0=2 — a long occupies two local slots) and bounded on the
+# left by the previous operator's invokeinterface. Re-applied at fixpoint, 116
+# peels the lloads right-to-left and PREPENDS one unit per capture, so state-acc
+# ends up appending x THEN y (slot 0 = x) with a Long.valueOf box and body-acc
+# gets two `fetch; longValue` pairs.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/1xx/116-c-map-peel-long.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      p ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "map", v2 ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;", v3 ↦ Φ.true ⟧,
+      x ↦ ⟦ φ ↦ Φ.jeo.opcode.lload, v0 ↦ 0 ⟧,
+      y ↦ ⟦ φ ↦ Φ.jeo.opcode.lload, v0 ↦ 2 ⟧,
+      cm ↦ ⟦
+        φ ↦ Φ.hone.c-map,
+        state-acc ↦ ⟦⟧,
+        body-acc ↦ ⟦⟧,
+        class ↦ "Foo",
+        bridge-input ↦ "Ljava/lang/Integer;",
+        bridge-output ↦ "Ljava/lang/Integer;",
+        accepted ↦ "Ljava/lang/Integer;",
+        returned ↦ "Ljava/lang/Integer;",
+        static ↦ "true",
+        target ↦ ⟦ handle ↦ 6, class ↦ "Foo", method ↦ "lambda$run$1", signature ↦ "(JJLjava/lang/Integer;)Ljava/lang/Integer;", is-interface ↦ Φ.false ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.hone.c-map, state-acc ↦ ⟦ 𝜏-d ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧, 𝜏-l ↦ ⟦ φ ↦ Φ.jeo.opcode.lload, v0 ↦ 0 ⟧, 𝜏-b ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "java/lang/Long", 𝐵-bx ⟧, 𝐵-sr ⟧, 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.hone.c-map, 𝐵-a, body-acc ↦ ⟦ 𝜏-f1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Long" ⟧, 𝜏-lv ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, i1 ↦ "java/lang/Long", 𝐵-lv ⟧, 𝜏-f2 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Long" ⟧, 𝐵-br ⟧, 𝐵-c ⟧
+  - ⟦ 𝐵-x, 𝜏-p ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", 𝐵-pr ⟧, 𝜏-cm ↦ ⟦ φ ↦ Φ.hone.c-map, 𝐵-cr ⟧, 𝐵-y ⟧

--- a/src/test/phino/117-c-map-peel-double.yml
+++ b/src/test/phino/117-c-map-peel-double.yml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 117 is the category-2 DOUBLE twin of 114/116. The input mimics 112's output: a
+# Φ.hone.c-map with two EMPTY accumulators, preceded by a single dload push and
+# bounded on the left by the previous operator's invokeinterface. 117 peels the
+# dload, PREPENDING a `dup; dload; Double.valueOf; List.add; pop` boxing append to
+# state-acc and a `fetch; doubleValue` pair to body-acc.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/1xx/117-c-map-peel-double.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      p ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "map", v2 ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;", v3 ↦ Φ.true ⟧,
+      x ↦ ⟦ φ ↦ Φ.jeo.opcode.dload, v0 ↦ 0 ⟧,
+      cm ↦ ⟦
+        φ ↦ Φ.hone.c-map,
+        state-acc ↦ ⟦⟧,
+        body-acc ↦ ⟦⟧,
+        class ↦ "Foo",
+        bridge-input ↦ "Ljava/lang/Integer;",
+        bridge-output ↦ "Ljava/lang/Integer;",
+        accepted ↦ "Ljava/lang/Integer;",
+        returned ↦ "Ljava/lang/Integer;",
+        static ↦ "true",
+        target ↦ ⟦ handle ↦ 6, class ↦ "Foo", method ↦ "lambda$run$1", signature ↦ "(DLjava/lang/Integer;)Ljava/lang/Integer;", is-interface ↦ Φ.false ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.hone.c-map, state-acc ↦ ⟦ 𝜏-d ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧, 𝜏-l ↦ ⟦ φ ↦ Φ.jeo.opcode.dload, v0 ↦ 0 ⟧, 𝜏-b ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "java/lang/Double", 𝐵-bx ⟧, 𝐵-sr ⟧, 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.hone.c-map, 𝐵-a, body-acc ↦ ⟦ 𝜏-f1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Double" ⟧, 𝜏-dv ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, i1 ↦ "java/lang/Double", 𝐵-dv ⟧, 𝐵-br ⟧, 𝐵-c ⟧
+  - ⟦ 𝐵-x, 𝜏-cm ↦ ⟦ φ ↦ Φ.hone.c-map, 𝐵-cr ⟧, 𝐵-y ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/closure-long.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/closure-long.yml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# End-to-end proof that capturing-lambda fusion is no longer pinned to category-1
+# int captures (issue #652). The captured value here is a CATEGORY-2 long — an
+# effectively-final `long` parameter — read inside the first map:
+#
+#   Stream.of(...).map(n -> (int)(n + x)).map(n -> n * 2).reduce(0, ...)
+#
+# The first map captures `x`, so javac compiles its factory descriptor as
+# "(J)L…Function;" and its SAM instantiated type as the type-preserving
+# "(Ljava/lang/Integer;)Ljava/lang/Integer;". 112's relaxed "\([IJD]+\)"
+# interface-guard branch admits the long capture and lifts it to a Φ.hone.c-map,
+# bumping the caller max-stack by 2 (a J capture's two-slot boxing append peaks one
+# slot higher than an int's). 116 peels the lone `lload` push, appending the long to
+# the shared state List with a Long.valueOf box and reading it back via a `fetch`
+# typed java/lang/Long followed by longValue. 316 folds a stateful distill and 401
+# fuses it with the following NON-capturing map (n -> n * 2, empty state).
+# 502/512/521/601 emit one Stream.mapMulti whose wrapper reads the captured long
+# back and adds it per element — the whole stateful machinery reused verbatim, only
+# the append/fetch box/unbox via Long instead of Integer.
+#
+# invokedynamic: before = map(capturing) + map + reduce-accumulator lambda = 3;
+# after = the single fused mapMulti + the untouched reduce lambda = 2. The dropped
+# indy is the proof the two maps collapsed into one dispatch. The runtime line
+# proves the captured long reaches the lambda correctly: x == 10, so
+# {1,2,3,4,5} -> n+10 -> {11,12,13,14,15} -> *2 -> {22,24,26,28,30} -> sum == 130.
+java: |
+  package fusion;
+  import java.util.*;
+  import java.util.stream.*;
+  public class C {
+    static int run(long x) {
+      return Stream.of(1, 2, 3, 4, 5)
+        .map(n -> (int) (n + x))
+        .map(n -> n * 2)
+        .reduce(0, (a, b) -> a + b);
+    }
+    public static void main(String[] args) {
+      System.out.printf("The result is %d%n", run(10L));
+    }
+  }
+before:
+  invokedynamic: 3
+after:
+  invokedynamic: 2
+log:
+  - "BUILD SUCCESS"
+  - "The result is 130"


### PR DESCRIPTION
Resolves #652 (the `647-f827a17a` puzzle in `112-capturing-invokedynamic-to-map.phr`).

## What

Generalises the capturing-map fusion channel from **category-1 `int`** captures to **any category-1/2 primitive** capture (`int`, `long`, `double`), including mixed runs. This is the "near-copy of 114" item the puzzle flagged.

## How

- **`112`** — relaxes the factory-descriptor guard from `\(I+\)L…Function;` to `\([IJD]+\)L…Function;` (one or more int/long/double captures). Because a `J`/`D` capture occupies two stack slots, the boxing append that `502` relocates into the caller peaks one slot higher than an `int`'s, so `112` now **bumps the enclosing method's `max-stack` by 2** whenever a `J`/`D` capture is present (a safe over-allocation; an int-only or reference capture bumps by 0). jeo emits the two `maxs` values under generated binding names (e.g. `v295 ↦ 5`), so they are matched positionally with `𝜏-max-stack` / `𝜏-max-locals`.
- **`116` / `117`** — byte-for-byte twins of `114` that peel an `lload` / `dload` push, boxing via `Long`/`Double.valueOf` and unboxing via `longValue`/`doubleValue`. The three primitive peelers each match only their own opcode, so they interleave at fixpoint and a mixed `int`/`long`/`double` run is gathered in left-to-right order. The rest of the stateful path (`316`/`401`/`502`/`512`/`521`/`601`) is reused **verbatim** — captures hide inside the shared `List`, so the indy descriptor is untouched.

## Tests

- `src/test/phino/116-c-map-peel-long.yml`, `117-c-map-peel-double.yml` — single-rule packs for the new peelers.
- `src/test/phino/112-capturing-invokedynamic-to-map-long.yml` — proves the relaxed guard admits a `long` capture and that `max-stack` is bumped `6 → 8`.
- `src/test/resources/org/eolang/hone/optimize/streams/closure-long.yml` — end-to-end: `map(n -> (int)(n + x))` over a captured `long` fuses with a following `map` into one `Stream.mapMulti` (invokedynamic `3 → 2`, runtime result `130`).

`CLAUDE.md` and `112`'s header are updated; the puzzle text is removed and re-scoped to the remaining deferred work (multi-reference / mixed-with-reference runs and the multi-capture filter).

## Note

The deep e2e suite (`mvn -Pdeep test`) needs the `phino` binary, which isn't available in this environment, so the new fixtures were validated by construction (mirroring the existing `114` / `closure-reference` rules) rather than executed. CI should run the `deep` profile to confirm.

https://claude.ai/code/session_013DKa2ipQeQHqwVsYDnefnF

---
_Generated by [Claude Code](https://claude.ai/code/session_013DKa2ipQeQHqwVsYDnefnF)_