### PR TITLE
#661 Category-2 (J/D) captures in the filter channel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,10 +180,10 @@ capturing map (N prim OR 1 ref)  → 112 → 114 (int) / 116 (long) / 117 (doubl
                                     map if unfused (multi-capture, category-2 and
                                     lone-ref stay mapMulti)
 capturing filter (N prim)        → 113 → 118 (int) / 120 (long) / 122 (double)
-                                    → 314 → c-filter state distill; 444 reverts a
-                                    LONE single-int-capture filter to invokedynamic
-                                    if unfused (multi-capture, category-2 stay
-                                    mapMulti)
+                                    → 314 → c-filter state distill; 444
+                                    reverts a LONE single-int-capture filter
+                                    to invokedynamic if unfused (multi-capture,
+                                    category-2 stay mapMulti)
 ```
 
 `401-fuse` is the only fuser: it matches two adjacent `Φ.hone.distill`
@@ -583,22 +583,23 @@ guard admits one or more long/double captures (and mixed int/long/double runs),
 map is not reverted by `443` (closed on the int box/unbox shape), so it is emitted
 as a standalone `mapMulti`, like the lone-reference and lone-multi-capture maps.
 
-The multi-capture FILTER is **done** (issue #655): `113`'s `\([IJD]+\)` guard admits
-one or more primitive captures, `118` peels the int pushes (`120`/`122` the long /
-double ones, issue #661) into the shared List, and `314` folds them with the same
-N-ary park/reload body as a capturing map — the keep-frame stays `503`'s plain
-`Φ.hone.frame-item` because the body keeps the item at the bottom of the stack. So
-`filter(n -> n > lo && n < hi)` fuses with its trailing `mapToInt` into one
-`Stream.mapMultiToInt`; see the `multiFil` case in `streams/closures.yml`. A lone
-multi-capture filter is not reverted by `444` (closed on the single-capture body),
-so it is emitted as a standalone `mapMulti`.
+The multi-capture FILTER is **done** (issue #655): `113`'s `\([IJD]+\)` guard
+admits one or more primitive captures, `118` peels the int pushes (`120`/`122`
+the long / double ones, issue #661) into the shared List, and `314` folds them
+with the same N-ary park/reload body as a capturing map — the keep-frame stays
+`503`'s plain `Φ.hone.frame-item` because the body keeps the item at the bottom
+of the stack. So `filter(n -> n > lo && n < hi)` fuses with its trailing
+`mapToInt` into one `Stream.mapMultiToInt`; see the `multiFil` case in
+`streams/closures.yml`. A lone multi-capture filter is not reverted by `444`
+(closed on the single-capture body), so it is emitted as a standalone
+`mapMulti`.
 
 The category-2 (`J`/`D`) capture FILTER is **done** (issue #661): `113`'s
-`\([IJD]+\)Ljava/util/function/Predicate;` guard admits long/double captures and
-bumps the caller max-stack by 2 exactly as `112` does for the map, `120`/`122` peel
-the `lload`/`dload` pushes with `Long`/`Double` box/unbox (the `cp-filter` mirrors of
-`116`/`117`), and `314` folds them into a stateful distill — see
-`streams/closure-long-filter.yml`.
+`\([IJD]+\)Ljava/util/function/Predicate;` guard admits long/double captures
+and bumps the caller max-stack by 2 exactly as `112` does for the map,
+`120`/`122` peel the `lload`/`dload` pushes with `Long`/`Double` box/unbox (the
+`cp-filter` mirrors of `116`/`117`), and `314` folds them into a stateful
+distill — see `streams/closure-long-filter.yml`.
 
 Deferred puzzles (each extends the same shared-List channel): the
 lone-multi-capture map/filter revert (above); a MULTI-reference /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,10 +179,11 @@ capturing map (N prim OR 1 ref)  → 112 → 114 (int) / 116 (long) / 117 (doubl
                                     distill; 443 reverts a lone single-int-capture
                                     map if unfused (multi-capture, category-2 and
                                     lone-ref stay mapMulti)
-capturing filter (N int)         → 113 → 118 → 314 → c-filter state distill;
-                                    444 reverts a LONE single-int-capture filter
-                                    to invokedynamic if unfused (multi-capture
-                                    stays mapMulti)
+capturing filter (N prim)        → 113 → 118 (int) / 120 (long) / 122 (double)
+                                    → 314 → c-filter state distill; 444 reverts a
+                                    LONE single-int-capture filter to invokedynamic
+                                    if unfused (multi-capture, category-2 stay
+                                    mapMulti)
 ```
 
 `401-fuse` is the only fuser: it matches two adjacent `Φ.hone.distill`
@@ -533,8 +534,10 @@ captures over Integer):
   keep-frame needed. The `"c-filter"` start label keeps `431`/`281` away. `444`
   reverts a LONE single-capture filter (closed on the single-capture park/reload
   body); a lone multi-capture filter is emitted as a standalone mapMulti, exactly
-  as `443` leaves a lone multi-capture map. A category-2/reference capture in a
-  filter stays native (its `116`/`117`/`115` peeler twins are a follow-up puzzle).
+  as `443` leaves a lone multi-capture map. A category-2 (`J`/`D`) capture in a
+  filter is now done (issue #661): `120`/`122` are the `cp-filter` mirrors of
+  `116`/`117` and `113` bumps the caller max-stack by 2 exactly as `112` does for
+  the map (a single reference capture, `119`, was done earlier in #659).
 - `401` fuses two capturing distills exactly like two `distinct`s: `join`
   concatenates the boxed appends into the List (slots in body order) and the
   two bodies in order, so guard *k*'s fetch reads slot *k*. `502`/`512`/`521`
@@ -580,22 +583,30 @@ guard admits one or more long/double captures (and mixed int/long/double runs),
 map is not reverted by `443` (closed on the int box/unbox shape), so it is emitted
 as a standalone `mapMulti`, like the lone-reference and lone-multi-capture maps.
 
-The multi-capture FILTER is **done** (issue #655): `113`'s `\(I+\)` guard admits
-one or more int captures, `118` peels them into the shared List, and `314` folds
-them with the same N-ary park/reload body as a capturing map — the keep-frame
-stays `503`'s plain `Φ.hone.frame-item` because the body keeps the item at the
-bottom of the stack. So `filter(n -> n > lo && n < hi)` fuses with its trailing
-`mapToInt` into one `Stream.mapMultiToInt`; see the `multiFil` case in
-`streams/closures.yml`. A lone multi-capture filter is not reverted by `444`
-(closed on the single-capture body), so it is emitted as a standalone `mapMulti`.
+The multi-capture FILTER is **done** (issue #655): `113`'s `\([IJD]+\)` guard admits
+one or more primitive captures, `118` peels the int pushes (`120`/`122` the long /
+double ones, issue #661) into the shared List, and `314` folds them with the same
+N-ary park/reload body as a capturing map — the keep-frame stays `503`'s plain
+`Φ.hone.frame-item` because the body keeps the item at the bottom of the stack. So
+`filter(n -> n > lo && n < hi)` fuses with its trailing `mapToInt` into one
+`Stream.mapMultiToInt`; see the `multiFil` case in `streams/closures.yml`. A lone
+multi-capture filter is not reverted by `444` (closed on the single-capture body),
+so it is emitted as a standalone `mapMulti`.
+
+The category-2 (`J`/`D`) capture FILTER is **done** (issue #661): `113`'s
+`\([IJD]+\)Ljava/util/function/Predicate;` guard admits long/double captures and
+bumps the caller max-stack by 2 exactly as `112` does for the map, `120`/`122` peel
+the `lload`/`dload` pushes with `Long`/`Double` box/unbox (the `cp-filter` mirrors of
+`116`/`117`), and `314` folds them into a stateful distill — see
+`streams/closure-long-filter.yml`.
 
 Deferred puzzles (each extends the same shared-List channel): the
 lone-multi-capture map/filter revert (above); a MULTI-reference /
-mixed-with-reference capture run (needs positional capture-type extraction); a
-category-2 (`J`/`D`) or reference capture in a FILTER (its `116`/`117`/`115`
-peeler twins); `this`-field captures; and capturing `peek`/`mapToX`. See the
+mixed-with-reference capture run (needs positional capture-type extraction);
+`this`-field captures; and capturing `peek`/`mapToX`. See the
 puzzle marker in `112`'s header. (The lone-reference-map revert is **done** via
-`445`.)
+`445`; a category-2 or reference capture in a FILTER is **done** via `120`/`122`
+and `119`.)
 
 ## phino: the only rewrite engine
 

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
@@ -74,14 +74,25 @@
 # reference-capture filter is not reverted (444 is closed on the int single-capture
 # body), so it is emitted as a standalone mapMulti, like a lone multi-capture filter.
 #
-# @todo #659:45min Generalise the CAPTURE channel further: a MIXED multi-capture
+# The category-2 (J/D) capture FILTER is now done (issue #661): 113's relaxed
+# "([IJD]+)L…Predicate;" interface guard admits one or more long/double captures and
+# bumps the caller max-stack by 2 exactly as this rule does for the map, the new 120
+# / 122 peel the lload/dload pushes with Long/Double box/unbox (the cp-filter mirrors
+# of 116/117), and 314 folds them into a stateful distill with the same N-ary
+# park/reload body — so `filter(n -> n > x)` over a captured long fuses exactly like
+# the category-2 map; see streams/closure-long-filter.yml. A lone single
+# long/double-capture filter is not reverted by 444 (closed on the int box/unbox
+# shape), so it is emitted as a standalone mapMulti, like the lone-reference and
+# lone-multi-capture filters.
+#
+# @todo #661:45min Generalise the CAPTURE channel further: a MIXED multi-capture
 #  run that contains a reference (only a SINGLE lone reference is admitted today,
 #  in both the map (115) and the filter (119), because each reads the capture type
 #  out of target.signature's first L-type — a multi-reference run needs positional
-#  type extraction). Still native in the FILTER channel too: a category-2 (J/D)
-#  capture (its 116/117 peeler twins) and the lone-multi-capture-filter revert (444
-#  is closed on the single-capture park/reload body, so a lone multi-capture filter
-#  is emitted as a standalone mapMulti). Each extends the same shared-List channel.
+#  type extraction). Also still deferred: the lone-multi-capture-MAP/FILTER revert
+#  (443/444 are closed on the single-capture park/reload body, so a lone multi-capture
+#  map or filter is emitted as a standalone mapMulti rather than reverted to its
+#  native invokedynamic). Each extends the same shared-List channel.
 name: capturing-invokedynamic-to-map
 pattern: |
   ⟦

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/113-capturing-invokedynamic-to-filter.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/113-capturing-invokedynamic-to-filter.phr
@@ -17,17 +17,21 @@
 # the static lambda$ (int…, Integer) signature wants — the same N-ary shape 316
 # gives a capturing map.
 #
-# Scope: one OR MORE category-1 INT captures (factory descriptor "(I+)L…Predicate;",
-# every push a constant-index iload, gathered by 118) OR a SINGLE reference capture
-# (factory descriptor "(L…;)L…Predicate;", push an aload, gathered by the reference
-# branch 119), over a Stream<Integer> predicate (instantiated type
+# Scope: one OR MORE category-1/2 PRIMITIVE captures (factory descriptor
+# "([IJD]+)L…Predicate;", every push a constant-index iload/lload/dload, gathered by
+# 118 for int and by its category-2 twins 120/122 for long/double) OR a SINGLE
+# reference capture (factory descriptor "(L…;)L…Predicate;", push an aload, gathered
+# by the reference branch 119), over a Stream<Integer> predicate (instantiated type
 # "(Ljava/lang/Integer;)Z"), a handle-6 static lambda$ target. So `filter(n -> n > t)`
-# (one int capture), `filter(n -> n > lo && n < hi)` (two int captures) and
+# (one int capture), `filter(n -> n > lo && n < hi)` (two int captures),
+# `filter(n -> n > x)` over a captured long (one J capture) and
 # `filter(n -> base.contains(n))` (one reference capture) all fuse exactly like the
-# original single-capture case, the filter mirror of 112's int/reference map split.
-# A category-2 (J/D) capture in a filter stays native — its peeler twins (116/117 for
-# the map) are a follow-up puzzle; see 112's header for the shared deferred
-# generalisations.
+# original single-capture case, the filter mirror of 112's primitive/reference map
+# split. A category-2 (J/D) capture occupies two stack slots, so its relocated boxing
+# append (120/122) peaks one slot higher than an int's; this rule BUMPS the caller
+# max-stack by 2 whenever the factory descriptor carries a J or D capture, exactly as
+# 112 does for the map (see 112's header for the rationale and the still-deferred
+# generalisations).
 name: capturing-invokedynamic-to-filter
 pattern: |
   ⟦
@@ -51,7 +55,11 @@ pattern: |
       descriptor ↦ 𝑒-method-descriptor,
       signature ↦ 𝑒-method-signature,
       exceptions ↦ 𝑒-method-exceptions,
-      maxs ↦ 𝑒-method-maxs,
+      maxs ↦ ⟦
+        φ ↦ Φ.jeo.maxs,
+        𝜏-max-stack ↦ 𝑒-max-stack,
+        𝜏-max-locals ↦ 𝑒-max-locals
+      ⟧,
       params ↦ 𝑒-method-params,
       annotations ↦ 𝑒-annotations,
       body ↦ ⟦
@@ -128,7 +136,11 @@ result: |
       descriptor ↦ 𝑒-method-descriptor,
       signature ↦ 𝑒-method-signature,
       exceptions ↦ 𝑒-method-exceptions,
-      maxs ↦ 𝑒-method-maxs,
+      maxs ↦ ⟦
+        φ ↦ Φ.jeo.maxs,
+        𝜏-max-stack ↦ 𝑒-bumped-stack,
+        𝜏-max-locals ↦ 𝑒-max-locals
+      ⟧,
       params ↦ 𝑒-method-params,
       annotations ↦ 𝑒-annotations,
       body ↦ ⟦
@@ -166,11 +178,35 @@ when:
         - 𝑒-target-method
     - or:
         - matches:
-            - '\(I+\)Ljava/util/function/Predicate;'
+            - '\([IJD]+\)Ljava/util/function/Predicate;'
             - 𝑒-interface
         - matches:
             - '\(L[^;]+;\)Ljava/util/function/Predicate;'
             - 𝑒-interface
 where:
+  # Bump the caller max-stack by 2 when a category-2 (J/D) primitive capture is
+  # present (its relocated 2-slot boxing append, 120/122, peaks one slot higher
+  # than an int append); an int-only or reference capture bumps by 0. The same
+  # machinery 112 uses for the capturing map — see its header for the rationale.
+  - meta: 𝑒-cap-params
+    function: sed
+    args:
+      - 𝑒-interface
+      - '"s/[(]//"'
+      - '"s/[)].*//"'
+      - '"s/L[^;]*;//g"'
+  - meta: 𝑒-bump-str
+    function: sed
+    args:
+      - 𝑒-cap-params
+      - '"s/.*[JD].*/2/"'
+      - '"s/^[^2].*$/0/"'
+      - '"s/^$/0/"'
+  - meta: 𝑒-bump
+    function: number
+    args: [𝑒-bump-str]
+  - meta: 𝑒-bumped-stack
+    function: sum
+    args: [𝑒-max-stack, 𝑒-bump]
   - meta: 𝜏-cp-filter
     function: random-tau

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/120-cp-filter-peel-long.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/120-cp-filter-peel-long.phr
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The cp-filter twin of 116 (the category-2 LONG c-map peeler). Peels a captured
+# long (`lload`) push off a Φ.hone.cp-filter and folds it into the operator's
+# shared-List state, exactly as 116 does for a Φ.hone.c-map and 118 does for an int
+# cp-filter capture. 113's relaxed "([IJD]+)L…Predicate;" interface guard now admits
+# a long capture (bumping the caller max-stack by 2), leaving the run of pushes
+# inline in front of the cp-filter; 118 peels the int (`iload`) pushes, this rule the
+# long (`lload`) pushes, and 122 the double (`dload`) pushes — the three interleave
+# at fixpoint on their own opcode, so a mixed int/long/double capture run is gathered
+# in the right left-to-right order exactly as 116/118 document.
+#
+# state-acc gains one boxing append `dup; lload k; Long.valueOf; List.add; pop`. A
+# long is two slots, so this append peaks one slot higher than 118's int append; 113
+# already bumped the caller max-stack by 2 to absorb it. body-acc gains one `fetch;
+# longValue` (521 turns the fetch into List.get(counter++); checkcast java/lang/Long
+# at emit, the longValue unboxes it). 314 wraps the finished body-acc into the
+# park/reload predicate guard, leaving the unboxed long below the reloaded item
+# exactly as the static lambda$ (long…, Integer)Z signature wants.
+name: cp-filter-peel-long
+pattern: |
+  ⟦
+    𝐵-h,
+    𝜏-ll ↦ ⟦ φ ↦ Φ.jeo.opcode.lload, 𝐵-llr ⟧,
+    𝜏-cf ↦ ⟦
+      φ ↦ Φ.hone.cp-filter,
+      state-acc ↦ ⟦ 𝐵-sacc, ρ ↦ ∅ ⟧,
+      body-acc ↦ ⟦ 𝐵-bacc, ρ ↦ ∅ ⟧,
+      𝐵-cf-tail
+    ⟧,
+    𝐵-t
+  ⟧
+result: |
+  ⟦
+    𝐵-h,
+    𝜏-cf ↦ ⟦
+      φ ↦ Φ.hone.cp-filter,
+      state-acc ↦ ⟦
+        𝜏-dup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+        𝜏-load ↦ ⟦ φ ↦ Φ.jeo.opcode.lload, 𝐵-llr ⟧,
+        𝜏-box ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokestatic,
+          i2 ↦ "java/lang/Long",
+          i3 ↦ "valueOf",
+          i4 ↦ "(J)Ljava/lang/Long;",
+          i5 ↦ Φ.false
+        ⟧,
+        𝜏-add ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          i2 ↦ "java/util/List",
+          i3 ↦ "add",
+          i4 ↦ "(Ljava/lang/Object;)Z",
+          i5 ↦ Φ.true
+        ⟧,
+        𝜏-pop ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+        𝐵-sacc,
+        ρ ↦ ∅
+      ⟧,
+      body-acc ↦ ⟦
+        𝜏-fetch ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Long" ⟧,
+        𝜏-lv ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokevirtual,
+          i1 ↦ "java/lang/Long",
+          i2 ↦ "longValue",
+          i3 ↦ "()J",
+          i4 ↦ Φ.false
+        ⟧,
+        𝐵-bacc,
+        ρ ↦ ∅
+      ⟧,
+      𝐵-cf-tail
+    ⟧,
+    𝐵-t
+  ⟧
+where:
+  - meta: 𝜏-dup
+    function: random-tau
+  - meta: 𝜏-load
+    function: random-tau
+  - meta: 𝜏-box
+    function: random-tau
+  - meta: 𝜏-add
+    function: random-tau
+  - meta: 𝜏-pop
+    function: random-tau
+  - meta: 𝜏-fetch
+    function: random-tau
+  - meta: 𝜏-lv
+    function: random-tau

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/122-cp-filter-peel-double.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/122-cp-filter-peel-double.phr
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The cp-filter twin of 117 (the category-2 DOUBLE c-map peeler). Peels a captured
+# double (`dload`) push off a Φ.hone.cp-filter, exactly as 120 peels a long, swapping
+# the boxing to Double.valueOf and the unboxing to doubleValue. 118 (int), 120 (long)
+# and this rule interleave at fixpoint on their own opcode, so a mixed int/long/double
+# capture run feeding a filter is gathered in left-to-right order, the filter mirror
+# of how 114/116/117 gather a capturing map's run.
+#
+# state-acc gains `dup; dload k; Double.valueOf; List.add; pop` (a double is two
+# slots, so the append peaks one slot higher than 118's int append; 113 already
+# bumped the caller max-stack by 2). body-acc gains `fetch; doubleValue` (521
+# resolves the fetch to List.get(counter++); checkcast java/lang/Double; the
+# doubleValue unboxes it). 314 wraps it into the park/reload predicate guard, leaving
+# the unboxed double below the reloaded item exactly as the static lambda$
+# (double…, Integer)Z signature wants.
+name: cp-filter-peel-double
+pattern: |
+  ⟦
+    𝐵-h,
+    𝜏-dl ↦ ⟦ φ ↦ Φ.jeo.opcode.dload, 𝐵-dlr ⟧,
+    𝜏-cf ↦ ⟦
+      φ ↦ Φ.hone.cp-filter,
+      state-acc ↦ ⟦ 𝐵-sacc, ρ ↦ ∅ ⟧,
+      body-acc ↦ ⟦ 𝐵-bacc, ρ ↦ ∅ ⟧,
+      𝐵-cf-tail
+    ⟧,
+    𝐵-t
+  ⟧
+result: |
+  ⟦
+    𝐵-h,
+    𝜏-cf ↦ ⟦
+      φ ↦ Φ.hone.cp-filter,
+      state-acc ↦ ⟦
+        𝜏-dup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+        𝜏-load ↦ ⟦ φ ↦ Φ.jeo.opcode.dload, 𝐵-dlr ⟧,
+        𝜏-box ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokestatic,
+          i2 ↦ "java/lang/Double",
+          i3 ↦ "valueOf",
+          i4 ↦ "(D)Ljava/lang/Double;",
+          i5 ↦ Φ.false
+        ⟧,
+        𝜏-add ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          i2 ↦ "java/util/List",
+          i3 ↦ "add",
+          i4 ↦ "(Ljava/lang/Object;)Z",
+          i5 ↦ Φ.true
+        ⟧,
+        𝜏-pop ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+        𝐵-sacc,
+        ρ ↦ ∅
+      ⟧,
+      body-acc ↦ ⟦
+        𝜏-fetch ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Double" ⟧,
+        𝜏-dv ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokevirtual,
+          i1 ↦ "java/lang/Double",
+          i2 ↦ "doubleValue",
+          i3 ↦ "()D",
+          i4 ↦ Φ.false
+        ⟧,
+        𝐵-bacc,
+        ρ ↦ ∅
+      ⟧,
+      𝐵-cf-tail
+    ⟧,
+    𝐵-t
+  ⟧
+where:
+  - meta: 𝜏-dup
+    function: random-tau
+  - meta: 𝜏-load
+    function: random-tau
+  - meta: 𝜏-box
+    function: random-tau
+  - meta: 𝜏-add
+    function: random-tau
+  - meta: 𝜏-pop
+    function: random-tau
+  - meta: 𝜏-fetch
+    function: random-tau
+  - meta: 𝜏-dv
+    function: random-tau

--- a/src/test/phino/120-cp-filter-peel-long.yml
+++ b/src/test/phino/120-cp-filter-peel-long.yml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 120 is the category-2 LONG twin of 118, the cp-filter mirror of 116. The input
+# mimics 113's output: a Φ.hone.cp-filter with two EMPTY accumulators, preceded by
+# two lload pushes (x at slot v0=0, y at slot v0=2 — a long occupies two local
+# slots) and bounded on the left by the previous operator's invokeinterface.
+# Re-applied at fixpoint, 120 peels the lloads right-to-left and PREPENDS one unit
+# per capture, so state-acc ends up appending x THEN y (slot 0 = x) with a
+# Long.valueOf box and body-acc gets two `fetch; longValue` pairs.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/1xx/120-cp-filter-peel-long.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      p ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "filter", v2 ↦ "(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;", v3 ↦ Φ.true ⟧,
+      x ↦ ⟦ φ ↦ Φ.jeo.opcode.lload, v0 ↦ 0 ⟧,
+      y ↦ ⟦ φ ↦ Φ.jeo.opcode.lload, v0 ↦ 2 ⟧,
+      cf ↦ ⟦
+        φ ↦ Φ.hone.cp-filter,
+        state-acc ↦ ⟦⟧,
+        body-acc ↦ ⟦⟧,
+        class ↦ "Foo",
+        bridge-input ↦ "Ljava/lang/Integer;",
+        bridge-output ↦ "Ljava/lang/Integer;",
+        accepted ↦ "Ljava/lang/Integer;",
+        returned ↦ "Ljava/lang/Integer;",
+        static ↦ "true",
+        target ↦ ⟦ handle ↦ 6, class ↦ "Foo", method ↦ "lambda$run$0", signature ↦ "(JJLjava/lang/Integer;)Z", is-interface ↦ Φ.false ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.hone.cp-filter, state-acc ↦ ⟦ 𝜏-d ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧, 𝜏-l ↦ ⟦ φ ↦ Φ.jeo.opcode.lload, v0 ↦ 0 ⟧, 𝜏-b ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "java/lang/Long", 𝐵-bx ⟧, 𝐵-sr ⟧, 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.hone.cp-filter, 𝐵-a, body-acc ↦ ⟦ 𝜏-f1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Long" ⟧, 𝜏-lv ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, i1 ↦ "java/lang/Long", 𝐵-lv ⟧, 𝜏-f2 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Long" ⟧, 𝐵-br ⟧, 𝐵-c ⟧
+  - ⟦ 𝐵-x, 𝜏-p ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", 𝐵-pr ⟧, 𝜏-cf ↦ ⟦ φ ↦ Φ.hone.cp-filter, 𝐵-cr ⟧, 𝐵-y ⟧

--- a/src/test/phino/122-cp-filter-peel-double.yml
+++ b/src/test/phino/122-cp-filter-peel-double.yml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 122 is the category-2 DOUBLE twin of 118/120, the cp-filter mirror of 117. The
+# input mimics 113's output: a Φ.hone.cp-filter with two EMPTY accumulators,
+# preceded by a single dload push and bounded on the left by the previous operator's
+# invokeinterface. 122 peels the dload, PREPENDING a `dup; dload; Double.valueOf;
+# List.add; pop` boxing append to state-acc and a `fetch; doubleValue` pair to
+# body-acc.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/1xx/122-cp-filter-peel-double.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      p ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "filter", v2 ↦ "(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;", v3 ↦ Φ.true ⟧,
+      x ↦ ⟦ φ ↦ Φ.jeo.opcode.dload, v0 ↦ 0 ⟧,
+      cf ↦ ⟦
+        φ ↦ Φ.hone.cp-filter,
+        state-acc ↦ ⟦⟧,
+        body-acc ↦ ⟦⟧,
+        class ↦ "Foo",
+        bridge-input ↦ "Ljava/lang/Integer;",
+        bridge-output ↦ "Ljava/lang/Integer;",
+        accepted ↦ "Ljava/lang/Integer;",
+        returned ↦ "Ljava/lang/Integer;",
+        static ↦ "true",
+        target ↦ ⟦ handle ↦ 6, class ↦ "Foo", method ↦ "lambda$run$0", signature ↦ "(DLjava/lang/Integer;)Z", is-interface ↦ Φ.false ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.hone.cp-filter, state-acc ↦ ⟦ 𝜏-d ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧, 𝜏-l ↦ ⟦ φ ↦ Φ.jeo.opcode.dload, v0 ↦ 0 ⟧, 𝜏-b ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "java/lang/Double", 𝐵-bx ⟧, 𝐵-sr ⟧, 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.hone.cp-filter, 𝐵-a, body-acc ↦ ⟦ 𝜏-f1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Double" ⟧, 𝜏-dv ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, i1 ↦ "java/lang/Double", 𝐵-dv ⟧, 𝐵-br ⟧, 𝐵-c ⟧
+  - ⟦ 𝐵-x, 𝜏-cf ↦ ⟦ φ ↦ Φ.hone.cp-filter, 𝐵-cr ⟧, 𝐵-y ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/closure-long-filter.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/closure-long-filter.yml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# End-to-end proof that the category-2 capture channel reaches the FILTER, the
+# filter mirror of closure-long.yml (the deferred half of issue #659). The captured
+# value is a CATEGORY-2 long — an effectively-final `long` parameter — read inside
+# the filter:
+#
+#   Stream.of(...).filter(n -> n > x).map(n -> n * 2).reduce(0, ...)
+#
+# The filter captures `x`, so javac compiles its factory descriptor as
+# "(J)L…Predicate;" and its SAM instantiated type as the type-preserving
+# "(Ljava/lang/Integer;)Z". 113's relaxed "\([IJD]+\)" interface-guard branch admits
+# the long capture and lifts it to a Φ.hone.cp-filter, bumping the caller max-stack
+# by 2 (a J capture's two-slot boxing append peaks one slot higher than an int's).
+# 120 peels the lone `lload` push, appending the long to the shared state List with a
+# Long.valueOf box and reading it back via a `fetch` typed java/lang/Long followed by
+# longValue. 314 folds a stateful distill and 401 fuses it with the following
+# NON-capturing map (n -> n * 2, empty state). 502/512/521/601 emit one
+# Stream.mapMulti whose wrapper reads the captured long back and tests it per element
+# — the whole stateful machinery reused verbatim, only the append/fetch box/unbox via
+# Long instead of Integer.
+#
+# invokedynamic: before = filter(capturing) + map + reduce-accumulator lambda = 3;
+# after = the single fused mapMulti + the untouched reduce lambda = 2. The dropped
+# indy is the proof the filter and map collapsed into one dispatch. The runtime line
+# proves the captured long reaches the lambda correctly: x == 2, so
+# {1,2,3,4,5} -> keep {3,4,5} -> *2 -> {6,8,10} -> sum == 24.
+java: |
+  package fusion;
+  import java.util.*;
+  import java.util.stream.*;
+  public class C {
+    static int run(long x) {
+      return Stream.of(1, 2, 3, 4, 5)
+        .filter(n -> n > x)
+        .map(n -> n * 2)
+        .reduce(0, (a, b) -> a + b);
+    }
+    public static void main(String[] args) {
+      System.out.printf("The result is %d%n", run(2L));
+    }
+  }
+before:
+  invokedynamic: 3
+after:
+  invokedynamic: 2
+log:
+  - "BUILD SUCCESS"
+  - "The result is 24"


### PR DESCRIPTION
Resolves the `@todo #659` puzzle in `112-capturing-invokedynamic-to-map.phr:77-84` (issue #661).

## What

Generalise the capturing-**filter** channel to admit category-2 (`long`/`double`) primitive captures, mirroring the already-supported capturing-**map** channel. So `filter(n -> n > x)` over a captured `long`/`double` now fuses into one `Stream.mapMulti` exactly like the category-2 map.

## Changes

- **`113-capturing-invokedynamic-to-filter.phr`** — relaxed the factory-descriptor interface guard from `\(I+\)Ljava/util/function/Predicate;` to `\([IJD]+\)Ljava/util/function/Predicate;`, and added the same max-stack `+2` bump machinery that `112` uses (a two-slot `J`/`D` boxing append peaks one slot higher than an `int`'s; jeo never recomputes maxs).
- **`120-cp-filter-peel-long.phr`** / **`122-cp-filter-peel-double.phr`** — new peelers, the `cp-filter` mirrors of `116`/`117`. They peel the `lload`/`dload` pushes into the shared state `List` with `Long`/`Double` `valueOf`/`xxxValue` box/unbox. `314` folds them into a stateful distill with the existing N-ary park/reload body — no edits needed to `314`/`401`/`502`/`512`/`521`/`601`.
- **Tests** — unit packs `src/test/phino/120-…yml`, `122-…yml`, and the end-to-end fixture `src/test/resources/org/eolang/hone/optimize/streams/closure-long-filter.yml` (long-capture filter fuses with a following map: invokedynamic `3 → 2`, runtime result `24`).
- **Docs** — removed the resolved `@todo #659` text; documented the fix and re-filed the genuinely-remaining items (mixed multi-reference capture run; lone-multi-capture map/filter revert) as a new `@todo #661` in `112`'s header and in `CLAUDE.md`.

## Verification

`mvn test` (non-deep) and `mvn test-compile` pass locally. The deep, phino-backed packs (`mvn -Pdeep test`) require the pinned `phino` binary, which isn't preinstalled in this environment; I'm building it locally to verify, and CI runs the `deep` profile regardless. The new rules are direct structural mirrors of the already-tested map-side machinery (`112`/`116`/`117`).

https://claude.ai/code/session_01VhWFp5RoEWFdmLbEZRVBcK

---
_Generated by [Claude Code](https://claude.ai/code/session_01VhWFp5RoEWFdmLbEZRVBcK)_