### PR TITLE
Revert unfused reference-capture map to native (#657)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -566,8 +566,11 @@ branch lifts `map(n -> n + base.size())` over a captured `List`, `115` peels the
 `aload` into the shared List with no box/unbox, and the whole stateful emit path
 (`316`/`401`/`502`/`512`/`521`/`601`) lowers it to one `Stream.mapMulti` — see
 the `streams/closure-reference.yml` end-to-end fixture. A lone reference-capture
-map is not reverted by `443` (closed on the int box/unbox shape), so it is
-emitted as a standalone `mapMulti` — correct, like the lone-multi-capture map.
+map is reverted to its native `invokedynamic` + `Stream.map` by
+`445-unfused-reference-capturing-map-to-invokedynamic` (issue #657, the
+reference-capture twin of `443`, closed on the box/unbox-free reference state and
+park/reload body), so it is never pessimised — see the
+`streams/closure-reference-lone.yml` end-to-end fixture.
 
 Category-2 (`J`/`D`) captures are **done** (issue #652): `112`'s `\([IJD]+\)`
 guard admits one or more long/double captures (and mixed int/long/double runs),
@@ -588,10 +591,11 @@ bottom of the stack. So `filter(n -> n > lo && n < hi)` fuses with its trailing
 
 Deferred puzzles (each extends the same shared-List channel): the
 lone-multi-capture map/filter revert (above); a MULTI-reference /
-mixed-with-reference capture run (needs positional capture-type extraction) and
-a lone-reference-map revert; a category-2 (`J`/`D`) or reference capture in a
-FILTER (its `116`/`117`/`115` peeler twins); `this`-field captures; and capturing
-`peek`/`mapToX`. See the puzzle marker in `112`'s header.
+mixed-with-reference capture run (needs positional capture-type extraction); a
+category-2 (`J`/`D`) or reference capture in a FILTER (its `116`/`117`/`115`
+peeler twins); `this`-field captures; and capturing `peek`/`mapToX`. See the
+puzzle marker in `112`'s header. (The lone-reference-map revert is **done** via
+`445`.)
 
 ## phino: the only rewrite engine
 

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
@@ -61,15 +61,19 @@
 # lone [item]. So `filter(n -> n > lo && n < hi)` fuses exactly like the int
 # multi-capture map; see the multiFil case in streams/closures.yml.
 #
-# @todo #655:45min Generalise the CAPTURE channel further: a MIXED multi-capture
+# The lone-reference-map revert is now done (issue #657): a single-reference-capture
+# map that never fuses is reverted to its native invokedynamic + Stream.map by
+# 445-unfused-reference-capturing-map-to-invokedynamic, the reference-capture twin
+# of 443.
+#
+# @todo #657:45min Generalise the CAPTURE channel further: a MIXED multi-capture
 #  run that contains a reference (only a SINGLE lone reference is admitted today,
 #  because 115 reads the capture type out of target.signature's first L-type — a
-#  multi-reference run needs positional type extraction) and a lone-reference-map
-#  revert. Still native in the FILTER channel too: a category-2 (J/D) or reference
-#  capture (its 116/117/115 peeler twins) and the lone-multi-capture-filter revert
-#  (444 is closed on the single-capture park/reload body, so a lone multi-capture
-#  filter is emitted as a standalone mapMulti). Each extends the same shared-List
-#  channel.
+#  multi-reference run needs positional type extraction). Still native in the
+#  FILTER channel too: a category-2 (J/D) or reference capture (its 116/117/115
+#  peeler twins) and the lone-multi-capture-filter revert (444 is closed on the
+#  single-capture park/reload body, so a lone multi-capture filter is emitted as a
+#  standalone mapMulti). Each extends the same shared-List channel.
 name: capturing-invokedynamic-to-map
 pattern: |
   ⟦

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/445-unfused-reference-capturing-map-to-invokedynamic.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/445-unfused-reference-capturing-map-to-invokedynamic.phr
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The reference-capture twin of 443 (issue #657). 443 reverts an UNFUSED single
+# int-capture map back to its native invokedynamic + Stream.map; it is closed on
+# the int box/unbox body shape (`Integer.valueOf` append, `intValue` unbox), so a
+# lone SINGLE-reference-capture map — `map(n -> n + base.size())` over a captured
+# List, lifted by 112's "(L…;)" branch, peeled by 115 — fell through and was
+# emitted as a standalone mapMulti even though it never fused, strictly slower
+# than the native Stream.map. This rule closes that gap: a c-map distill that
+# still carries ONLY the reference append (`dup; aload k; List.add; pop`, no box,
+# because a reference is already an Object) and the single-capture park/reload
+# body 115/316 built WITHOUT an unbox (`astore 1; fetch; aload 1; invokestatic`)
+# is put back as the original invokedynamic + Stream.map.
+#
+# Both the state block and the body match are CLOSED (no 𝐵-rest), so a FUSED
+# reference c-map — whose state and body carry a neighbour's append and guard — is
+# left for 502, exactly as in 443. The capture-push (𝑒-push, an `aload k`) is
+# recovered from the state and replayed before the indy; the target handle is read
+# from the body's invokestatic. The 𝜑-calculus fields the fold dropped are
+# reconstructed literally: the Function SAM name "apply", the metafactory handle,
+# and the erased lambda-signature "(Ljava/lang/Object;)Ljava/lang/Object;". The
+# captured factory descriptor "(L<capture>;)L…Function;" is rebuilt from the
+# capture's class — read off the body's `fetch` type (𝑒-captype), which 115 seeded
+# from the lambda$ signature's first L-type — and the SAM instantiated type
+# "(LX;)LX;" is rebuilt from the distill's bridge-input/bridge-output (the
+# type-preserving element type X), matching 112's element-type-agnostic lift. The
+# reverted Stream.map carries `reverted ↦ Φ.true`: 112's invokeinterface pattern
+# is closed on the four-operand opcode jeo emits, so the fifth binding stops 112
+# re-lifting this map and the 112 → 316 → 445 cycle cannot spin (jeo ignores the
+# extra binding, exactly as for 442's skip and 443's int-capture map).
+#
+# A MULTI-reference / mixed-with-reference capture run, and the lone-multi-capture
+# map/filter and category-2/reference FILTER reverts, remain native follow-ups
+# (see the @todo in 112's header).
+name: unfused-reference-capturing-map-to-invokedynamic
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-distill ↦ ⟦
+      φ ↦ Φ.hone.distill,
+      class ↦ 𝑒-class,
+      bridge-input ↦ 𝑒-bridge-input,
+      bridge-output ↦ 𝑒-bridge-output,
+      start ↦ "c-map",
+      accepted ↦ 𝑒-accepted,
+      returned ↦ 𝑒-returned,
+      static ↦ 𝑒-static,
+      state ↦ ⟦
+        𝜏-dup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+        𝜏-load ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, 𝐵-load-args ⟧,
+        𝜏-add ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          i2 ↦ "java/util/List",
+          i3 ↦ "add",
+          i4 ↦ "(Ljava/lang/Object;)Z",
+          i5 ↦ Φ.true
+        ⟧,
+        𝜏-pop ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+        ρ ↦ ∅
+      ⟧,
+      body ↦ ⟦
+        𝜏-park ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, i1 ↦ 1 ⟧,
+        𝜏-fetch ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ 𝑒-captype ⟧,
+        𝜏-reload ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
+        𝜏-call ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokestatic,
+          i1 ↦ 𝑒-target-class,
+          i2 ↦ 𝑒-target-method,
+          i3 ↦ 𝑒-target-signature,
+          i4 ↦ 𝑒-target-is-interface
+        ⟧,
+        ρ ↦ ∅
+      ⟧
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-push-back ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, 𝐵-load-args ⟧,
+    𝜏-indy ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokedynamic,
+      v0 ↦ "apply",
+      v1 ↦ 𝑒-factory,
+      h2 ↦ ⟦
+        φ ↦ Φ.jeo.handle,
+        v0 ↦ 6,
+        v1 ↦ "java/lang/invoke/LambdaMetafactory",
+        v2 ↦ "metafactory",
+        v3 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+        v4 ↦ Φ.false
+      ⟧,
+      t3 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Object;)Ljava/lang/Object;" ⟧,
+      h4 ↦ ⟦
+        φ ↦ Φ.jeo.handle,
+        v0 ↦ 6,
+        v1 ↦ 𝑒-target-class,
+        v2 ↦ 𝑒-target-method,
+        v3 ↦ 𝑒-target-signature,
+        v4 ↦ 𝑒-target-is-interface
+      ⟧,
+      t5 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ 𝑒-instantiated ⟧
+    ⟧,
+    𝜏-map ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      v0 ↦ "java/util/stream/Stream",
+      v1 ↦ "map",
+      v2 ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;",
+      v3 ↦ Φ.true,
+      reverted ↦ Φ.true
+    ⟧,
+    𝐵-after
+  ⟧
+where:
+  - meta: 𝑒-factory
+    function: concat
+    args:
+      - '"(L"'
+      - 𝑒-captype
+      - '";)Ljava/util/function/Function;"'
+  - meta: 𝑒-instantiated
+    function: concat
+    args:
+      - '"("'
+      - 𝑒-bridge-input
+      - '")"'
+      - 𝑒-bridge-output
+  - meta: 𝜏-push-back
+    function: random-tau
+  - meta: 𝜏-indy
+    function: random-tau
+  - meta: 𝜏-map
+    function: random-tau

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/445-unfused-reference-capturing-map-to-invokedynamic.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/445-unfused-reference-capturing-map-to-invokedynamic.phr
@@ -33,7 +33,7 @@
 #
 # A MULTI-reference / mixed-with-reference capture run, and the lone-multi-capture
 # map/filter and category-2/reference FILTER reverts, remain native follow-ups
-# (see the @todo in 112's header).
+# (see the puzzle marker in 112's header).
 name: unfused-reference-capturing-map-to-invokedynamic
 pattern: |
   ⟦

--- a/src/test/phino/445-unfused-reference-capturing-map-to-invokedynamic.yml
+++ b/src/test/phino/445-unfused-reference-capturing-map-to-invokedynamic.yml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A lone single-reference-capture map distill that never fused (closed reference
+# state + park/reload body with NO box/unbox) is reverted to the native
+# invokedynamic + Stream.map, replaying the captured push (aload 0, the captured
+# List) and marking the call reverted↦Φ.true so 112 cannot re-lift it. This is the
+# never-pessimise guarantee for a lone `map(n -> n + base.size())` — the issue-#657
+# reference-capture analogue of 443's int-capture revert. The rebuilt factory
+# descriptor is "(Ljava/util/List;)L…Function;" (from the body fetch's type) and
+# the SAM instantiated type is "(Ljava/lang/Integer;)Ljava/lang/Integer;" (from the
+# distill bridge fields).
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/4xx/445-unfused-reference-capturing-map-to-invokedynamic.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      op ↦ ⟦
+        φ ↦ Φ.hone.distill,
+        class ↦ "Foo",
+        bridge-input ↦ "Ljava/lang/Integer;",
+        bridge-output ↦ "Ljava/lang/Integer;",
+        start ↦ "c-map",
+        accepted ↦ "Ljava/lang/Integer;",
+        returned ↦ "Ljava/lang/Integer;",
+        static ↦ "true",
+        state ↦ ⟦
+          s1 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+          s2 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 0 ⟧,
+          s3 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/List", i3 ↦ "add", i4 ↦ "(Ljava/lang/Object;)Z", i5 ↦ Φ.true ⟧,
+          s4 ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+          ρ ↦ ∅
+        ⟧,
+        body ↦ ⟦
+          b0 ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, i1 ↦ 1 ⟧,
+          b1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/util/List" ⟧,
+          b2 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
+          b3 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i1 ↦ "Foo", i2 ↦ "lambda$run$0", i3 ↦ "(Ljava/util/List;Ljava/lang/Integer;)Ljava/lang/Integer;", i4 ↦ Φ.false ⟧,
+          ρ ↦ ∅
+        ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.jeo.opcode.invokedynamic, 𝐵-a, v1 ↦ "(Ljava/util/List;)Ljava/util/function/Function;", 𝐵-b ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "map", v2 ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;", v3 ↦ Φ.true, reverted ↦ Φ.true ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 0 ⟧
+  - ⟦ φ ↦ Φ.jeo.handle, 𝐵-e, v2 ↦ "lambda$run$0", 𝐵-f ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/closure-reference-lone.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/closure-reference-lone.yml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# End-to-end proof that a LONE single-reference-capture map is never pessimised
+# (issue #657). Unlike closure-reference.yml — where two maps fuse into one
+# mapMulti — here the capturing map has no neighbour to fuse with:
+#
+#   Stream.of(...).map(n -> n + base.size()).reduce(0, ...)
+#
+# 112's "(L…;)" branch lifts the capturing map to a Φ.hone.c-map, 115 peels the
+# captured `aload` (the List) into the shared state, and 316 folds a lone stateful
+# distill. Because nothing fuses with it, turning it into a mapMulti would add an
+# invokedynamic, a wrapper, an ArrayList and a List.get per element — strictly
+# slower than the native Stream.map. 445 (the reference-capture twin of 443)
+# reverts the unfused c-map distill back to its original invokedynamic +
+# Stream.map, replaying the captured push and marking the call reverted↦Φ.true so
+# 112 cannot re-lift it.
+#
+# invokedynamic: before = map(capturing) + reduce-accumulator lambda = 2; after =
+# the reverted map indy + the untouched reduce lambda = 2. The count is UNCHANGED,
+# proving the lone capturing map came out native rather than being lowered to a
+# (slower) mapMulti. The runtime line proves the captured List still reaches the
+# lambda correctly: base.size() == 3, so {1,2,3,4,5} -> n+3 -> {4,5,6,7,8} -> sum
+# == 30.
+java: |
+  package fusion;
+  import java.util.*;
+  import java.util.stream.*;
+  public class C {
+    static int run(List<Integer> base) {
+      return Stream.of(1, 2, 3, 4, 5)
+        .map(n -> n + base.size())
+        .reduce(0, (a, b) -> a + b);
+    }
+    public static void main(String[] args) {
+      System.out.printf("The result is %d%n", run(Arrays.asList(7, 8, 9)));
+    }
+  }
+before:
+  invokedynamic: 2
+after:
+  invokedynamic: 2
+log:
+  - "BUILD SUCCESS"
+  - "The result is 30"


### PR DESCRIPTION
Resolves part of #657 (the `@todo #655` puzzle in `112-capturing-invokedynamic-to-map.phr`).

## Problem

A lone single-**reference**-capture map — e.g. `map(n -> n + base.size())` over a captured `List` — is lifted by `112`'s `(L…;)` branch, peeled by `115`, and folded into a stateful distill by `316`. When it has no neighbour to fuse with, `443` (the int-capture revert) does **not** match it (it is closed on the `Integer.valueOf`/`intValue` box/unbox shape), so the lone map was emitted as a standalone `Stream.mapMulti` — strictly slower than the native `Stream.map` (an extra invokedynamic, a wrapper, an `ArrayList` and a `List.get` per element). This violated the never-pessimise guarantee.

## Fix

New rule `445-unfused-reference-capturing-map-to-invokedynamic.phr`, the reference-capture twin of `443`. It matches an unfused `c-map` distill carrying only the box/unbox-free reference state (`dup; aload k; List.add; pop`) and the single-capture park/reload body (`astore 1; fetch; aload 1; invokestatic`), and reverts it to its original `invokedynamic` + `Stream.map`:

- replays the captured `aload` push,
- rebuilds the factory descriptor `(L<capture>;)Ljava/util/function/Function;` from the body `fetch`'s type,
- rebuilds the SAM instantiated type `(LX;)LX;` from the distill bridge fields,
- marks the reverted call `reverted ↦ Φ.true` so `112` cannot re-lift it (same loop-break as `442`/`443`).

Both the state and body matches are CLOSED, so a **fused** reference c-map is left untouched for `502`.

## Puzzle bookkeeping (PDD)

The `@todo #655` puzzle text is removed from `112`'s header. The genuinely-remaining capture-channel follow-ups (multi-reference/mixed runs needing positional type extraction; category-2/reference captures in the FILTER channel; the lone-multi-capture-filter revert) are re-filed as a new `@todo #657`. `CLAUDE.md` is updated accordingly.

## Tests

- `src/test/phino/445-unfused-reference-capturing-map-to-invokedynamic.yml` — single-rule unit pack. **Verified passing** against the pinned `phino` 0.0.0.73.
- `src/test/resources/org/eolang/hone/optimize/streams/closure-reference-lone.yml` — end-to-end fixture proving the lone capturing map stays native (`invokedynamic` count unchanged at 2) and runs correctly.

Note: in this sandbox a locally `cabal`-built `phino` 0.0.0.73 fails to fire `112` on the 4 pre-existing `112-*` unit packs (reproduced on the untouched parent commit — unrelated to this change). My new `445` pack passes and `RulesTest` is green.

https://claude.ai/code/session_01VgLgJqzwtmYMaV6Lfpex3i

---
_Generated by [Claude Code](https://claude.ai/code/session_01VgLgJqzwtmYMaV6Lfpex3i)_