### PR TITLE
#655 fuse multi-int-capture filters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,8 +179,10 @@ capturing map (N prim OR 1 ref)  → 112 → 114 (int) / 116 (long) / 117 (doubl
                                     distill; 443 reverts a lone single-int-capture
                                     map if unfused (multi-capture, category-2 and
                                     lone-ref stay mapMulti)
-capturing filter (one int)       → 113 → 314 → c-filter state distill;
-                                    444 reverts it to invokedynamic if unfused
+capturing filter (N int)         → 113 → 118 → 314 → c-filter state distill;
+                                    444 reverts a LONE single-int-capture filter
+                                    to invokedynamic if unfused (multi-capture
+                                    stays mapMulti)
 ```
 
 `401-fuse` is the only fuser: it matches two adjacent `Φ.hone.distill`
@@ -470,13 +472,15 @@ edits to any existing rule**. They ride a parallel set of pragma names
 touches them.
 
 The path (object streams; map handles any number of category-1/2 primitive
-captures over any type-preserving reference element type, filter one int capture
-over Integer):
+captures over any type-preserving reference element type, filter one OR MORE int
+captures over Integer):
 
 - `112` / `113` lift a capturing map / primitive-filter indy to
-  `Φ.hone.c-map` / `Φ.hone.cp-filter`. `113` (single capture) still **grabs the
-  one `iload k` push** and carries it as `capture-push`. `112` is now arity-
-  agnostic: its guard is `\([IJD]+\)L…Function;` (one OR MORE category-1/2
+  `Φ.hone.c-map` / `Φ.hone.cp-filter`. Both are now arity-agnostic and grab **no**
+  push: `113`'s guard is `\(I+\)L…Predicate;` (one OR MORE int captures) and it
+  seeds two EMPTY accumulators exactly as `112` does, leaving the run of `iload`s
+  inline for `118` to peel. `112` is arity-agnostic too: its guard is
+  `\([IJD]+\)L…Function;` (one OR MORE category-1/2
   primitives) OR `\(L…;\)L…Function;` (a SINGLE reference), and it grabs **no**
   push — it leaves the whole run of `iload`/`lload`/`dload`s / the lone `aload`
   inline in front of the c-map and seeds two EMPTY accumulators (`state-acc`,
@@ -494,7 +498,9 @@ over Integer):
   to the unbox/box machinery), computed/field push — all stay native.
 - `114` (int) / `116` (long) / `117` (double) / `115` (reference) gather `112`'s
   inline pushes into the c-map, one per firing, re-applying at fixpoint (the same
-  self-iteration `521` uses). Each matches its own push opcode **directly in front
+  self-iteration `521` uses); `118` is `114`'s twin for the `cp-filter`, peeling
+  the filter's int pushes into its accumulators byte-for-byte the same way. Each
+  matches its own push opcode **directly in front
   of** the c-map; phino's leading group is greedy, so the bound push is always the
   LAST one and the rule peels right-to-left — a mixed int/long/double run is
   gathered by the three primitive peelers interleaving. `114` PREPENDS one boxing
@@ -519,11 +525,16 @@ over Integer):
   park/reload **replaces v1's single-capture `swap`**, unifying one and many
   captures (omit the reload and the operands silently invert — the verifier
   accepts it, so the e2e asserts the numeric runtime result, not just opcode
-  counts). `314`'s single-capture FILTER still uses the `swap` body plus its
-  own opening `dup` and a `Φ.hone.frame-item` keep-label (the `"c-filter"`
-  start label keeps `431`/`281` away); a multi-capture filter stays native
-  (113's `\(I\)` guard declines it) — its park/reload twin, which must also
-  defer the keep-frame, is a follow-up puzzle.
+  counts). `314` is now the FILTER twin of `316`: it folds an N-int-capture
+  `cp-filter` with the same N-ary park/reload body, opened by a `dup` that keeps
+  the item at the BOTTOM of the stack so the predicate (whose captures + a
+  reloaded item copy ride above it) can run and the keep label still sees a lone
+  `[item]` — the standard `Φ.hone.frame-item` `503` fills, no separate empty-stack
+  keep-frame needed. The `"c-filter"` start label keeps `431`/`281` away. `444`
+  reverts a LONE single-capture filter (closed on the single-capture park/reload
+  body); a lone multi-capture filter is emitted as a standalone mapMulti, exactly
+  as `443` leaves a lone multi-capture map. A category-2/reference capture in a
+  filter stays native (its `116`/`117`/`115` peeler twins are a follow-up puzzle).
 - `401` fuses two capturing distills exactly like two `distinct`s: `join`
   concatenates the boxed appends into the List (slots in body order) and the
   two bodies in order, so guard *k*'s fetch reads slot *k*. `502`/`512`/`521`
@@ -537,12 +548,12 @@ over Integer):
   `map(i -> i + x)` — is put back as the native `invokedynamic` +
   `Stream.{map,filter}`, replaying the push and marking the call
   `reverted ↦ Φ.true` so `112`/`113` cannot re-lift it (closed patterns plus
-  the marker, the same loop-break `442` uses). `443` matches the park/reload
-  single-capture body. A LONE multi-capture map (two or more appends) fails
-  that closed pattern and is emitted as a standalone `mapMulti` — correct, only
-  marginally slower than native, and rarer than a lone single-capture map;
-  reverting it (replaying N pushes, rebuilding the `(I^N)` descriptor) is a
-  follow-up puzzle.
+  the marker, the same loop-break `442` uses). `443`/`444` both match the
+  park/reload single-capture body. A LONE multi-capture map OR filter (two or
+  more appends) fails that closed pattern and is emitted as a standalone
+  `mapMulti` — correct, only marginally slower than native, and rarer than a lone
+  single-capture operator; reverting it (replaying N pushes, rebuilding the
+  `(I^N)` descriptor) is a follow-up puzzle.
 
 Other type-preserving element types are **done** (issue #640): `112`'s
 `(LX;)LX;` backreference guard admits a capturing map over any reference element
@@ -566,11 +577,21 @@ guard admits one or more long/double captures (and mixed int/long/double runs),
 map is not reverted by `443` (closed on the int box/unbox shape), so it is emitted
 as a standalone `mapMulti`, like the lone-reference and lone-multi-capture maps.
 
-Deferred puzzles (each extends the same shared-List channel): a multi-capture
-FILTER and the lone-multi-capture-map revert (both above); a MULTI-reference /
+The multi-capture FILTER is **done** (issue #655): `113`'s `\(I+\)` guard admits
+one or more int captures, `118` peels them into the shared List, and `314` folds
+them with the same N-ary park/reload body as a capturing map — the keep-frame
+stays `503`'s plain `Φ.hone.frame-item` because the body keeps the item at the
+bottom of the stack. So `filter(n -> n > lo && n < hi)` fuses with its trailing
+`mapToInt` into one `Stream.mapMultiToInt`; see the `multiFil` case in
+`streams/closures.yml`. A lone multi-capture filter is not reverted by `444`
+(closed on the single-capture body), so it is emitted as a standalone `mapMulti`.
+
+Deferred puzzles (each extends the same shared-List channel): the
+lone-multi-capture map/filter revert (above); a MULTI-reference /
 mixed-with-reference capture run (needs positional capture-type extraction) and
-a lone-reference-map revert; `this`-field captures; and capturing `peek`/`mapToX`.
-See the puzzle marker in `112`'s header.
+a lone-reference-map revert; a category-2 (`J`/`D`) or reference capture in a
+FILTER (its `116`/`117`/`115` peeler twins); `this`-field captures; and capturing
+`peek`/`mapToX`. See the puzzle marker in `112`'s header.
 
 ## phino: the only rewrite engine
 

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
@@ -52,12 +52,24 @@
 # instantiated type whose input and output differ (e.g. "(LString;)LInteger;"),
 # so those keep flowing through the unbox/box machinery untouched.
 #
-# @todo #652:45min Generalise the CAPTURE channel further: a MIXED multi-capture
+# The multi-capture FILTER is now done (issue #655): 113 lifts a "(I+)L…Predicate;"
+# factory (one OR MORE int captures), the new 118 peels each push into the shared
+# List, and 314 folds it into a stateful distill with the same N-ary park/reload
+# body this rule's 316 gives a capturing map — the keep-frame stays 503's plain
+# Φ.hone.frame-item because the body preserves the item at the BOTTOM of the stack
+# (dup; astore 1; <captures>; aload 1; predicate) so the keep label still sees a
+# lone [item]. So `filter(n -> n > lo && n < hi)` fuses exactly like the int
+# multi-capture map; see the multiFil case in streams/closures.yml.
+#
+# @todo #655:45min Generalise the CAPTURE channel further: a MIXED multi-capture
 #  run that contains a reference (only a SINGLE lone reference is admitted today,
 #  because 115 reads the capture type out of target.signature's first L-type — a
-#  multi-reference run needs positional type extraction), and a multi-capture
-#  FILTER (113/314), the nearest unfinished twin (its park/reload body must also
-#  defer the keep-frame). Each extends the same shared-List channel.
+#  multi-reference run needs positional type extraction) and a lone-reference-map
+#  revert. Still native in the FILTER channel too: a category-2 (J/D) or reference
+#  capture (its 116/117/115 peeler twins) and the lone-multi-capture-filter revert
+#  (444 is closed on the single-capture park/reload body, so a lone multi-capture
+#  filter is emitted as a standalone mapMulti). Each extends the same shared-List
+#  channel.
 name: capturing-invokedynamic-to-map
 pattern: |
   ⟦

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/113-capturing-invokedynamic-to-filter.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/113-capturing-invokedynamic-to-filter.phr
@@ -3,17 +3,28 @@
 ---
 # yamllint disable rule:line-length
 # The filter twin of 112. Lifts a CAPTURING primitive-filter invokedynamic —
-# one 111 declines for its "(I)L…Predicate;" factory descriptor — into a
-# Φ.hone.cp-filter pragma, the capturing sibling of the Φ.hone.p-filter that
-# 201 produces for a predicate whose backing lambda$ returns Z. The captured
-# int rides exactly as in 112: grabbed out of the body as `capture-push`,
-# carried as `captured`, re-materialised by 314 as a boxed append to the shared
-# state List (and replayed by 444 if the filter never fuses).
+# one 111 declines for its "(I)L…Predicate;" or "(II…)L…Predicate;" factory
+# descriptor — into a Φ.hone.cp-filter pragma, the capturing sibling of the
+# Φ.hone.p-filter that 201 produces for a predicate whose backing lambda$
+# returns Z. Exactly as 112 does for a capturing map, this rule grabs NO push:
+# it leaves the whole run of `iload k` pushes inline in front of the emitted
+# cp-filter and seeds two EMPTY accumulators (`state-acc`, `body-acc`). 118 then
+# peels the pushes one at a time (right-to-left, greedy-left makes the match
+# exact), prepending one boxed append to `state-acc` and one fetch+unbox to
+# `body-acc` per capture, so the captures land in the shared state List in
+# left-to-right order. 314 finally assembles the two accumulators into a stateful
+# distill whose park/reload body holds every capture below the item exactly as
+# the static lambda$ (int…, Integer) signature wants — the same N-ary shape 316
+# gives a capturing map.
 #
-# v1 scope: a single category-1 INT capture, a Stream<Integer> predicate
-# (bridge-signature "(Ljava/lang/Integer;)Z"), a handle-6 static lambda$
-# target, the push a constant-index iload. See 112's header for the deferred
-# generalisations; they apply here unchanged.
+# v1 scope: one OR MORE category-1 INT captures (factory descriptor
+# "(I+)L…Predicate;", every push a constant-index iload, gathered by 118), a
+# Stream<Integer> predicate (instantiated type "(Ljava/lang/Integer;)Z"), a
+# handle-6 static lambda$ target. So both `filter(n -> n > t)` (one capture) and
+# `filter(n -> n > lo && n < hi)` (two captures) fuse exactly like the original
+# single-capture case. A category-2 (J/D) or reference capture in a filter stays
+# native — its peeler twins (116/117/115 for the map) are a follow-up puzzle;
+# see 112's header for the shared deferred generalisations.
 name: capturing-invokedynamic-to-filter
 pattern: |
   ⟦
@@ -42,10 +53,6 @@ pattern: |
       annotations ↦ 𝑒-annotations,
       body ↦ ⟦
         𝐵-body-head,
-        𝜏-capture ↦ ⟦
-          φ ↦ Φ.jeo.opcode.iload,
-          𝐵-cap-rest
-        ⟧,
         𝜏-invokedynamic ↦ ⟦
           φ ↦ Φ.jeo.opcode.invokedynamic,
           𝜏3 ↦ 𝑒-method,
@@ -125,21 +132,14 @@ result: |
         𝐵-body-head,
         𝜏-cp-filter ↦ ⟦
           φ ↦ Φ.hone.cp-filter,
+          state-acc ↦ ⟦ ρ ↦ ∅ ⟧,
+          body-acc ↦ ⟦ ρ ↦ ∅ ⟧,
           class ↦ 𝑒-class,
           bridge-input ↦ "Ljava/lang/Integer;",
           bridge-output ↦ "Ljava/lang/Integer;",
           accepted ↦ "Ljava/lang/Integer;",
           returned ↦ "Ljava/lang/Integer;",
           static ↦ "true",
-          captured ↦ "I",
-          capture-push ↦ ⟦
-            φ ↦ Φ.jeo.opcode.iload,
-            𝐵-cap-rest
-          ⟧,
-          interface ↦ 𝑒-interface,
-          method ↦ 𝑒-method,
-          lambda-signature ↦ 𝑒-lambda-signature,
-          bridge-signature ↦ "(Ljava/lang/Integer;)Z",
           target ↦ ⟦
             handle ↦ 6,
             class ↦ 𝑒-target-class,
@@ -162,7 +162,7 @@ when:
         - 'lambda\$.+'
         - 𝑒-target-method
     - matches:
-        - '\(I\)Ljava/util/function/Predicate;'
+        - '\(I+\)Ljava/util/function/Predicate;'
         - 𝑒-interface
 where:
   - meta: 𝜏-cp-filter

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/118-cp-filter-peel-capture.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/118-cp-filter-peel-capture.phr
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The cp-filter twin of 114. Peels one captured push off a Φ.hone.cp-filter and
+# folds it into the operator's shared-List state, exactly as 114 does for a
+# Φ.hone.c-map. 113 emits the cp-filter with the whole run of `iload k` pushes
+# still inline in front of it and two EMPTY accumulators; this rule does the
+# gathering, one capture per firing, re-applying at fixpoint until the run is
+# gone (the same self-iteration 521 uses to resolve every fetch).
+#
+# It matches the single `iload` directly in front of the cp-filter: phino's
+# leading `𝐵-h` group is greedy, so for a run "iload lo; iload hi; <cp-filter>"
+# the bound `𝜏-il` is always the LAST push (hi), and the rule peels right-to-left
+# (hi, then lo). Each peel PREPENDS its unit to the accumulators, so the captures
+# end up in left-to-right (lo, hi) order — exactly the order javac pushed them and
+# the order the static lambda$ expects, and the order in which they are appended
+# to the List (slot 0 = lo, …) so guard k reads capture k.
+#
+# state-acc gains one boxing append `dup; iload k; Integer.valueOf; List.add;
+# pop` (begins and ends at [list], peak 3, so any number of them — across this
+# operator and any fused neighbours — join without growing the caller's stack).
+# body-acc gains one `fetch; intValue` (521 turns the fetch into List.get(counter++)
+# at emit, the intValue unboxes it). 314 wraps the finished body-acc as
+# `dup; astore 1; <fetches>; aload 1; invokestatic lambda$; ifne keep; return`, so
+# the unboxed captures sit below the reloaded item exactly as the predicate
+# lambda$ (int…, Integer)Z signature wants.
+#
+# The run is always bounded on the left by the previous stream operator's
+# invokeinterface (which left a Stream ref on the stack), never by another
+# iload, so peeling stops cleanly once every capture has been gathered.
+name: cp-filter-peel-capture
+pattern: |
+  ⟦
+    𝐵-h,
+    𝜏-il ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, 𝐵-ilr ⟧,
+    𝜏-cf ↦ ⟦
+      φ ↦ Φ.hone.cp-filter,
+      state-acc ↦ ⟦ 𝐵-sacc, ρ ↦ ∅ ⟧,
+      body-acc ↦ ⟦ 𝐵-bacc, ρ ↦ ∅ ⟧,
+      𝐵-cf-tail
+    ⟧,
+    𝐵-t
+  ⟧
+result: |
+  ⟦
+    𝐵-h,
+    𝜏-cf ↦ ⟦
+      φ ↦ Φ.hone.cp-filter,
+      state-acc ↦ ⟦
+        𝜏-dup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+        𝜏-load ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, 𝐵-ilr ⟧,
+        𝜏-box ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokestatic,
+          i2 ↦ "java/lang/Integer",
+          i3 ↦ "valueOf",
+          i4 ↦ "(I)Ljava/lang/Integer;",
+          i5 ↦ Φ.false
+        ⟧,
+        𝜏-add ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          i2 ↦ "java/util/List",
+          i3 ↦ "add",
+          i4 ↦ "(Ljava/lang/Object;)Z",
+          i5 ↦ Φ.true
+        ⟧,
+        𝜏-pop ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+        𝐵-sacc,
+        ρ ↦ ∅
+      ⟧,
+      body-acc ↦ ⟦
+        𝜏-fetch ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
+        𝜏-iv ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokevirtual,
+          i1 ↦ "java/lang/Integer",
+          i2 ↦ "intValue",
+          i3 ↦ "()I",
+          i4 ↦ Φ.false
+        ⟧,
+        𝐵-bacc,
+        ρ ↦ ∅
+      ⟧,
+      𝐵-cf-tail
+    ⟧,
+    𝐵-t
+  ⟧
+where:
+  - meta: 𝜏-dup
+    function: random-tau
+  - meta: 𝜏-load
+    function: random-tau
+  - meta: 𝜏-box
+    function: random-tau
+  - meta: 𝜏-add
+    function: random-tau
+  - meta: 𝜏-pop
+    function: random-tau
+  - meta: 𝜏-fetch
+    function: random-tau
+  - meta: 𝜏-iv
+    function: random-tau

--- a/src/main/resources/org/eolang/hone/rules/streams/3xx/314-cp-filter-to-distill.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/3xx/314-cp-filter-to-distill.phr
@@ -2,41 +2,49 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-# Folds a Φ.hone.cp-filter (a capturing primitive filter recognised by 113) into
-# a Φ.hone.distill, the capturing analogue of 304 + the state mechanism of
-# 307/308. The captured int rides the shared List exactly as in 316 (see its
-# header for the state block).
+# Folds a Φ.hone.cp-filter (a capturing primitive filter recognised by 113 and
+# gathered by 118) into a stateful Φ.hone.distill — the capturing/filter analogue
+# of how 316 folds a capturing map. Every captured int is appended to the shared
+# state List in the `state` block (built by 118 in left-to-right order, slot 0 =
+# first capture) and read back in the body via a Φ.hone.fetch marker, so two
+# capturing operators fuse by 401's blind state+body join exactly like two
+# distincts.
 #
-# body: a filter guard prefixed with the fetch+unbox+swap that brings the
-# captured int below the item. Because the predicate consumes the item, the body
-# opens with a `dup` to keep a copy for the keep path — unlike a plain filter
-# (305/304) whose dup is spliced in later by 431/281, a c-filter carries its own
-# dup so the "c-filter" start label can keep 431 (which only matches start
-# "filter") away. The sequence on entry [item]:
-#   dup            [item, item]
-#   fetch;intValue [item, item, int captured]
-#   swap           [item, int captured, item]
-#   invokestatic   [item, Z]          (predicate consumes captured + item copy)
-#   ifne L         [item]             keep, else fall through and return (drop)
-# The keep label leaves a single [item], so the Φ.hone.frame-item marker (503
-# fills it with the counter-aware of4 frame once 502 has set captured=List) is
-# the same single-item frame distinct/skip use.
+# 118 has already assembled both halves into the cp-filter's accumulators:
+#   state-acc — one `dup; iload k; Integer.valueOf; List.add; pop` per capture;
+#               it becomes the distill `state` verbatim.
+#   body-acc  — one `fetch; intValue` per capture (521 later turns each fetch
+#               into List.get(counter++); the intValue unboxes it).
+# This rule wraps body-acc into the auto emit-shape — a filter guard whose item
+# is preserved at the BOTTOM of the stack while the predicate runs above it, so
+# the keep label still sees exactly [item] and reuses 503's Φ.hone.frame-item
+# (no separate empty-stack keep-frame is needed). The sequence on entry [item]:
+#   dup            [item, item]        keep a copy at the bottom for the keep path
+#   astore 1       [item]              park the top copy in its own (dead) param slot
+#   <fetch;intValue>×N [item, c0..cN-1] push the N unboxed captures above the item
+#   aload 1        [item, c0..cN-1, item]   reload the copy on top
+#   invokestatic   [item, Z]           predicate(int…, Integer)Z consumes captures + copy
+#   ifne L         [item]              keep, else fall through and return (drop)
+#   return         drop the kept item  (void return discards the stack)
+#   L: frame-item  [item]              keep path — single [item], same frame distinct/skip use
+# Parking in local 1 (which 512's wrapper only reads once, at entry) needs no
+# extra local, so 512's max-locals is untouched. This N-ary park/reload replaces
+# v1's single-capture `swap`, so one capture and many captures share one shape —
+# the filter twin of 316's map park/reload. The start label "c-filter" (not
+# "filter") keeps 431/281 off this body and lets 444 find an unfused single-capture
+# filter to revert.
 name: cp-filter-to-distill
 pattern: |
   ⟦
     φ ↦ Φ.hone.cp-filter,
+    state-acc ↦ ⟦ 𝐵-sacc, ρ ↦ ∅ ⟧,
+    body-acc ↦ ⟦ 𝐵-bacc, ρ ↦ ∅ ⟧,
     class ↦ 𝑒-class,
     bridge-input ↦ 𝑒-bridge-input,
     bridge-output ↦ 𝑒-bridge-output,
     accepted ↦ 𝑒-accepted,
     returned ↦ 𝑒-returned,
     static ↦ 𝑒-static,
-    captured ↦ 𝑒-captured,
-    capture-push ↦ 𝑒-capture-push,
-    interface ↦ 𝑒-interface,
-    method ↦ 𝑒-method,
-    lambda-signature ↦ 𝑒-lambda-signature,
-    bridge-signature ↦ 𝑒-bridge-signature,
     target ↦ ⟦
       handle ↦ 𝑒-target-handle,
       class ↦ 𝑒-target-class,
@@ -55,51 +63,27 @@ result: |
     accepted ↦ 𝑒-accepted,
     returned ↦ 𝑒-returned,
     static ↦ 𝑒-static,
-    state ↦ ⟦
-      𝜏-dup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
-      𝜏-load ↦ 𝑒-capture-push,
-      𝜏-box ↦ ⟦
-        φ ↦ Φ.jeo.opcode.invokestatic,
-        i2 ↦ "java/lang/Integer",
-        i3 ↦ "valueOf",
-        i4 ↦ "(I)Ljava/lang/Integer;",
-        i5 ↦ Φ.false
-      ⟧,
-      𝜏-add ↦ ⟦
-        φ ↦ Φ.jeo.opcode.invokeinterface,
-        i2 ↦ "java/util/List",
-        i3 ↦ "add",
-        i4 ↦ "(Ljava/lang/Object;)Z",
-        i5 ↦ Φ.true
-      ⟧,
-      𝜏-pop ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
-      ρ ↦ ∅
-    ⟧,
+    state ↦ ⟦ 𝐵-sacc, ρ ↦ ∅ ⟧,
     body ↦ ⟦
-      i1 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
-      i2 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
-      i3 ↦ ⟦
-        φ ↦ Φ.jeo.opcode.invokevirtual,
-        i1 ↦ "java/lang/Integer",
-        i2 ↦ "intValue",
-        i3 ↦ "()I",
-        i4 ↦ Φ.false
-      ⟧,
-      i4 ↦ ⟦ φ ↦ Φ.jeo.opcode.swap ⟧,
-      i5 ↦ ⟦
+      𝜏-dup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+      𝜏-park ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, i1 ↦ 1 ⟧,
+      𝐵-bacc,
+      𝜏-reload ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
+      𝜏-call ↦ ⟦
         φ ↦ Φ.jeo.opcode.invokestatic,
         i1 ↦ 𝑒-target-class,
         i2 ↦ 𝑒-target-method,
         i3 ↦ 𝑒-target-signature,
         i4 ↦ 𝑒-target-is-interface
       ⟧,
-      i6 ↦ ⟦
+      𝜏-ifne ↦ ⟦
         φ ↦ Φ.jeo.opcode.ifne,
         i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label ⟧
       ⟧,
-      i7 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
-      i8 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label ⟧,
-      i9 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧
+      𝜏-return ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      𝜏-label ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label ⟧,
+      𝜏-frame ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+      ρ ↦ ∅
     ⟧
   ⟧
 where:
@@ -108,11 +92,17 @@ where:
     args: ['"L%d"']
   - meta: 𝜏-dup
     function: random-tau
-  - meta: 𝜏-load
+  - meta: 𝜏-park
     function: random-tau
-  - meta: 𝜏-box
+  - meta: 𝜏-reload
     function: random-tau
-  - meta: 𝜏-add
+  - meta: 𝜏-call
     function: random-tau
-  - meta: 𝜏-pop
+  - meta: 𝜏-ifne
+    function: random-tau
+  - meta: 𝜏-return
+    function: random-tau
+  - meta: 𝜏-label
+    function: random-tau
+  - meta: 𝜏-frame
     function: random-tau

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/444-unfused-capturing-filter-to-invokedynamic.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/444-unfused-capturing-filter-to-invokedynamic.phr
@@ -6,11 +6,18 @@
 # that never fused back to its native invokedynamic + Stream.filter, replaying
 # the capture-push and marking the call `reverted ↦ Φ.true` so 113 cannot
 # re-lift it (its invokeinterface pattern is closed, the same loop-break 442/443
-# rely on). The closed state + body match only an UNFUSED c-filter; a fused one
-# carries a neighbour's guard and is left for 502. The body match includes the
-# leading item-preserving dup and the keep-guard 314 built (fetch; intValue; swap;
+# rely on). The closed state + body match only an UNFUSED single-capture
+# c-filter; a fused one carries a neighbour's guard and is left for 502. The body
+# match includes the leading item-preserving dup and the single-capture
+# park/reload keep-guard 314 built (dup; astore 1; fetch; intValue; aload 1;
 # predicate; ifne; return; label; frame-item), and the Predicate SAM constants
-# are reconstructed literally for the int-capture Stream<Integer> case.
+# are reconstructed literally for the int-capture Stream<Integer> case. A MULTI-
+# capture lone filter (two or more appends / fetches, e.g. the issue's
+# `filter(n -> n > lo && n < hi)`) fails this single-append, single-fetch closed
+# pattern and is emitted as a standalone mapMulti rather than reverted — correct,
+# only marginally slower than native, exactly as 443 leaves a lone multi-capture
+# map. Reverting it (replaying N pushes, rebuilding the "(I^N)" descriptor) is a
+# follow-up puzzle.
 name: unfused-capturing-filter-to-invokedynamic
 pattern: |
   ⟦
@@ -46,6 +53,7 @@ pattern: |
       ⟧,
       body ↦ ⟦
         𝜏-itemdup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+        𝜏-park ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, i1 ↦ 1 ⟧,
         𝜏-fetch ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
         𝜏-unbox ↦ ⟦
           φ ↦ Φ.jeo.opcode.invokevirtual,
@@ -54,7 +62,7 @@ pattern: |
           i3 ↦ "()I",
           i4 ↦ Φ.false
         ⟧,
-        𝜏-swap ↦ ⟦ φ ↦ Φ.jeo.opcode.swap ⟧,
+        𝜏-reload ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
         𝜏-call ↦ ⟦
           φ ↦ Φ.jeo.opcode.invokestatic,
           i1 ↦ 𝑒-target-class,

--- a/src/test/phino/113-capturing-invokedynamic-to-filter.yml
+++ b/src/test/phino/113-capturing-invokedynamic-to-filter.yml
@@ -2,9 +2,14 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-# The filter twin of 112: a capturing primitive-filter invokedynamic —
-# "(I)L…Predicate;", a handle-6 static lambda$ returning Z — is lifted to a
-# Φ.hone.cp-filter pragma with the captured int grabbed out of the body.
+# The filter twin of 112: a MULTI-capturing primitive-filter invokedynamic —
+# descriptor "(II)L…Predicate;", two int captures pushed by the preceding iloads,
+# a handle-6 static lambda$ returning Z — is lifted to a Φ.hone.cp-filter pragma.
+# 113 consumes ONLY the indy and the invokeinterface; it leaves the run of iload
+# pushes inline in front of the cp-filter (118 gathers them) and seeds two EMPTY
+# accumulators. The target lambda$ signature "(IILjava/lang/Integer;)Z" rides
+# through verbatim. The relaxed "\(I+\)" guard also covers the single-int case
+# (one I) the same way.
 rules:
   - src/main/resources/org/eolang/hone/rules/streams/1xx/113-capturing-invokedynamic-to-filter.phr
 input: |
@@ -21,30 +26,31 @@ input: |
       access ↦ 8,
       modifiers ↦ ⟦ φ ↦ Φ.jeo.modifiers, static ↦ Φ.true ⟧,
       name ↦ "run",
-      descriptor ↦ "(I)J",
+      descriptor ↦ "(II)J",
       signature ↦ "",
       exceptions ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
-      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, m1 ↦ 4, m2 ↦ 1 ⟧,
+      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, m1 ↦ 5, m2 ↦ 2 ⟧,
       params ↦ ⟦ φ ↦ Φ.jeo.params ⟧,
       annotations ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
       body ↦ ⟦
         i20 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 0 ⟧,
-        i21 ↦ ⟦
+        i21 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 1 ⟧,
+        i22 ↦ ⟦
           φ ↦ Φ.jeo.opcode.invokedynamic,
           v0 ↦ "test",
-          v1 ↦ "(I)Ljava/util/function/Predicate;",
+          v1 ↦ "(II)Ljava/util/function/Predicate;",
           h2 ↦ ⟦ φ ↦ Φ.jeo.handle, v0 ↦ 6, v1 ↦ "java/lang/invoke/LambdaMetafactory", v2 ↦ "metafactory", v3 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;", v4 ↦ Φ.false ⟧,
           t3 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Object;)Z" ⟧,
-          h4 ↦ ⟦ φ ↦ Φ.jeo.handle, v0 ↦ 6, v1 ↦ "Foo", v2 ↦ "lambda$run$0", v3 ↦ "(ILjava/lang/Integer;)Z", v4 ↦ Φ.false ⟧,
+          h4 ↦ ⟦ φ ↦ Φ.jeo.handle, v0 ↦ 6, v1 ↦ "Foo", v2 ↦ "lambda$run$0", v3 ↦ "(IILjava/lang/Integer;)Z", v4 ↦ Φ.false ⟧,
           t5 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Integer;)Z" ⟧
         ⟧,
-        i22 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "filter", v2 ↦ "(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;", v3 ↦ Φ.true ⟧
+        i23 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "filter", v2 ↦ "(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;", v3 ↦ Φ.true ⟧
       ⟧,
       trycatchblocks ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
       local-variable-table ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
     ⟧
   ⟧}
 expected:
-  - ⟦ φ ↦ Φ.hone.cp-filter, 𝐵-a, captured ↦ "I", 𝐵-b ⟧
-  - ⟦ φ ↦ Φ.hone.cp-filter, 𝐵-c, capture-push ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 0 ⟧, 𝐵-d ⟧
-  - ⟦ 𝐵-e, method ↦ "lambda$run$0", signature ↦ "(ILjava/lang/Integer;)Z", 𝐵-f ⟧
+  - ⟦ φ ↦ Φ.hone.cp-filter, state-acc ↦ ⟦⟧, body-acc ↦ ⟦⟧, 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.hone.cp-filter, 𝐵-g, target ↦ ⟦ 𝐵-h, signature ↦ "(IILjava/lang/Integer;)Z", 𝐵-i ⟧, 𝐵-j ⟧
+  - ⟦ 𝐵-k, 𝜏-last ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 1 ⟧, 𝜏-cf ↦ ⟦ φ ↦ Φ.hone.cp-filter, 𝐵-l ⟧, 𝐵-m ⟧

--- a/src/test/phino/118-cp-filter-peel-capture.yml
+++ b/src/test/phino/118-cp-filter-peel-capture.yml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 118 gathers the captures 113 left inline, exactly as 114 does for a c-map. The
+# input mimics 113's output: a Φ.hone.cp-filter with two EMPTY accumulators,
+# preceded by two iload pushes (lo at slot v0=0, hi at slot v0=1) and bounded on
+# the left by the previous operator's invokeinterface. Re-applied at fixpoint,
+# 118 peels the iloads right-to-left (greedy-left binds the LAST one first) and
+# PREPENDS one unit per capture, so state-acc ends up appending lo THEN hi
+# (slot 0 = lo) and body-acc gets two `fetch; intValue` pairs. After it runs, no
+# iload sits between the invokeinterface and the cp-filter — every capture has
+# moved into the accumulators.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/1xx/118-cp-filter-peel-capture.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      p ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "filter", v2 ↦ "(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;", v3 ↦ Φ.true ⟧,
+      lo ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 0 ⟧,
+      hi ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 1 ⟧,
+      cf ↦ ⟦
+        φ ↦ Φ.hone.cp-filter,
+        state-acc ↦ ⟦⟧,
+        body-acc ↦ ⟦⟧,
+        class ↦ "Foo",
+        bridge-input ↦ "Ljava/lang/Integer;",
+        bridge-output ↦ "Ljava/lang/Integer;",
+        accepted ↦ "Ljava/lang/Integer;",
+        returned ↦ "Ljava/lang/Integer;",
+        static ↦ "true",
+        target ↦ ⟦ handle ↦ 6, class ↦ "Foo", method ↦ "lambda$run$0", signature ↦ "(IILjava/lang/Integer;)Z", is-interface ↦ Φ.false ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.hone.cp-filter, state-acc ↦ ⟦ 𝜏-d ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧, 𝜏-l ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 0 ⟧, 𝐵-sr ⟧, 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.hone.cp-filter, 𝐵-a, body-acc ↦ ⟦ 𝜏-f1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧, 𝜏-iv ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, 𝐵-iv ⟧, 𝜏-f2 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧, 𝐵-br ⟧, 𝐵-c ⟧
+  - ⟦ 𝐵-x, 𝜏-p ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", 𝐵-pr ⟧, 𝜏-cf ↦ ⟦ φ ↦ Φ.hone.cp-filter, 𝐵-cr ⟧, 𝐵-y ⟧

--- a/src/test/phino/314-cp-filter-to-distill.yml
+++ b/src/test/phino/314-cp-filter-to-distill.yml
@@ -2,38 +2,52 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-# A capturing primitive-filter pragma (113's output) folds into a stateful
-# Φ.hone.distill: same boxed-capture append as 316, plus a guard body that opens
-# with an item-preserving `dup` (the predicate consumes the item) then fetch; intValue;
-# swap; predicate; ifne keep; return drop. The keep label carries a
-# Φ.hone.frame-item marker that 503 fills once 502 has set captured=List.
+# A capturing primitive-filter pragma (113's output, gathered by 118) folds into
+# a stateful Φ.hone.distill — the filter twin of 316. The input is a two-capture
+# cp-filter: state-acc already holds two boxing appends (capture lo at v0=0 then
+# hi at v0=1) and body-acc two `fetch; intValue` pairs. 314 copies state-acc into
+# the distill `state` verbatim and wraps body-acc into a filter guard whose item
+# is preserved at the bottom of the stack: `dup; astore 1; <fetches>; aload 1;
+# invokestatic lambda$; ifne keep; return drop; keep: frame-item`. The keep label
+# leaves a lone [item], so the Φ.hone.frame-item marker is exactly the one 503
+# fills for distinct/skip — no separate empty-stack keep-frame is needed. start is
+# "c-filter" so 401 fuses it and 444 can find a lone single-capture filter.
 rules:
   - src/main/resources/org/eolang/hone/rules/streams/3xx/314-cp-filter-to-distill.phr
 input: |
   {⟦
-    body ↦ ⟦
-      op ↦ ⟦
-        φ ↦ Φ.hone.cp-filter,
-        class ↦ "Foo",
-        bridge-input ↦ "Ljava/lang/Integer;",
-        bridge-output ↦ "Ljava/lang/Integer;",
-        accepted ↦ "Ljava/lang/Integer;",
-        returned ↦ "Ljava/lang/Integer;",
-        static ↦ "true",
-        captured ↦ "I",
-        capture-push ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 3 ⟧,
-        interface ↦ "(I)Ljava/util/function/Predicate;",
-        method ↦ "test",
-        lambda-signature ↦ "(Ljava/lang/Object;)Z",
-        bridge-signature ↦ "(Ljava/lang/Integer;)Z",
-        target ↦ ⟦ handle ↦ 6, class ↦ "Foo", method ↦ "lambda$run$0", signature ↦ "(ILjava/lang/Integer;)Z", is-interface ↦ Φ.false ⟧
-      ⟧,
+    φ ↦ Φ.hone.cp-filter,
+    state-acc ↦ ⟦
+      s1 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+      s2 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 0 ⟧,
+      s3 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "java/lang/Integer", i3 ↦ "valueOf", i4 ↦ "(I)Ljava/lang/Integer;", i5 ↦ Φ.false ⟧,
+      s4 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/List", i3 ↦ "add", i4 ↦ "(Ljava/lang/Object;)Z", i5 ↦ Φ.true ⟧,
+      s5 ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+      s6 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+      s7 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 1 ⟧,
+      s8 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "java/lang/Integer", i3 ↦ "valueOf", i4 ↦ "(I)Ljava/lang/Integer;", i5 ↦ Φ.false ⟧,
+      s9 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/List", i3 ↦ "add", i4 ↦ "(Ljava/lang/Object;)Z", i5 ↦ Φ.true ⟧,
+      s10 ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
       ρ ↦ ∅
-    ⟧
+    ⟧,
+    body-acc ↦ ⟦
+      b1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
+      b2 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, i1 ↦ "java/lang/Integer", i2 ↦ "intValue", i3 ↦ "()I", i4 ↦ Φ.false ⟧,
+      b3 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
+      b4 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, i1 ↦ "java/lang/Integer", i2 ↦ "intValue", i3 ↦ "()I", i4 ↦ Φ.false ⟧,
+      ρ ↦ ∅
+    ⟧,
+    class ↦ "Foo",
+    bridge-input ↦ "Ljava/lang/Integer;",
+    bridge-output ↦ "Ljava/lang/Integer;",
+    accepted ↦ "Ljava/lang/Integer;",
+    returned ↦ "Ljava/lang/Integer;",
+    static ↦ "true",
+    target ↦ ⟦ handle ↦ 6, class ↦ "Foo", method ↦ "lambda$run$0", signature ↦ "(IILjava/lang/Integer;)Z", is-interface ↦ Φ.false ⟧
   ⟧}
 expected:
   - ⟦ φ ↦ Φ.hone.distill, 𝐵-a, start ↦ "c-filter", 𝐵-b ⟧
-  - ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧
-  - ⟦ φ ↦ Φ.jeo.opcode.swap ⟧
+  - ⟦ 𝜏-dup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧, 𝜏-park ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, i1 ↦ 1 ⟧, 𝜏-f ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧, 𝐵-br ⟧
+  - ⟦ 𝐵-e, 𝜏-reload ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧, 𝜏-call ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i1 ↦ "Foo", i2 ↦ "lambda$run$0", i3 ↦ "(IILjava/lang/Integer;)Z", i4 ↦ Φ.false ⟧, 𝐵-f ⟧
   - ⟦ φ ↦ Φ.hone.frame-item ⟧
-  - ⟦ φ ↦ Φ.jeo.opcode.invokestatic, 𝐵-c, i2 ↦ "lambda$run$0", i3 ↦ "(ILjava/lang/Integer;)Z", 𝐵-d ⟧
+  - ⟦ φ ↦ Φ.hone.distill, 𝐵-g, state ↦ ⟦ 𝜏-d1 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧, 𝜏-l1 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 0 ⟧, 𝐵-sr ⟧, 𝐵-h ⟧

--- a/src/test/phino/444-unfused-capturing-filter-to-invokedynamic.yml
+++ b/src/test/phino/444-unfused-capturing-filter-to-invokedynamic.yml
@@ -30,14 +30,15 @@ input: |
         ⟧,
         body ↦ ⟦
           b0 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
-          b1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
-          b2 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, i1 ↦ "java/lang/Integer", i2 ↦ "intValue", i3 ↦ "()I", i4 ↦ Φ.false ⟧,
-          b3 ↦ ⟦ φ ↦ Φ.jeo.opcode.swap ⟧,
-          b4 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i1 ↦ "Foo", i2 ↦ "lambda$run$0", i3 ↦ "(ILjava/lang/Integer;)Z", i4 ↦ Φ.false ⟧,
-          b5 ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L9" ⟧ ⟧,
-          b6 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
-          b7 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L9" ⟧,
-          b8 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+          b1 ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, i1 ↦ 1 ⟧,
+          b2 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
+          b3 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, i1 ↦ "java/lang/Integer", i2 ↦ "intValue", i3 ↦ "()I", i4 ↦ Φ.false ⟧,
+          b4 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
+          b5 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i1 ↦ "Foo", i2 ↦ "lambda$run$0", i3 ↦ "(ILjava/lang/Integer;)Z", i4 ↦ Φ.false ⟧,
+          b6 ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L9" ⟧ ⟧,
+          b7 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+          b8 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L9" ⟧,
+          b9 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
           ρ ↦ ∅
         ⟧
       ⟧,

--- a/src/test/resources/org/eolang/hone/optimize/streams/closures.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/closures.yml
@@ -7,18 +7,27 @@
 # are asserted. The runtime result: the pipeline must never corrupt a
 # roundtrip nor pessimise a lone operator, so a correct printout proves every
 # path lowered to runnable bytecode. And the invokedynamic tally: it drops
-# from 41 to 29 as the capturing and non-capturing operators collapse into 10
-# Stream.mapMulti dispatches — 3 stay an object mapMulti and 7 become a
+# from 41 to 28 as the capturing and non-capturing operators collapse into 11
+# Stream.mapMulti dispatches — 3 stay an object mapMulti and 8 become a
 # mapMultiToInt, because a trailing mapToInt(Integer::intValue) now folds into
 # the distill in front of it whether that distill is empty-state OR
 # stateful/capturing (the generalized 451 preserves the predecessor's state,
-# so capLoc / multiCap / loneMulti each absorb their trailing mapToInt instead
-# of leaving it native). The indys that remain are the string-concat
-# (makeConcatWithConstants in decorate / the reduce) and the genuinely native
-# or reverted cases (capObj, capArr, capFld, lone, named, multiFil, …); the
-# twelve that disappear are the fusion win. Which indy collapses into which
+# so capLoc / multiCap / loneMulti / multiFil each absorb their trailing
+# mapToInt instead of leaving it native). The indys that remain are the
+# string-concat (makeConcatWithConstants in decorate / the reduce) and the
+# genuinely native or reverted cases (capObj, capArr, capFld, lone, named, …);
+# the thirteen that disappear are the fusion win. Which indy collapses into which
 # mapMulti is proven per-rule by the src/test/phino/ packs — this fixture
 # proves the rules COMPOSE on a real class.
+#
+# Update (issue #655): the multi-int-capture filter is no longer deferred. 113
+# now lifts a "(I+)L…Predicate;" factory (one OR MORE int captures), 118 peels
+# every push into the shared List, and 314 folds it into a stateful distill with
+# the same N-ary park/reload body 316 gives a capturing map. So multiFil
+# (filter(n>lo && n<hi), two int captures) fuses with its trailing mapToInt into
+# ONE Stream.mapMultiToInt instead of staying native — the indy tally drops 41 →
+# 28 (11 mapMulti dispatches: 3 object + 8 mapMultiToInt), and multiFil leaves
+# the "genuinely native or reverted" set.
 #
 # Native roundtrip shapes — must survive untouched:
 #   bound   : String::length             unbound-instance method ref
@@ -37,7 +46,7 @@
 #   multiCap  : map(+1).map(+x+y+z)       three-int-capture map fuses (v1.1)
 #   lone      : map(n+off)                lone single-capture map REVERTS to native
 #   loneMulti : map(n+p+q)                lone multi-capture map -> standalone mapMulti
-#   multiFil  : filter(n>lo && n<hi)      multi-int-capture filter stays native (deferred)
+#   multiFil  : filter(n>lo && n<hi)      multi-int-capture filter FUSES (issue #655)
 java: |
   package closures;
   import java.util.*;
@@ -146,7 +155,7 @@ java: |
 before:
   invokedynamic: 41
 after:
-  invokedynamic: 29
+  invokedynamic: 28
 log:
   - "BUILD SUCCESS"
   - "The result is 14 200 14 84 315 >2>3>4 36 27 3006 87 24 387 5 54 12"


### PR DESCRIPTION
Resolves the `#652` puzzle in `112-capturing-invokedynamic-to-map.phr:55-60` (issue #655): generalise the capturing **filter** channel from a single int capture to one OR MORE int captures — the twin of the multi-int-capture map.

## What changed

- **`113-capturing-invokedynamic-to-filter.phr`** — now lifts a `(I+)L…Predicate;` factory (one or more int captures). Like `112`, it grabs **no** push: it seeds two empty accumulators (`state-acc`, `body-acc`) and leaves the run of `iload`s inline for the peeler.
- **`118-cp-filter-peel-capture.phr`** *(new)* — the `cp-filter` twin of `114`: peels each `iload` push into the shared-List state, one per firing, right-to-left, so captures land in left-to-right order.
- **`314-cp-filter-to-distill.phr`** — folds the accumulators into a stateful `Φ.hone.distill` with the same N-ary **park/reload** body `316` gives a capturing map. The guard keeps the item at the **bottom** of the stack (`dup; astore 1; <captures>; aload 1; predicate; ifne keep; return`) so the keep label still sees a lone `[item]` and reuses `503`'s `Φ.hone.frame-item` — **no separate empty-stack keep-frame is needed** (this is the subtlety the puzzle flagged).
- **`444-unfused-capturing-filter-to-invokedynamic.phr`** — its closed body pattern is updated to the new single-capture park/reload shape so a *lone* single-int-capture filter still reverts to native. A lone *multi*-capture filter falls through to a standalone `mapMulti`, exactly as `443` leaves a lone multi-capture map.

So `filter(n -> n > lo && n < hi)` now fuses with its trailing `mapToInt` into one `Stream.mapMultiToInt`. In `streams/closures.yml` the `multiFil` case stops being native; the invokedynamic tally drops **41 → 28** (11 mapMulti dispatches: 3 object + 8 `mapMultiToInt`).

Updated the `113`/`314`/`444` rule-unit packs, added the `118` pack, and updated `CLAUDE.md`. The puzzle text in `112`'s header is removed; the remaining deferred work (mixed/multi-**reference** capture runs needing positional type extraction, plus J/D-capture filters) is re-filed as a new `#655` puzzle.

## Verification note

The sandbox this was developed in has **no `phino` binary** (Docker Hub was rate-limited and there's no GHC/cabal), so the `@Tag("deep")` end-to-end and rule-unit suites — which require `phino` — could **not** be run locally. `RulesTest` (rule discovery) passes and all changed YAML/`.phr` files lint clean against the repo conventions. The rule logic mirrors the already-tested multi-capture **map** path, and the one novel concern (the filter keep-frame) is resolved by reusing the existing `frame-item`. Please let CI run the `deep` profile to confirm; I'm happy to iterate on any failures — in particular the exact `after.invokedynamic: 28` count is reasoned, not yet machine-verified.

https://claude.ai/code/session_014DQ6PVrWjUSFW1tRo7oJvU

---
_Generated by [Claude Code](https://claude.ai/code/session_014DQ6PVrWjUSFW1tRo7oJvU)_