### PR TITLE
#663 Revert lone two-capture map/filter to native invokedynamic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,12 +177,14 @@ skip                             → 220 → 308 → state distill;
 capturing map (N prim OR 1 ref)  → 112 → 114 (int) / 116 (long) / 117 (double)
                                     / 115 (ref peeler) → 316 → c-map state
                                     distill; 443 reverts a lone single-int-capture
-                                    map if unfused (multi-capture, category-2 and
-                                    lone-ref stay mapMulti)
+                                    map and 446 a lone TWO-int-capture map if
+                                    unfused (3+-capture, category-2 and lone-ref
+                                    stay mapMulti)
 capturing filter (N prim)        → 113 → 118 (int) / 120 (long) / 122 (double)
                                     → 314 → c-filter state distill; 444
-                                    reverts a LONE single-int-capture filter
-                                    to invokedynamic if unfused (multi-capture,
+                                    reverts a LONE single-int-capture filter and
+                                    447 a lone TWO-int-capture filter to
+                                    invokedynamic if unfused (3+-capture,
                                     category-2 stay mapMulti)
 ```
 
@@ -552,10 +554,17 @@ captures over Integer):
   `Stream.{map,filter}`, replaying the push and marking the call
   `reverted ↦ Φ.true` so `112`/`113` cannot re-lift it (closed patterns plus
   the marker, the same loop-break `442` uses). `443`/`444` both match the
-  park/reload single-capture body. A LONE multi-capture map OR filter (two or
-  more appends) fails that closed pattern and is emitted as a standalone
-  `mapMulti` — correct, only marginally slower than native, and rarer than a lone
-  single-capture operator; reverting it (replaying N pushes, rebuilding the
+  park/reload single-capture body. `446`/`447` are their TWO-capture twins
+  (issue #663): a LONE two-int-capture map or filter (e.g. `map(n -> n + p + q)`,
+  `filter(n -> n > lo && n < hi)` with no neighbour to fuse) matches a CLOSED
+  state and body of EXACTLY two appends and two fetches, so it reverts to the
+  native `invokedynamic` + `Stream.{map,filter}` with the `(II)` factory
+  descriptor and both pushes replayed, while a fused operator (two
+  park/reload/call triples) cannot match and is left for `502`. A LONE map OR
+  filter with THREE OR MORE captures fails both the single- and two-capture
+  closed patterns and is still emitted as a standalone `mapMulti` — correct, only
+  marginally slower than native, and rarer than a lone one- or two-capture
+  operator; reverting it (an arity-agnostic replay of N pushes rebuilding the
   `(I^N)` descriptor) is a follow-up puzzle.
 
 Other type-preserving element types are **done** (issue #640): `112`'s
@@ -590,9 +599,22 @@ with the same N-ary park/reload body as a capturing map — the keep-frame stays
 `503`'s plain `Φ.hone.frame-item` because the body keeps the item at the bottom
 of the stack. So `filter(n -> n > lo && n < hi)` fuses with its trailing
 `mapToInt` into one `Stream.mapMultiToInt`; see the `multiFil` case in
-`streams/closures.yml`. A lone multi-capture filter is not reverted by `444`
-(closed on the single-capture body), so it is emitted as a standalone
-`mapMulti`.
+`streams/closures.yml`. A lone TWO-capture filter is reverted by `447` (the
+two-capture twin of `444`; see below); a lone filter with three or more captures
+is still emitted as a standalone `mapMulti`.
+
+The lone-TWO-capture revert is **done** (issue #663): `446`/`447` are the
+two-capture twins of `443`/`444`. A lone two-int-capture map or filter that never
+fused — e.g. `map(n -> n + p + q)` ending in a terminal `reduce`, or
+`filter(n -> n > lo && n < hi)` ending in `count` — is reverted to its native
+`invokedynamic` + `Stream.{map,filter}`, replaying BOTH `iload` pushes and the
+`(II)` factory descriptor and marking the call `reverted ↦ Φ.true` so `112`/`113`
+cannot re-lift it. Both rules match a CLOSED state and body of EXACTLY two appends
+and two fetches, so a FUSED operator (two park/reload/call triples) cannot match
+and is left for `502` — the never-touch-a-fused-distill guarantee `443`/`444` get,
+extended by one capture. See the `streams/closure-multi-lone.yml` end-to-end
+fixture. A lone map/filter with THREE OR MORE captures still stays a standalone
+`mapMulti` (a follow-up puzzle).
 
 The category-2 (`J`/`D`) capture FILTER is **done** (issue #661): `113`'s
 `\([IJD]+\)Ljava/util/function/Predicate;` guard admits long/double captures
@@ -602,12 +624,14 @@ and bumps the caller max-stack by 2 exactly as `112` does for the map,
 distill — see `streams/closure-long-filter.yml`.
 
 Deferred puzzles (each extends the same shared-List channel): the
-lone-multi-capture map/filter revert (above); a MULTI-reference /
-mixed-with-reference capture run (needs positional capture-type extraction);
-`this`-field captures; and capturing `peek`/`mapToX`. See the
-puzzle marker in `112`'s header. (The lone-reference-map revert is **done** via
-`445`; a category-2 or reference capture in a FILTER is **done** via `120`/`122`
-and `119`.)
+lone-THREE-OR-MORE-capture map/filter revert (an arity-agnostic revert that
+rebuilds the `(I^N)` descriptor for any N; `446`/`447` close only the
+two-capture case); a MULTI-reference / mixed-with-reference capture run (needs
+positional capture-type extraction); `this`-field captures; and capturing
+`peek`/`mapToX`. See the puzzle marker in `112`'s header. (The lone-reference-map
+revert is **done** via `445`; the lone-two-capture map/filter revert is **done**
+via `446`/`447`; a category-2 or reference capture in a FILTER is **done** via
+`120`/`122` and `119`.)
 
 ## phino: the only rewrite engine
 

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
@@ -85,14 +85,27 @@
 # shape), so it is emitted as a standalone mapMulti, like the lone-reference and
 # lone-multi-capture filters.
 #
-# @todo #661:45min Generalise the CAPTURE channel further: a MIXED multi-capture
+# The lone-TWO-capture revert is now done (issue #663): 446 / 447 are the
+# multi-capture twins of 443 / 444 — a lone two-int-capture map / filter (e.g.
+# `map(n -> n + p + q)` or `filter(n -> n > lo && n < hi)` with no neighbour to
+# fuse, ending in a terminal) is reverted to its native invokedynamic +
+# Stream.{map,filter}, replaying BOTH `iload` pushes and rebuilding the "(II)"
+# factory descriptor. Both rules match EXACTLY two boxing appends and two fetches
+# with a CLOSED state and body, so a FUSED capturing operator (which carries two
+# park/reload/call triples) cannot match and is left for 502 — the same
+# never-touch-a-fused-distill guarantee 443 / 444 get, extended by one capture. See
+# streams/closure-multi-lone.yml.
+#
+# @todo #663:45min Generalise the CAPTURE channel further: a MIXED multi-capture
 #  run that contains a reference (only a SINGLE lone reference is admitted today,
 #  in both the map (115) and the filter (119), because each reads the capture type
 #  out of target.signature's first L-type — a multi-reference run needs positional
-#  type extraction). Also still deferred: the lone-multi-capture-MAP/FILTER revert
-#  (443/444 are closed on the single-capture park/reload body, so a lone multi-capture
-#  map or filter is emitted as a standalone mapMulti rather than reverted to its
-#  native invokedynamic). Each extends the same shared-List channel.
+#  type extraction). Also still deferred: the lone-THREE-OR-MORE-capture map/filter
+#  revert (446/447 are closed on exactly two appends/fetches, so a lone map or
+#  filter with three or more captures is still emitted as a standalone mapMulti
+#  rather than reverted to its native invokedynamic — extending it needs an
+#  arity-agnostic revert that rebuilds the "(I^N)" descriptor for any N). Each
+#  extends the same shared-List channel.
 name: capturing-invokedynamic-to-map
 pattern: |
   ⟦

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/443-unfused-capturing-map-to-invokedynamic.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/443-unfused-capturing-map-to-invokedynamic.phr
@@ -16,10 +16,12 @@
 # FUSED c-map — whose state and body carry a second operator's append and
 # guard — is left for 502. A MULTI-capture lone map (two or more appends, the
 # v1.1 `map(i -> i + x + y)` shape) likewise fails this single-append, single-
-# fetch pattern and is emitted as a standalone mapMulti rather than reverted:
-# correct, only marginally slower than native, and a rarer shape than the lone
-# single-capture map. Reverting it (replaying N pushes and rebuilding the
-# "(I^N)" descriptor) is a follow-up puzzle. The capture-push (𝑒-push) is
+# fetch pattern; the TWO-capture case is reverted by 446 (the multi-capture twin
+# of this rule), and only a lone map with THREE OR MORE captures is still emitted
+# as a standalone mapMulti rather than reverted — correct, only marginally slower
+# than native, and a rarer shape than the lone single- or two-capture map.
+# Reverting that (an arity-agnostic replay of N pushes rebuilding the "(I^N)"
+# descriptor) is a follow-up puzzle. The capture-push (𝑒-push) is
 # recovered from the state and replayed before the indy; the target handle is
 # read from the body's invokestatic. The 𝜑-calculus fields the fold dropped (the Function SAM name,
 # the erased lambda-signature, the captured "(I)" interface) are constants for an

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/444-unfused-capturing-filter-to-invokedynamic.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/444-unfused-capturing-filter-to-invokedynamic.phr
@@ -14,9 +14,11 @@
 # are reconstructed literally for the int-capture Stream<Integer> case. A MULTI-
 # capture lone filter (two or more appends / fetches, e.g. the issue's
 # `filter(n -> n > lo && n < hi)`) fails this single-append, single-fetch closed
-# pattern and is emitted as a standalone mapMulti rather than reverted — correct,
-# only marginally slower than native, exactly as 443 leaves a lone multi-capture
-# map. Reverting it (replaying N pushes, rebuilding the "(I^N)" descriptor) is a
+# pattern; the TWO-capture case is reverted by 447 (the multi-capture twin of this
+# rule), and only a lone filter with THREE OR MORE captures is still emitted as a
+# standalone mapMulti rather than reverted — correct, only marginally slower than
+# native, exactly as 443 leaves a lone three-or-more-capture map. Reverting that
+# (an arity-agnostic replay of N pushes rebuilding the "(I^N)" descriptor) is a
 # follow-up puzzle.
 name: unfused-capturing-filter-to-invokedynamic
 pattern: |

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/446-unfused-multi-capturing-map-to-invokedynamic.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/446-unfused-multi-capturing-map-to-invokedynamic.phr
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The multi-capture twin of 443. Reverts a TWO-int-capture map distill (folded by
+# 316) that never fused back to its native invokedynamic + Stream.map, replaying
+# both capture-pushes and rebuilding the "(II)" factory descriptor. 443 only
+# reverts a LONE single-capture map (its state and body are closed on ONE boxing
+# append and ONE fetch); a lone two-capture map — e.g. `map(n -> n + p + q)` with
+# no neighbour to fuse, as in `loneMultiMap` ending in a terminal `.count()` —
+# fails 443's single-append pattern and used to be emitted as a standalone
+# mapMulti, which is strictly slower than the native Stream.map the JVM already
+# has. This rule closes that gap for the two-capture case.
+#
+# Both the state and the body match are CLOSED (no 𝐵-rest), enumerating EXACTLY
+# two boxing appends and EXACTLY two fetches plus a single park/reload/call. The
+# exact binding count is what makes the revert safe: a FUSED capturing map (two
+# operators joined by 401) carries TWO park/reload/call triples and a longer
+# state, so it cannot match this fixed-length pattern and is left for 502 — the
+# same never-touch-a-fused-distill guarantee 443 gets from its closed pattern,
+# only extended by one capture. A lone map with THREE OR MORE captures fails this
+# two-append pattern and is still emitted as a standalone mapMulti (a follow-up
+# puzzle; see 112's header). Both captured pushes (𝑒-push-a, 𝑒-push-b) are
+# recovered from the state and replayed before the indy in left-to-right order
+# (slot 0 = first capture); the target handle is read from the body's
+# invokestatic. The 𝜑-calculus fields the fold dropped (the Function SAM name,
+# the erased lambda-signature, the captured "(II)" interface) are constants for a
+# two-int-capture map over any reference element type, so they are reconstructed
+# literally; the SAM instantiated type "(LX;)LX;" is rebuilt from the distill's
+# bridge-input/bridge-output, matching 112's element-type-agnostic lift. The
+# reverted Stream.map carries `reverted ↦ Φ.true`: 112's invokeinterface pattern
+# is closed on the four-operand opcode jeo emits, so the fifth binding stops 112
+# re-lifting this map and the 112 → 316 → 446 cycle cannot spin (jeo ignores the
+# extra binding, exactly as for 443's single-capture map).
+name: unfused-multi-capturing-map-to-invokedynamic
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-distill ↦ ⟦
+      φ ↦ Φ.hone.distill,
+      class ↦ 𝑒-class,
+      bridge-input ↦ 𝑒-bridge-input,
+      bridge-output ↦ 𝑒-bridge-output,
+      start ↦ "c-map",
+      accepted ↦ 𝑒-accepted,
+      returned ↦ 𝑒-returned,
+      static ↦ 𝑒-static,
+      state ↦ ⟦
+        𝜏-dup-a ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+        𝜏-load-a ↦ 𝑒-push-a,
+        𝜏-box-a ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokestatic,
+          i2 ↦ "java/lang/Integer",
+          i3 ↦ "valueOf",
+          i4 ↦ "(I)Ljava/lang/Integer;",
+          i5 ↦ Φ.false
+        ⟧,
+        𝜏-add-a ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          i2 ↦ "java/util/List",
+          i3 ↦ "add",
+          i4 ↦ "(Ljava/lang/Object;)Z",
+          i5 ↦ Φ.true
+        ⟧,
+        𝜏-pop-a ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+        𝜏-dup-b ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+        𝜏-load-b ↦ 𝑒-push-b,
+        𝜏-box-b ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokestatic,
+          i2 ↦ "java/lang/Integer",
+          i3 ↦ "valueOf",
+          i4 ↦ "(I)Ljava/lang/Integer;",
+          i5 ↦ Φ.false
+        ⟧,
+        𝜏-add-b ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          i2 ↦ "java/util/List",
+          i3 ↦ "add",
+          i4 ↦ "(Ljava/lang/Object;)Z",
+          i5 ↦ Φ.true
+        ⟧,
+        𝜏-pop-b ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+        ρ ↦ ∅
+      ⟧,
+      body ↦ ⟦
+        𝜏-park ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, i1 ↦ 1 ⟧,
+        𝜏-fetch-a ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
+        𝜏-unbox-a ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokevirtual,
+          i1 ↦ "java/lang/Integer",
+          i2 ↦ "intValue",
+          i3 ↦ "()I",
+          i4 ↦ Φ.false
+        ⟧,
+        𝜏-fetch-b ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
+        𝜏-unbox-b ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokevirtual,
+          i1 ↦ "java/lang/Integer",
+          i2 ↦ "intValue",
+          i3 ↦ "()I",
+          i4 ↦ Φ.false
+        ⟧,
+        𝜏-reload ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
+        𝜏-call ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokestatic,
+          i1 ↦ 𝑒-target-class,
+          i2 ↦ 𝑒-target-method,
+          i3 ↦ 𝑒-target-signature,
+          i4 ↦ 𝑒-target-is-interface
+        ⟧,
+        ρ ↦ ∅
+      ⟧
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-push-back-a ↦ 𝑒-push-a,
+    𝜏-push-back-b ↦ 𝑒-push-b,
+    𝜏-indy ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokedynamic,
+      v0 ↦ "apply",
+      v1 ↦ "(II)Ljava/util/function/Function;",
+      h2 ↦ ⟦
+        φ ↦ Φ.jeo.handle,
+        v0 ↦ 6,
+        v1 ↦ "java/lang/invoke/LambdaMetafactory",
+        v2 ↦ "metafactory",
+        v3 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+        v4 ↦ Φ.false
+      ⟧,
+      t3 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Object;)Ljava/lang/Object;" ⟧,
+      h4 ↦ ⟦
+        φ ↦ Φ.jeo.handle,
+        v0 ↦ 6,
+        v1 ↦ 𝑒-target-class,
+        v2 ↦ 𝑒-target-method,
+        v3 ↦ 𝑒-target-signature,
+        v4 ↦ 𝑒-target-is-interface
+      ⟧,
+      t5 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ 𝑒-instantiated ⟧
+    ⟧,
+    𝜏-map ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      v0 ↦ "java/util/stream/Stream",
+      v1 ↦ "map",
+      v2 ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;",
+      v3 ↦ Φ.true,
+      reverted ↦ Φ.true
+    ⟧,
+    𝐵-after
+  ⟧
+where:
+  - meta: 𝑒-instantiated
+    function: concat
+    args:
+      - '"("'
+      - 𝑒-bridge-input
+      - '")"'
+      - 𝑒-bridge-output
+  - meta: 𝜏-push-back-a
+    function: random-tau
+  - meta: 𝜏-push-back-b
+    function: random-tau
+  - meta: 𝜏-indy
+    function: random-tau
+  - meta: 𝜏-map
+    function: random-tau

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/447-unfused-multi-capturing-filter-to-invokedynamic.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/447-unfused-multi-capturing-filter-to-invokedynamic.phr
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The filter twin of 446 (and the multi-capture twin of 444). Reverts a
+# TWO-int-capture primitive-filter distill (folded by 314) that never fused back
+# to its native invokedynamic + Stream.filter, replaying both capture-pushes and
+# rebuilding the "(II)" factory descriptor. 444 only reverts a LONE single-capture
+# filter (closed on ONE boxing append and ONE fetch); a lone two-capture filter —
+# e.g. `filter(n -> n > lo && n < hi)` with no neighbour to fuse (ending in a
+# terminal such as `.count()`) — fails 444's single-append pattern and used to be
+# emitted as a standalone mapMulti, strictly slower than the native Stream.filter.
+# This rule closes that gap for the two-capture case.
+#
+# Both the state and the body match are CLOSED, enumerating EXACTLY two boxing
+# appends and EXACTLY two fetches plus the single item-preserving dup, park/reload
+# and keep-guard 314 built (dup; astore 1; (fetch; intValue)×2; aload 1; predicate;
+# ifne; return; label; frame-item). The exact binding count is what makes the
+# revert safe: a FUSED filter (two operators joined by 401) carries two
+# park/reload/predicate triples and a longer state, so it cannot match this
+# fixed-length pattern and is left for 502 — the same never-touch-a-fused-distill
+# guarantee 444 gets, extended by one capture. A lone filter with THREE OR MORE
+# captures fails this two-append pattern and is still emitted as a standalone
+# mapMulti (a follow-up puzzle; see 112's header). Both pushes are replayed in
+# left-to-right order; the Predicate SAM constants are reconstructed literally for
+# the two-int-capture Stream<Integer> case, and the reverted Stream.filter carries
+# `reverted ↦ Φ.true` so 113 cannot re-lift it (its invokeinterface pattern is
+# closed, the loop-break 442/443/444 rely on).
+name: unfused-multi-capturing-filter-to-invokedynamic
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-distill ↦ ⟦
+      φ ↦ Φ.hone.distill,
+      class ↦ 𝑒-class,
+      bridge-input ↦ 𝑒-bridge-input,
+      bridge-output ↦ 𝑒-bridge-output,
+      start ↦ "c-filter",
+      accepted ↦ 𝑒-accepted,
+      returned ↦ 𝑒-returned,
+      static ↦ 𝑒-static,
+      state ↦ ⟦
+        𝜏-dup-a ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+        𝜏-load-a ↦ 𝑒-push-a,
+        𝜏-box-a ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokestatic,
+          i2 ↦ "java/lang/Integer",
+          i3 ↦ "valueOf",
+          i4 ↦ "(I)Ljava/lang/Integer;",
+          i5 ↦ Φ.false
+        ⟧,
+        𝜏-add-a ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          i2 ↦ "java/util/List",
+          i3 ↦ "add",
+          i4 ↦ "(Ljava/lang/Object;)Z",
+          i5 ↦ Φ.true
+        ⟧,
+        𝜏-pop-a ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+        𝜏-dup-b ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+        𝜏-load-b ↦ 𝑒-push-b,
+        𝜏-box-b ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokestatic,
+          i2 ↦ "java/lang/Integer",
+          i3 ↦ "valueOf",
+          i4 ↦ "(I)Ljava/lang/Integer;",
+          i5 ↦ Φ.false
+        ⟧,
+        𝜏-add-b ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          i2 ↦ "java/util/List",
+          i3 ↦ "add",
+          i4 ↦ "(Ljava/lang/Object;)Z",
+          i5 ↦ Φ.true
+        ⟧,
+        𝜏-pop-b ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+        ρ ↦ ∅
+      ⟧,
+      body ↦ ⟦
+        𝜏-itemdup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+        𝜏-park ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, i1 ↦ 1 ⟧,
+        𝜏-fetch-a ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
+        𝜏-unbox-a ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokevirtual,
+          i1 ↦ "java/lang/Integer",
+          i2 ↦ "intValue",
+          i3 ↦ "()I",
+          i4 ↦ Φ.false
+        ⟧,
+        𝜏-fetch-b ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
+        𝜏-unbox-b ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokevirtual,
+          i1 ↦ "java/lang/Integer",
+          i2 ↦ "intValue",
+          i3 ↦ "()I",
+          i4 ↦ Φ.false
+        ⟧,
+        𝜏-reload ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
+        𝜏-call ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokestatic,
+          i1 ↦ 𝑒-target-class,
+          i2 ↦ 𝑒-target-method,
+          i3 ↦ 𝑒-target-signature,
+          i4 ↦ 𝑒-target-is-interface
+        ⟧,
+        𝜏-ifne ↦ ⟦
+          φ ↦ Φ.jeo.opcode.ifne,
+          i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label ⟧
+        ⟧,
+        𝜏-return ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+        𝜏-label ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label ⟧,
+        𝜏-frame ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+        ρ ↦ ∅
+      ⟧
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-push-back-a ↦ 𝑒-push-a,
+    𝜏-push-back-b ↦ 𝑒-push-b,
+    𝜏-indy ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokedynamic,
+      v0 ↦ "test",
+      v1 ↦ "(II)Ljava/util/function/Predicate;",
+      h2 ↦ ⟦
+        φ ↦ Φ.jeo.handle,
+        v0 ↦ 6,
+        v1 ↦ "java/lang/invoke/LambdaMetafactory",
+        v2 ↦ "metafactory",
+        v3 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+        v4 ↦ Φ.false
+      ⟧,
+      t3 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Object;)Z" ⟧,
+      h4 ↦ ⟦
+        φ ↦ Φ.jeo.handle,
+        v0 ↦ 6,
+        v1 ↦ 𝑒-target-class,
+        v2 ↦ 𝑒-target-method,
+        v3 ↦ 𝑒-target-signature,
+        v4 ↦ 𝑒-target-is-interface
+      ⟧,
+      t5 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ 𝑒-instantiated ⟧
+    ⟧,
+    𝜏-filter ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      v0 ↦ "java/util/stream/Stream",
+      v1 ↦ "filter",
+      v2 ↦ "(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;",
+      v3 ↦ Φ.true,
+      reverted ↦ Φ.true
+    ⟧,
+    𝐵-after
+  ⟧
+where:
+  - meta: 𝑒-instantiated
+    function: concat
+    args:
+      - '"("'
+      - 𝑒-bridge-input
+      - '")Z"'
+  - meta: 𝜏-push-back-a
+    function: random-tau
+  - meta: 𝜏-push-back-b
+    function: random-tau
+  - meta: 𝜏-indy
+    function: random-tau
+  - meta: 𝜏-filter
+    function: random-tau

--- a/src/test/phino/446-unfused-multi-capturing-map-to-invokedynamic.yml
+++ b/src/test/phino/446-unfused-multi-capturing-map-to-invokedynamic.yml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A two-int-capture map distill that never fused (closed state with EXACTLY two
+# boxing appends and a two-fetch park/reload body) is reverted to the native
+# invokedynamic + Stream.map, replaying BOTH captured pushes (iload 0, iload 1) in
+# left-to-right order, rebuilding the "(II)" factory descriptor and marking the
+# call reverted ↦ Φ.true so 112 cannot re-lift it. This is the never-pessimise
+# guarantee for a lone `map(n -> n + p + q)` — the two-capture analogue of 443.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/4xx/446-unfused-multi-capturing-map-to-invokedynamic.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      op ↦ ⟦
+        φ ↦ Φ.hone.distill,
+        class ↦ "Foo",
+        bridge-input ↦ "Ljava/lang/Integer;",
+        bridge-output ↦ "Ljava/lang/Integer;",
+        start ↦ "c-map",
+        accepted ↦ "Ljava/lang/Integer;",
+        returned ↦ "Ljava/lang/Integer;",
+        static ↦ "true",
+        state ↦ ⟦
+          s1 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+          s2 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 0 ⟧,
+          s3 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "java/lang/Integer", i3 ↦ "valueOf", i4 ↦ "(I)Ljava/lang/Integer;", i5 ↦ Φ.false ⟧,
+          s4 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/List", i3 ↦ "add", i4 ↦ "(Ljava/lang/Object;)Z", i5 ↦ Φ.true ⟧,
+          s5 ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+          s6 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+          s7 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 1 ⟧,
+          s8 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "java/lang/Integer", i3 ↦ "valueOf", i4 ↦ "(I)Ljava/lang/Integer;", i5 ↦ Φ.false ⟧,
+          s9 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/List", i3 ↦ "add", i4 ↦ "(Ljava/lang/Object;)Z", i5 ↦ Φ.true ⟧,
+          s10 ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+          ρ ↦ ∅
+        ⟧,
+        body ↦ ⟦
+          b0 ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, i1 ↦ 1 ⟧,
+          b1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
+          b2 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, i1 ↦ "java/lang/Integer", i2 ↦ "intValue", i3 ↦ "()I", i4 ↦ Φ.false ⟧,
+          b3 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
+          b4 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, i1 ↦ "java/lang/Integer", i2 ↦ "intValue", i3 ↦ "()I", i4 ↦ Φ.false ⟧,
+          b5 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
+          b6 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i1 ↦ "Foo", i2 ↦ "lambda$run$0", i3 ↦ "(IILjava/lang/Integer;)Ljava/lang/Integer;", i4 ↦ Φ.false ⟧,
+          ρ ↦ ∅
+        ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.jeo.opcode.invokedynamic, 𝐵-a, v1 ↦ "(II)Ljava/util/function/Function;", 𝐵-b ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "map", v2 ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;", v3 ↦ Φ.true, reverted ↦ Φ.true ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 0 ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 1 ⟧
+  - ⟦ φ ↦ Φ.jeo.handle, 𝐵-e, v2 ↦ "lambda$run$0", 𝐵-f ⟧

--- a/src/test/phino/447-unfused-multi-capturing-filter-to-invokedynamic.yml
+++ b/src/test/phino/447-unfused-multi-capturing-filter-to-invokedynamic.yml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The filter twin of 446: a two-int-capture filter distill that never fused
+# (closed state with EXACTLY two boxing appends and the dup/two-fetch guard body
+# 314 built) reverts to the native invokedynamic + Stream.filter, replaying BOTH
+# captured pushes (iload 0, iload 1), rebuilding the "(II)" factory descriptor and
+# marking the call reverted ↦ Φ.true so 113 cannot re-lift it. This is the
+# never-pessimise guarantee for a lone `filter(n -> n > lo && n < hi)`.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/4xx/447-unfused-multi-capturing-filter-to-invokedynamic.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      op ↦ ⟦
+        φ ↦ Φ.hone.distill,
+        class ↦ "Foo",
+        bridge-input ↦ "Ljava/lang/Integer;",
+        bridge-output ↦ "Ljava/lang/Integer;",
+        start ↦ "c-filter",
+        accepted ↦ "Ljava/lang/Integer;",
+        returned ↦ "Ljava/lang/Integer;",
+        static ↦ "true",
+        state ↦ ⟦
+          s1 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+          s2 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 0 ⟧,
+          s3 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "java/lang/Integer", i3 ↦ "valueOf", i4 ↦ "(I)Ljava/lang/Integer;", i5 ↦ Φ.false ⟧,
+          s4 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/List", i3 ↦ "add", i4 ↦ "(Ljava/lang/Object;)Z", i5 ↦ Φ.true ⟧,
+          s5 ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+          s6 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+          s7 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 1 ⟧,
+          s8 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "java/lang/Integer", i3 ↦ "valueOf", i4 ↦ "(I)Ljava/lang/Integer;", i5 ↦ Φ.false ⟧,
+          s9 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/List", i3 ↦ "add", i4 ↦ "(Ljava/lang/Object;)Z", i5 ↦ Φ.true ⟧,
+          s10 ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+          ρ ↦ ∅
+        ⟧,
+        body ↦ ⟦
+          d ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+          b0 ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, i1 ↦ 1 ⟧,
+          b1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
+          b2 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, i1 ↦ "java/lang/Integer", i2 ↦ "intValue", i3 ↦ "()I", i4 ↦ Φ.false ⟧,
+          b3 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
+          b4 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, i1 ↦ "java/lang/Integer", i2 ↦ "intValue", i3 ↦ "()I", i4 ↦ Φ.false ⟧,
+          b5 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
+          b6 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i1 ↦ "Foo", i2 ↦ "lambda$run$0", i3 ↦ "(IILjava/lang/Integer;)Z", i4 ↦ Φ.false ⟧,
+          b7 ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L9" ⟧ ⟧,
+          b8 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+          b9 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L9" ⟧,
+          b10 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+          ρ ↦ ∅
+        ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.jeo.opcode.invokedynamic, 𝐵-a, v1 ↦ "(II)Ljava/util/function/Predicate;", 𝐵-b ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "filter", v2 ↦ "(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;", v3 ↦ Φ.true, reverted ↦ Φ.true ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 0 ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 1 ⟧
+  - ⟦ φ ↦ Φ.jeo.handle, 𝐵-e, v2 ↦ "lambda$run$0", 𝐵-f ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/closure-multi-lone.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/closure-multi-lone.yml
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# End-to-end proof that a LONE TWO-int-capture map AND a LONE two-int-capture
+# filter are never pessimised (issue #663, the multi-capture twin of #657's
+# closure-reference-lone.yml). Neither operator has a neighbour to fuse with — the
+# map is followed only by a terminal reduce and the filter only by a terminal
+# count:
+#
+#   Stream.of(...).map(n -> n + p + q).reduce(0, (a, b) -> a + b)
+#   Stream.of(...).filter(n -> n > lo && n < hi).count()
+#
+# 112 / 113 lift each capturing operator (factory descriptor "(II)L…Function;" /
+# "(II)L…Predicate;") to a Φ.hone.{c-map,cp-filter}, 114 / 118 peel both `iload`
+# pushes into the shared state, and 316 / 314 fold a lone stateful distill. Because
+# nothing fuses with them, lowering each to a mapMulti would add an invokedynamic,
+# a wrapper, an ArrayList and a List.get per element — strictly slower than the
+# native Stream.{map,filter}. 446 / 447 (the multi-capture twins of 443 / 444)
+# revert each unfused two-capture distill back to its original invokedynamic +
+# Stream.{map,filter}, replaying BOTH captured pushes and the "(II)" factory
+# descriptor and marking the call reverted↦Φ.true so 112 / 113 cannot re-lift it.
+#
+# invokedynamic: before = capturing map (1) + capturing filter (1) + the reduce
+# accumulator lambda (1) = 3; after = the reverted map indy + the reverted filter
+# indy + the untouched reduce lambda = 3. The count is UNCHANGED, proving both
+# lone capturing operators came out native rather than being lowered to a (slower)
+# mapMulti. The runtime line proves both captures still reach their lambdas: with
+# p=10, q=20 the map sends {1..5} -> n+30 -> {31..35} summing to 165; with lo=2,
+# hi=6 the filter keeps {3,4,5} from {1..6}, a count of 3.
+java: |
+  package fusion;
+  import java.util.stream.*;
+  public class C {
+    static int mapRun(int p, int q) {
+      return Stream.of(1, 2, 3, 4, 5)
+        .map(n -> n + p + q)
+        .reduce(0, (a, b) -> a + b);
+    }
+    static long filterRun(int lo, int hi) {
+      return Stream.of(1, 2, 3, 4, 5, 6)
+        .filter(n -> n > lo && n < hi)
+        .count();
+    }
+    public static void main(String[] args) {
+      System.out.printf("The result is %d %d%n", mapRun(10, 20), filterRun(2, 6));
+    }
+  }
+before:
+  invokedynamic: 3
+after:
+  invokedynamic: 3
+log:
+  - "BUILD SUCCESS"
+  - "The result is 165 3"


### PR DESCRIPTION
Resolves the `@todo #661` puzzle in `112-capturing-invokedynamic-to-map.phr` (issue #663): generalise the never-pessimise capture revert from **one** capture (`443`/`444`) to **two** captures.

## What was deferred

A lone capturing map/filter that never fuses must be put back as its native `invokedynamic` + `Stream.{map,filter}` rather than lowered to a (slower) `mapMulti`. `443`/`444` did this only for a **single** capture — their state/body patterns are closed on exactly one boxing append and one fetch. A lone **multi**-capture operator (e.g. `map(n -> n + p + q)`, `filter(n -> n > lo && n < hi)`) failed those patterns and was emitted as a standalone `mapMulti`.

## What this PR does

- **`446-unfused-multi-capturing-map-to-invokedynamic`** — the multi-capture twin of `443`. A lone **two**-int-capture map distill (folded by `316`) that never fused is reverted to its native `invokedynamic` + `Stream.map`, replaying **both** `iload` pushes (in left-to-right order) and rebuilding the `(II)` factory descriptor, marking the call `reverted ↦ Φ.true` so `112` cannot re-lift it.
- **`447-unfused-multi-capturing-filter-to-invokedynamic`** — the filter twin (multi-capture twin of `444`), same shape over `Stream.filter` / `Predicate`.
- Both rules match a **CLOSED** state and body of **exactly two** appends and two fetches. The exact binding count is what makes the revert safe: a **fused** capturing operator carries two park/reload/call triples and a longer state, so it cannot match this fixed-length pattern and is left for `502` — the same never-touch-a-fused-distill guarantee `443`/`444` get, extended by one capture. (A lone operator with **three or more** captures still stays a standalone `mapMulti`; that arity-agnostic revert is re-filed as the new `@todo #663`.)

## Tests

- New phino unit packs `src/test/phino/446-*.yml` and `447-*.yml` (rewrite + match).
- New end-to-end fixture `streams/closure-multi-lone.yml`: a lone `map(n -> n + p + q).reduce(...)` and a lone `filter(n -> n > lo && n < hi).count()`. `invokedynamic` count is **unchanged 3 → 3**, proving neither is pessimised into a `mapMulti`; runtime line `The result is 165 3` proves both captures still reach their lambdas.

## Verification performed locally

- Both unit packs pass against `phino 0.0.0.73` (rewrite produces the native indy + reverted `Stream.{map,filter}`, with both pushes replayed).
- Running the **entire** `streams/*` ruleset (87 rules) over the lone two-capture map and filter distills leaves **0** `Φ.hone` markers and produces the native `(II)` indy with `reverted ↦ Φ.true` and **no** `mapMulti` — i.e. it composes and reaches a stable fixpoint (no loop).
- A fused two-operator distill is left untouched (still a `Φ.hone.distill`), and a single-capture distill is left for `443`/`444`.
- `before` invokedynamic count (3) and runtime output confirmed with `javac`/`java`.

## Docs

- Removed the resolved puzzle text from `112`'s header; documented `446`/`447` in the `112`/`443`/`444` headers and in `CLAUDE.md`; re-filed the remaining deferred items (mixed/multi-reference run; lone three-or-more-capture revert) as `@todo #663`.

https://claude.ai/code/session_01TB7NJuAgXgdiahnCmY3ow3

---
_Generated by [Claude Code](https://claude.ai/code/session_01TB7NJuAgXgdiahnCmY3ow3)_