### PR TITLE
#659 fuse reference-capture filters

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
@@ -66,14 +66,22 @@
 # 445-unfused-reference-capturing-map-to-invokedynamic, the reference-capture twin
 # of 443.
 #
-# @todo #657:45min Generalise the CAPTURE channel further: a MIXED multi-capture
+# The reference-capture FILTER is now done (issue #659): 113's interface guard also
+# admits a "(L…;)L…Predicate;" factory (a SINGLE reference capture), the new 119 peels
+# the lone aload into the shared List with no box/unbox (the cp-filter mirror of 115),
+# and 314 folds it into a stateful distill with the same N-ary park/reload body — so
+# `filter(n -> base.contains(n))` fuses exactly like the reference-capture map. A lone
+# reference-capture filter is not reverted (444 is closed on the int single-capture
+# body), so it is emitted as a standalone mapMulti, like a lone multi-capture filter.
+#
+# @todo #659:45min Generalise the CAPTURE channel further: a MIXED multi-capture
 #  run that contains a reference (only a SINGLE lone reference is admitted today,
-#  because 115 reads the capture type out of target.signature's first L-type — a
-#  multi-reference run needs positional type extraction). Still native in the
-#  FILTER channel too: a category-2 (J/D) or reference capture (its 116/117/115
-#  peeler twins) and the lone-multi-capture-filter revert (444 is closed on the
-#  single-capture park/reload body, so a lone multi-capture filter is emitted as a
-#  standalone mapMulti). Each extends the same shared-List channel.
+#  in both the map (115) and the filter (119), because each reads the capture type
+#  out of target.signature's first L-type — a multi-reference run needs positional
+#  type extraction). Still native in the FILTER channel too: a category-2 (J/D)
+#  capture (its 116/117 peeler twins) and the lone-multi-capture-filter revert (444
+#  is closed on the single-capture park/reload body, so a lone multi-capture filter
+#  is emitted as a standalone mapMulti). Each extends the same shared-List channel.
 name: capturing-invokedynamic-to-map
 pattern: |
   ⟦

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/113-capturing-invokedynamic-to-filter.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/113-capturing-invokedynamic-to-filter.phr
@@ -17,14 +17,17 @@
 # the static lambda$ (int…, Integer) signature wants — the same N-ary shape 316
 # gives a capturing map.
 #
-# v1 scope: one OR MORE category-1 INT captures (factory descriptor
-# "(I+)L…Predicate;", every push a constant-index iload, gathered by 118), a
-# Stream<Integer> predicate (instantiated type "(Ljava/lang/Integer;)Z"), a
-# handle-6 static lambda$ target. So both `filter(n -> n > t)` (one capture) and
-# `filter(n -> n > lo && n < hi)` (two captures) fuse exactly like the original
-# single-capture case. A category-2 (J/D) or reference capture in a filter stays
-# native — its peeler twins (116/117/115 for the map) are a follow-up puzzle;
-# see 112's header for the shared deferred generalisations.
+# Scope: one OR MORE category-1 INT captures (factory descriptor "(I+)L…Predicate;",
+# every push a constant-index iload, gathered by 118) OR a SINGLE reference capture
+# (factory descriptor "(L…;)L…Predicate;", push an aload, gathered by the reference
+# branch 119), over a Stream<Integer> predicate (instantiated type
+# "(Ljava/lang/Integer;)Z"), a handle-6 static lambda$ target. So `filter(n -> n > t)`
+# (one int capture), `filter(n -> n > lo && n < hi)` (two int captures) and
+# `filter(n -> base.contains(n))` (one reference capture) all fuse exactly like the
+# original single-capture case, the filter mirror of 112's int/reference map split.
+# A category-2 (J/D) capture in a filter stays native — its peeler twins (116/117 for
+# the map) are a follow-up puzzle; see 112's header for the shared deferred
+# generalisations.
 name: capturing-invokedynamic-to-filter
 pattern: |
   ⟦
@@ -161,9 +164,13 @@ when:
     - matches:
         - 'lambda\$.+'
         - 𝑒-target-method
-    - matches:
-        - '\(I+\)Ljava/util/function/Predicate;'
-        - 𝑒-interface
+    - or:
+        - matches:
+            - '\(I+\)Ljava/util/function/Predicate;'
+            - 𝑒-interface
+        - matches:
+            - '\(L[^;]+;\)Ljava/util/function/Predicate;'
+            - 𝑒-interface
 where:
   - meta: 𝜏-cp-filter
     function: random-tau

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/119-cp-filter-peel-reference.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/119-cp-filter-peel-reference.phr
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The reference-capture twin of 118, and the cp-filter mirror of 115. 113 admits
+# a SINGLE reference capture (factory descriptor "(L…;)L…Predicate;", e.g.
+# `filter(n -> base.contains(n))` over a captured Collection) and leaves the lone
+# `aload k` push inline in front of the cp-filter with two EMPTY accumulators;
+# this rule folds it into the operator's shared-List state, exactly as 115 does
+# for a Φ.hone.c-map — only the boxing and the unboxing drop out, because a
+# reference is already an Object.
+#
+# state-acc gains `dup; aload k; List.add; pop` (no Integer.valueOf — the captured
+# reference goes straight into the List; the append begins and ends at [list],
+# peak 3, identical to 118's int append, so it joins any number of fused
+# neighbours without growing the caller's stack). body-acc gains a single `fetch`
+# whose `type` is the captured object's class (521 turns the fetch into
+# List.get(counter++) and a checkcast to that class; no unbox follows). The class
+# is sed-extracted from the cp-filter's target.signature — the lambda$ descriptor
+# is "(Lcapture;Lelement;)Z", so its first L-type IS the capture type. This is
+# why only a SINGLE reference capture is supported: with one capture arg the first
+# L-type is unambiguous (a multi-reference run needs positional extraction).
+#
+# 314 then wraps body-acc into the auto emit-shape `dup; astore 1; <fetch>;
+# aload 1; invokestatic lambda$; ifne keep`, so the reloaded reference sits below
+# the parked item exactly as the (Lcapture;Lelement;)Z predicate signature wants.
+# The "c-filter" start label and the whole 502/512/521/601 stateful emit path are
+# reused verbatim. A lone reference-capture filter is not reverted (444 is closed
+# on the int single-capture park/reload body), so it is emitted as a standalone
+# mapMulti — like a lone multi-capture filter.
+name: cp-filter-peel-reference
+pattern: |
+  ⟦
+    𝐵-h,
+    𝜏-al ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, 𝐵-alr ⟧,
+    𝜏-cf ↦ ⟦
+      φ ↦ Φ.hone.cp-filter,
+      state-acc ↦ ⟦ 𝐵-sacc, ρ ↦ ∅ ⟧,
+      body-acc ↦ ⟦ 𝐵-bacc, ρ ↦ ∅ ⟧,
+      𝐵-cf-mid,
+      target ↦ ⟦ 𝐵-tgt-head, signature ↦ 𝑒-sig, 𝐵-tgt-tail ⟧,
+      𝐵-cf-tail
+    ⟧,
+    𝐵-t
+  ⟧
+result: |
+  ⟦
+    𝐵-h,
+    𝜏-cf ↦ ⟦
+      φ ↦ Φ.hone.cp-filter,
+      state-acc ↦ ⟦
+        𝜏-dup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+        𝜏-load ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, 𝐵-alr ⟧,
+        𝜏-add ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          i2 ↦ "java/util/List",
+          i3 ↦ "add",
+          i4 ↦ "(Ljava/lang/Object;)Z",
+          i5 ↦ Φ.true
+        ⟧,
+        𝜏-pop ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+        𝐵-sacc,
+        ρ ↦ ∅
+      ⟧,
+      body-acc ↦ ⟦
+        𝜏-fetch ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ 𝑒-captype ⟧,
+        𝐵-bacc,
+        ρ ↦ ∅
+      ⟧,
+      𝐵-cf-mid,
+      target ↦ ⟦ 𝐵-tgt-head, signature ↦ 𝑒-sig, 𝐵-tgt-tail ⟧,
+      𝐵-cf-tail
+    ⟧,
+    𝐵-t
+  ⟧
+where:
+  - meta: 𝑒-captype
+    function: sed
+    args:
+      - 𝑒-sig
+      - '"s/[(]L//"'
+      - '"s/;.*//"'
+  - meta: 𝜏-dup
+    function: random-tau
+  - meta: 𝜏-load
+    function: random-tau
+  - meta: 𝜏-add
+    function: random-tau
+  - meta: 𝜏-pop
+    function: random-tau
+  - meta: 𝜏-fetch
+    function: random-tau

--- a/src/test/phino/113-capturing-invokedynamic-to-filter-reference.yml
+++ b/src/test/phino/113-capturing-invokedynamic-to-filter-reference.yml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The reference-capture variant of 113 (issue #659): a capturing primitive-filter
+# invokedynamic whose factory descriptor is "(Ljava/util/List;)L…Predicate;" — a
+# SINGLE reference capture pushed by the preceding aload, a handle-6 static lambda$
+# returning Z — is lifted to a Φ.hone.cp-filter pragma by the widened
+# "\(L[^;]+;\)L…Predicate;" guard branch, exactly as the int "(I+)" branch does.
+# 113 leaves the aload push inline in front of the cp-filter (119 gathers it) and
+# seeds two EMPTY accumulators. The lambda$ signature
+# "(Ljava/util/List;Ljava/lang/Integer;)Z" rides through verbatim so 119 can read
+# the capture type from its first L-slot.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/1xx/113-capturing-invokedynamic-to-filter.phr
+input: |
+  {⟦
+    φ ↦ Φ.jeo.class,
+    version ↦ 68,
+    access ↦ 33,
+    modifiers ↦ ⟦ φ ↦ Φ.jeo.modifiers, static ↦ Φ.false ⟧,
+    name ↦ "Foo",
+    supername ↦ "java/lang/Object",
+    interfaces ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+    m$run ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 8,
+      modifiers ↦ ⟦ φ ↦ Φ.jeo.modifiers, static ↦ Φ.true ⟧,
+      name ↦ "run",
+      descriptor ↦ "(Ljava/util/List;)J",
+      signature ↦ "",
+      exceptions ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, m1 ↦ 5, m2 ↦ 2 ⟧,
+      params ↦ ⟦ φ ↦ Φ.jeo.params ⟧,
+      annotations ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      body ↦ ⟦
+        a20 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 0 ⟧,
+        i22 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokedynamic,
+          v0 ↦ "test",
+          v1 ↦ "(Ljava/util/List;)Ljava/util/function/Predicate;",
+          h2 ↦ ⟦ φ ↦ Φ.jeo.handle, v0 ↦ 6, v1 ↦ "java/lang/invoke/LambdaMetafactory", v2 ↦ "metafactory", v3 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;", v4 ↦ Φ.false ⟧,
+          t3 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Object;)Z" ⟧,
+          h4 ↦ ⟦ φ ↦ Φ.jeo.handle, v0 ↦ 6, v1 ↦ "Foo", v2 ↦ "lambda$run$0", v3 ↦ "(Ljava/util/List;Ljava/lang/Integer;)Z", v4 ↦ Φ.false ⟧,
+          t5 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Integer;)Z" ⟧
+        ⟧,
+        i23 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "filter", v2 ↦ "(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;", v3 ↦ Φ.true ⟧
+      ⟧,
+      trycatchblocks ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      local-variable-table ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.hone.cp-filter, state-acc ↦ ⟦⟧, body-acc ↦ ⟦⟧, 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.hone.cp-filter, 𝐵-g, target ↦ ⟦ 𝐵-h, signature ↦ "(Ljava/util/List;Ljava/lang/Integer;)Z", 𝐵-i ⟧, 𝐵-j ⟧
+  - ⟦ 𝐵-k, 𝜏-last ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 0 ⟧, 𝜏-cf ↦ ⟦ φ ↦ Φ.hone.cp-filter, 𝐵-l ⟧, 𝐵-m ⟧

--- a/src/test/phino/119-cp-filter-peel-reference.yml
+++ b/src/test/phino/119-cp-filter-peel-reference.yml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 119 gathers the SINGLE reference capture that 113 left inline, the cp-filter
+# mirror of 115. The input mimics 113's output for `filter(n -> base.contains(n))`:
+# a Φ.hone.cp-filter with two EMPTY accumulators, preceded by one `aload 0` push
+# (the captured List) and bounded on the left by the previous operator's
+# invokeinterface. The cp-filter's target signature
+# "(Ljava/util/List;Ljava/lang/Integer;)Z" carries the capture type in its first
+# L-slot. After 119 runs to fixpoint, state-acc appends the reference verbatim
+# (dup; aload 0; List.add; pop — NO Integer.valueOf box), body-acc gets one `fetch`
+# typed java/util/List (NO unbox), and no aload sits between the invokeinterface
+# and the cp-filter.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/1xx/119-cp-filter-peel-reference.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      p ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "filter", v2 ↦ "(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;", v3 ↦ Φ.true ⟧,
+      a ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 0 ⟧,
+      cf ↦ ⟦
+        φ ↦ Φ.hone.cp-filter,
+        state-acc ↦ ⟦⟧,
+        body-acc ↦ ⟦⟧,
+        class ↦ "Foo",
+        bridge-input ↦ "Ljava/lang/Integer;",
+        bridge-output ↦ "Ljava/lang/Integer;",
+        accepted ↦ "Ljava/lang/Integer;",
+        returned ↦ "Ljava/lang/Integer;",
+        static ↦ "true",
+        target ↦ ⟦ handle ↦ 6, class ↦ "Foo", method ↦ "lambda$run$0", signature ↦ "(Ljava/util/List;Ljava/lang/Integer;)Z", is-interface ↦ Φ.false ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.hone.cp-filter, state-acc ↦ ⟦ 𝜏-d ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧, 𝜏-l ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 0 ⟧, 𝐵-sr ⟧, 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.hone.cp-filter, 𝐵-a, body-acc ↦ ⟦ 𝜏-f ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/util/List" ⟧, 𝐵-br ⟧, 𝐵-c ⟧
+  - ⟦ 𝐵-x, 𝜏-p ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", 𝐵-pr ⟧, 𝜏-cf ↦ ⟦ φ ↦ Φ.hone.cp-filter, 𝐵-cr ⟧, 𝐵-y ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/closure-reference-filter.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/closure-reference-filter.yml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# End-to-end proof that the reference-capture channel reaches the FILTER, the
+# filter mirror of closure-reference.yml (issue #659). The captured value is a
+# REFERENCE — an effectively-final List<Integer> — read inside the filter:
+#
+#   Stream.of(...).filter(n -> base.contains(n)).map(n -> n * 2).reduce(0, ...)
+#
+# The filter captures `base`, so javac compiles its factory descriptor as
+# "(Ljava/util/List;)L…Predicate;" and its SAM instantiated type as
+# "(Ljava/lang/Integer;)Z". 113's new "(L…;)L…Predicate;" interface-guard branch
+# admits the single reference capture and lifts it to a Φ.hone.cp-filter; 119 peels
+# the lone `aload` push, appending the List to the shared state List WITHOUT a box
+# (a reference is already an Object) and reading it back via a `fetch` typed
+# java/util/List (no unbox), the cp-filter mirror of 115. 314 folds a stateful
+# distill and 401 fuses it with the following NON-capturing map (n -> n * 2, empty
+# state). 502/512/521/601 emit one Stream.mapMulti whose wrapper reads the captured
+# List back and calls List.contains() per element — the whole stateful machinery
+# reused verbatim, only the append/fetch lose their box/unbox.
+#
+# invokedynamic: before = filter(capturing) + map + reduce-accumulator lambda = 3;
+# after = the single fused mapMulti + the untouched reduce lambda = 2. The dropped
+# indy is the proof the filter and map collapsed into one dispatch. The runtime
+# line proves the captured List reaches the lambda correctly: base = {2,4,6}, so
+# {1,2,3,4,5} -> keep {2,4} -> *2 -> {8} ... sum: 4+8 == 12.
+java: |
+  package fusion;
+  import java.util.*;
+  import java.util.stream.*;
+  public class CF {
+    static int run(List<Integer> base) {
+      return Stream.of(1, 2, 3, 4, 5)
+        .filter(n -> base.contains(n))
+        .map(n -> n * 2)
+        .reduce(0, (a, b) -> a + b);
+    }
+    public static void main(String[] args) {
+      System.out.printf("The result is %d%n", run(Arrays.asList(2, 4, 6)));
+    }
+  }
+before:
+  invokedynamic: 3
+after:
+  invokedynamic: 2
+log:
+  - "BUILD SUCCESS"
+  - "The result is 12"


### PR DESCRIPTION
Resolves the reference-capture-filter portion of the `@todo #657:45min` puzzle at `112-capturing-invokedynamic-to-map.phr:69-76` (issue #659).

## What

Generalise the capture channel so a **single reference capture in a `Stream.filter`** fuses just like the reference-capture map already does for `map` (issue #647). Concretely, `filter(n -> base.contains(n)).map(n -> n * 2)` now collapses into one `Stream.mapMulti` dispatch instead of leaving the capturing filter native.

## How

- **`113-capturing-invokedynamic-to-filter.phr`** — the interface guard now also admits a `(L…;)L…Predicate;` factory descriptor (one reference capture) via an `or`, alongside the existing `(I+)` int-capture branch. This mirrors `112`'s int/reference split for the map.
- **`119-cp-filter-peel-reference.phr`** *(new)* — the `cp-filter` mirror of `115`: it peels the lone `aload` push into the shared state `List` with **no box/unbox** (a reference is already an `Object`) and reads it back via a bare `Φ.hone.fetch` typed with the capture's class (sed-extracted from the target signature's first `L`-slot).
- `314`/`401`/`502`/`512`/`521`/`601` fold and emit it as one `Stream.mapMulti`, reusing the existing stateful machinery verbatim — no edits needed there.

A lone reference-capture filter is left as a standalone `mapMulti` (444 is closed on the int single-capture park/reload body), consistent with how a lone multi-capture filter is handled today.

The puzzle text is removed; the genuinely remaining work (a category-2 `J`/`D` capture in the filter, a mixed/multi-reference capture run needing positional type extraction, and the lone-multi-capture-filter revert) is re-filed as a smaller `@todo #659:45min` in `112`'s header.

## Tests

- `src/test/phino/113-capturing-invokedynamic-to-filter-reference.yml` — proves the widened guard lifts a `(L…;)L…Predicate;` indy to a `Φ.hone.cp-filter`.
- `src/test/phino/119-cp-filter-peel-reference.yml` — proves the new peeler folds the reference push into the shared List.
- `src/test/resources/org/eolang/hone/optimize/streams/closure-reference-filter.yml` — end-to-end fixture (invokedynamic 3 → 2, runtime result `12`), the filter mirror of `closure-reference.yml`.

### Verification notes

Both new phino unit packs (and all pre-existing packs that touch the capture channel — `113`/`114`/`115`/`116`/`117`/`118`/`314`/`316`/`443`/`444`/`445`) pass against a locally-built `phino 0.0.0.73`. The e2e fixture's `before` invokedynamic count (3) and runtime output (`The result is 12`) were verified directly with `javac`/`java`; the `after` count (2) follows the exact structure of the already-green `closure-reference.yml` (one capturing op + one non-capturing op fuse to a single `mapMulti`, the `reduce` lambda stays native).

https://claude.ai/code/session_01SfPJA9EzC2bsr1hA17pvZr

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfPJA9EzC2bsr1hA17pvZr)_