### PR TITLE
#665 Revert lone three-capture map/filter to native invokedynamic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,9 +177,9 @@ skip                             → 220 → 308 → state distill;
 capturing map (N prim OR 1 ref)  → 112 → 114 (int) / 116 (long) / 117 (double)
                                     / 115 (ref peeler) → 316 → c-map state
                                     distill; 443 reverts a lone single-int-capture
-                                    map, 446 a lone TWO-int-capture map and 448 a
-                                    lone THREE-int-capture map if
-                                    unfused (4+-capture, category-2 and lone-ref
+                                    map, 446 a lone TWO-int-capture map and
+                                    448 a lone THREE-int-capture map if unfused
+                                    (4+-capture, category-2 and lone-ref
                                     stay mapMulti)
 capturing filter (N prim)        → 113 → 118 (int) / 120 (long) / 122 (double)
                                     → 314 → c-filter state distill; 444

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,14 +177,16 @@ skip                             → 220 → 308 → state distill;
 capturing map (N prim OR 1 ref)  → 112 → 114 (int) / 116 (long) / 117 (double)
                                     / 115 (ref peeler) → 316 → c-map state
                                     distill; 443 reverts a lone single-int-capture
-                                    map and 446 a lone TWO-int-capture map if
-                                    unfused (3+-capture, category-2 and lone-ref
+                                    map, 446 a lone TWO-int-capture map and 448 a
+                                    lone THREE-int-capture map if
+                                    unfused (4+-capture, category-2 and lone-ref
                                     stay mapMulti)
 capturing filter (N prim)        → 113 → 118 (int) / 120 (long) / 122 (double)
                                     → 314 → c-filter state distill; 444
-                                    reverts a LONE single-int-capture filter and
-                                    447 a lone TWO-int-capture filter to
-                                    invokedynamic if unfused (3+-capture,
+                                    reverts a LONE single-int-capture filter,
+                                    447 a lone TWO-int-capture filter and 449 a
+                                    lone THREE-int-capture filter to
+                                    invokedynamic if unfused (4+-capture,
                                     category-2 stay mapMulti)
 ```
 
@@ -560,12 +562,18 @@ captures over Integer):
   state and body of EXACTLY two appends and two fetches, so it reverts to the
   native `invokedynamic` + `Stream.{map,filter}` with the `(II)` factory
   descriptor and both pushes replayed, while a fused operator (two
-  park/reload/call triples) cannot match and is left for `502`. A LONE map OR
-  filter with THREE OR MORE captures fails both the single- and two-capture
-  closed patterns and is still emitted as a standalone `mapMulti` — correct, only
-  marginally slower than native, and rarer than a lone one- or two-capture
-  operator; reverting it (an arity-agnostic replay of N pushes rebuilding the
-  `(I^N)` descriptor) is a follow-up puzzle.
+  park/reload/call triples) cannot match and is left for `502`. `448`/`449` are
+  their THREE-capture twins (issue #665): a LONE three-int-capture map or filter
+  (e.g. `map(n -> n + p + q + r)`, `filter(n -> n > a && n < b && n != c)` with
+  no neighbour to fuse) matches a CLOSED state and body of EXACTLY three appends
+  and three fetches and reverts to the native `invokedynamic` +
+  `Stream.{map,filter}` with the `(III)` factory descriptor and all three pushes
+  replayed. A LONE map OR filter with FOUR OR MORE captures fails the single-,
+  two- and three-capture closed patterns and is still emitted as a standalone
+  `mapMulti` — correct, only marginally slower than native, and rarer than a lone
+  one/two/three-capture operator; replacing the one-rule-per-arity ladder with a
+  single arity-agnostic revert (an N-push replay rebuilding the `(I^N)`
+  descriptor) is a follow-up puzzle.
 
 Other type-preserving element types are **done** (issue #640): `112`'s
 `(LX;)LX;` backreference guard admits a capturing map over any reference element
@@ -600,8 +608,8 @@ with the same N-ary park/reload body as a capturing map — the keep-frame stays
 of the stack. So `filter(n -> n > lo && n < hi)` fuses with its trailing
 `mapToInt` into one `Stream.mapMultiToInt`; see the `multiFil` case in
 `streams/closures.yml`. A lone TWO-capture filter is reverted by `447` (the
-two-capture twin of `444`; see below); a lone filter with three or more captures
-is still emitted as a standalone `mapMulti`.
+two-capture twin of `444`) and a lone THREE-capture filter by `449`; a lone
+filter with four or more captures is still emitted as a standalone `mapMulti`.
 
 The lone-TWO-capture revert is **done** (issue #663): `446`/`447` are the
 two-capture twins of `443`/`444`. A lone two-int-capture map or filter that never
@@ -613,8 +621,19 @@ cannot re-lift it. Both rules match a CLOSED state and body of EXACTLY two appen
 and two fetches, so a FUSED operator (two park/reload/call triples) cannot match
 and is left for `502` — the never-touch-a-fused-distill guarantee `443`/`444` get,
 extended by one capture. See the `streams/closure-multi-lone.yml` end-to-end
-fixture. A lone map/filter with THREE OR MORE captures still stays a standalone
-`mapMulti` (a follow-up puzzle).
+fixture.
+
+The lone-THREE-capture revert is **done** (issue #665): `448`/`449` are the
+three-capture twins of `446`/`447`. A lone three-int-capture map or filter that
+never fused — e.g. `map(n -> n + p + q + r)` ending in a terminal `reduce`, or
+`filter(n -> n > a && n < b && n != c)` ending in `count` — is reverted to its
+native `invokedynamic` + `Stream.{map,filter}`, replaying ALL THREE `iload`
+pushes and the `(III)` factory descriptor and marking the call
+`reverted ↦ Φ.true`. Both rules match a CLOSED state and body of EXACTLY three
+appends and three fetches, so a FUSED operator (two park/reload/call triples)
+cannot match and is left for `502`. See the `streams/closure-three-lone.yml`
+end-to-end fixture. A lone map/filter with FOUR OR MORE captures still stays a
+standalone `mapMulti` (a follow-up puzzle).
 
 The category-2 (`J`/`D`) capture FILTER is **done** (issue #661): `113`'s
 `\([IJD]+\)Ljava/util/function/Predicate;` guard admits long/double captures
@@ -624,14 +643,15 @@ and bumps the caller max-stack by 2 exactly as `112` does for the map,
 distill — see `streams/closure-long-filter.yml`.
 
 Deferred puzzles (each extends the same shared-List channel): the
-lone-THREE-OR-MORE-capture map/filter revert (an arity-agnostic revert that
-rebuilds the `(I^N)` descriptor for any N; `446`/`447` close only the
-two-capture case); a MULTI-reference / mixed-with-reference capture run (needs
-positional capture-type extraction); `this`-field captures; and capturing
-`peek`/`mapToX`. See the puzzle marker in `112`'s header. (The lone-reference-map
+lone-FOUR-OR-MORE-capture map/filter revert (an arity-agnostic revert that
+rebuilds the `(I^N)` descriptor for any N; `446`/`447`/`448`/`449` close only the
+two- and three-capture cases); a MULTI-reference / mixed-with-reference capture
+run (needs positional capture-type extraction); `this`-field captures; and
+capturing `peek`/`mapToX`. See the puzzle marker in `112`'s header. (The
+lone-reference-map
 revert is **done** via `445`; the lone-two-capture map/filter revert is **done**
-via `446`/`447`; a category-2 or reference capture in a FILTER is **done** via
-`120`/`122` and `119`.)
+via `446`/`447` and the lone-three-capture one via `448`/`449`; a category-2 or
+reference capture in a FILTER is **done** via `120`/`122` and `119`.)
 
 ## phino: the only rewrite engine
 

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
@@ -96,16 +96,28 @@
 # never-touch-a-fused-distill guarantee 443 / 444 get, extended by one capture. See
 # streams/closure-multi-lone.yml.
 #
-# @todo #663:45min Generalise the CAPTURE channel further: a MIXED multi-capture
+# The lone-THREE-capture revert is now done (issue #665): 448 / 449 are the
+# three-capture twins of 446 / 447 — a lone three-int-capture map / filter (e.g.
+# `map(n -> n + p + q + r)` or `filter(n -> n > a && n < b && n != c)` with no
+# neighbour to fuse, ending in a terminal) is reverted to its native
+# invokedynamic + Stream.{map,filter}, replaying ALL THREE `iload` pushes and
+# rebuilding the "(III)" factory descriptor. Both rules match EXACTLY three
+# boxing appends and three fetches with a CLOSED state and body, so a FUSED
+# capturing operator (which carries two park/reload/call triples) cannot match
+# and is left for 502 — the same never-touch-a-fused-distill guarantee 446 / 447
+# get, extended by one more capture. See streams/closure-three-lone.yml.
+#
+# @todo #665:45min Generalise the CAPTURE channel further: a MIXED multi-capture
 #  run that contains a reference (only a SINGLE lone reference is admitted today,
 #  in both the map (115) and the filter (119), because each reads the capture type
 #  out of target.signature's first L-type — a multi-reference run needs positional
-#  type extraction). Also still deferred: the lone-THREE-OR-MORE-capture map/filter
-#  revert (446/447 are closed on exactly two appends/fetches, so a lone map or
-#  filter with three or more captures is still emitted as a standalone mapMulti
-#  rather than reverted to its native invokedynamic — extending it needs an
-#  arity-agnostic revert that rebuilds the "(I^N)" descriptor for any N). Each
-#  extends the same shared-List channel.
+#  type extraction). Also still deferred: the lone-FOUR-OR-MORE-capture map/filter
+#  revert (443/446/448 and 444/447/449 are closed on exactly one, two and three
+#  appends/fetches respectively, so a lone map or filter with four or more captures
+#  is still emitted as a standalone mapMulti rather than reverted to its native
+#  invokedynamic — replacing the one-rule-per-arity ladder with a single
+#  arity-agnostic revert that rebuilds the "(I^N)" descriptor for any N is the real
+#  fix). Each extends the same shared-List channel.
 name: capturing-invokedynamic-to-map
 pattern: |
   ⟦

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/443-unfused-capturing-map-to-invokedynamic.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/443-unfused-capturing-map-to-invokedynamic.phr
@@ -17,11 +17,12 @@
 # guard — is left for 502. A MULTI-capture lone map (two or more appends, the
 # v1.1 `map(i -> i + x + y)` shape) likewise fails this single-append, single-
 # fetch pattern; the TWO-capture case is reverted by 446 (the multi-capture twin
-# of this rule), and only a lone map with THREE OR MORE captures is still emitted
-# as a standalone mapMulti rather than reverted — correct, only marginally slower
-# than native, and a rarer shape than the lone single- or two-capture map.
-# Reverting that (an arity-agnostic replay of N pushes rebuilding the "(I^N)"
-# descriptor) is a follow-up puzzle. The capture-push (𝑒-push) is
+# of this rule) and the THREE-capture case by 448, and only a lone map with FOUR
+# OR MORE captures is still emitted as a standalone mapMulti rather than reverted
+# — correct, only marginally slower than native, and a rarer shape than the lone
+# one/two/three-capture map. Reverting that (an arity-agnostic replay of N pushes
+# rebuilding the "(I^N)" descriptor) is a follow-up puzzle. The capture-push
+# (𝑒-push) is
 # recovered from the state and replayed before the indy; the target handle is
 # read from the body's invokestatic. The 𝜑-calculus fields the fold dropped (the Function SAM name,
 # the erased lambda-signature, the captured "(I)" interface) are constants for an

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/444-unfused-capturing-filter-to-invokedynamic.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/444-unfused-capturing-filter-to-invokedynamic.phr
@@ -15,11 +15,11 @@
 # capture lone filter (two or more appends / fetches, e.g. the issue's
 # `filter(n -> n > lo && n < hi)`) fails this single-append, single-fetch closed
 # pattern; the TWO-capture case is reverted by 447 (the multi-capture twin of this
-# rule), and only a lone filter with THREE OR MORE captures is still emitted as a
-# standalone mapMulti rather than reverted — correct, only marginally slower than
-# native, exactly as 443 leaves a lone three-or-more-capture map. Reverting that
-# (an arity-agnostic replay of N pushes rebuilding the "(I^N)" descriptor) is a
-# follow-up puzzle.
+# rule) and the THREE-capture case by 449, and only a lone filter with FOUR OR
+# MORE captures is still emitted as a standalone mapMulti rather than reverted —
+# correct, only marginally slower than native, exactly as 443 leaves a lone
+# four-or-more-capture map. Reverting that (an arity-agnostic replay of N pushes
+# rebuilding the "(I^N)" descriptor) is a follow-up puzzle.
 name: unfused-capturing-filter-to-invokedynamic
 pattern: |
   ⟦

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/447-unfused-multi-capturing-filter-to-invokedynamic.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/447-unfused-multi-capturing-filter-to-invokedynamic.phr
@@ -19,9 +19,10 @@
 # revert safe: a FUSED filter (two operators joined by 401) carries two
 # park/reload/predicate triples and a longer state, so it cannot match this
 # fixed-length pattern and is left for 502 — the same never-touch-a-fused-distill
-# guarantee 444 gets, extended by one capture. A lone filter with THREE OR MORE
-# captures fails this two-append pattern and is still emitted as a standalone
-# mapMulti (a follow-up puzzle; see 112's header). Both pushes are replayed in
+# guarantee 444 gets, extended by one capture. A lone filter with THREE captures
+# is reverted by its three-capture twin 449; FOUR OR MORE captures fail every
+# closed append pattern and are still emitted as a standalone mapMulti (a
+# follow-up puzzle; see 112's header). Both pushes are replayed in
 # left-to-right order; the Predicate SAM constants are reconstructed literally for
 # the two-int-capture Stream<Integer> case, and the reverted Stream.filter carries
 # `reverted ↦ Φ.true` so 113 cannot re-lift it (its invokeinterface pattern is

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/448-unfused-three-capturing-map-to-invokedynamic.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/448-unfused-three-capturing-map-to-invokedynamic.phr
@@ -2,38 +2,39 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-# The multi-capture twin of 443. Reverts a TWO-int-capture map distill (folded by
-# 316) that never fused back to its native invokedynamic + Stream.map, replaying
-# both capture-pushes and rebuilding the "(II)" factory descriptor. 443 only
-# reverts a LONE single-capture map (its state and body are closed on ONE boxing
-# append and ONE fetch); a lone two-capture map — e.g. `map(n -> n + p + q)` with
-# no neighbour to fuse, as in `loneMultiMap` ending in a terminal `.count()` —
-# fails 443's single-append pattern and used to be emitted as a standalone
-# mapMulti, which is strictly slower than the native Stream.map the JVM already
-# has. This rule closes that gap for the two-capture case.
+# The three-capture twin of 446 (and the multi-capture twin of 443). Reverts a
+# THREE-int-capture map distill (folded by 316) that never fused back to its
+# native invokedynamic + Stream.map, replaying all three capture-pushes and
+# rebuilding the "(III)" factory descriptor. 446 only reverts a LONE two-capture
+# map (its state and body are closed on EXACTLY two boxing appends and two
+# fetches); a lone three-capture map — e.g. `map(n -> n + p + q + r)` with no
+# neighbour to fuse, ending in a terminal `.reduce(...)` — fails 446's
+# two-append pattern and used to be emitted as a standalone mapMulti, which is
+# strictly slower than the native Stream.map the JVM already has. This rule
+# closes that gap for the three-capture case.
 #
 # Both the state and the body match are CLOSED (no 𝐵-rest), enumerating EXACTLY
-# two boxing appends and EXACTLY two fetches plus a single park/reload/call. The
-# exact binding count is what makes the revert safe: a FUSED capturing map (two
-# operators joined by 401) carries TWO park/reload/call triples and a longer
-# state, so it cannot match this fixed-length pattern and is left for 502 — the
-# same never-touch-a-fused-distill guarantee 443 gets from its closed pattern,
-# only extended by one capture. A lone map with THREE captures is reverted by its
-# three-capture twin 448; FOUR OR MORE captures fail every closed append pattern
-# and are still emitted as a standalone mapMulti (a follow-up puzzle; see 112's
-# header). Both captured pushes (𝑒-push-a, 𝑒-push-b) are
-# recovered from the state and replayed before the indy in left-to-right order
-# (slot 0 = first capture); the target handle is read from the body's
-# invokestatic. The 𝜑-calculus fields the fold dropped (the Function SAM name,
-# the erased lambda-signature, the captured "(II)" interface) are constants for a
-# two-int-capture map over any reference element type, so they are reconstructed
-# literally; the SAM instantiated type "(LX;)LX;" is rebuilt from the distill's
-# bridge-input/bridge-output, matching 112's element-type-agnostic lift. The
-# reverted Stream.map carries `reverted ↦ Φ.true`: 112's invokeinterface pattern
-# is closed on the four-operand opcode jeo emits, so the fifth binding stops 112
-# re-lifting this map and the 112 → 316 → 446 cycle cannot spin (jeo ignores the
-# extra binding, exactly as for 443's single-capture map).
-name: unfused-multi-capturing-map-to-invokedynamic
+# three boxing appends and EXACTLY three fetches plus a single park/reload/call.
+# The exact binding count is what makes the revert safe: a FUSED capturing map
+# (two operators joined by 401) carries TWO park/reload/call triples and a
+# longer state, so it cannot match this fixed-length pattern and is left for 502
+# — the same never-touch-a-fused-distill guarantee 443 / 446 get from their
+# closed patterns, only extended by one more capture. A lone map with FOUR OR
+# MORE captures fails this three-append pattern and is still emitted as a
+# standalone mapMulti (a follow-up puzzle; see 112's header). All three captured
+# pushes (𝑒-push-a, 𝑒-push-b, 𝑒-push-c) are recovered from the state and
+# replayed before the indy in left-to-right order (slot 0 = first capture); the
+# target handle is read from the body's invokestatic. The 𝜑-calculus fields the
+# fold dropped (the Function SAM name, the erased lambda-signature, the captured
+# "(III)" interface) are constants for a three-int-capture map over any reference
+# element type, so they are reconstructed literally; the SAM instantiated type
+# "(LX;)LX;" is rebuilt from the distill's bridge-input/bridge-output, matching
+# 112's element-type-agnostic lift. The reverted Stream.map carries
+# `reverted ↦ Φ.true`: 112's invokeinterface pattern is closed on the
+# four-operand opcode jeo emits, so the fifth binding stops 112 re-lifting this
+# map and the 112 → 316 → 448 cycle cannot spin (jeo ignores the extra binding,
+# exactly as for 446's two-capture map).
+name: unfused-three-capturing-map-to-invokedynamic
 pattern: |
   ⟦
     𝐵-before,
@@ -81,6 +82,23 @@ pattern: |
           i5 ↦ Φ.true
         ⟧,
         𝜏-pop-b ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+        𝜏-dup-c ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+        𝜏-load-c ↦ 𝑒-push-c,
+        𝜏-box-c ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokestatic,
+          i2 ↦ "java/lang/Integer",
+          i3 ↦ "valueOf",
+          i4 ↦ "(I)Ljava/lang/Integer;",
+          i5 ↦ Φ.false
+        ⟧,
+        𝜏-add-c ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          i2 ↦ "java/util/List",
+          i3 ↦ "add",
+          i4 ↦ "(Ljava/lang/Object;)Z",
+          i5 ↦ Φ.true
+        ⟧,
+        𝜏-pop-c ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
         ρ ↦ ∅
       ⟧,
       body ↦ ⟦
@@ -95,6 +113,14 @@ pattern: |
         ⟧,
         𝜏-fetch-b ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
         𝜏-unbox-b ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokevirtual,
+          i1 ↦ "java/lang/Integer",
+          i2 ↦ "intValue",
+          i3 ↦ "()I",
+          i4 ↦ Φ.false
+        ⟧,
+        𝜏-fetch-c ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
+        𝜏-unbox-c ↦ ⟦
           φ ↦ Φ.jeo.opcode.invokevirtual,
           i1 ↦ "java/lang/Integer",
           i2 ↦ "intValue",
@@ -119,10 +145,11 @@ result: |
     𝐵-before,
     𝜏-push-back-a ↦ 𝑒-push-a,
     𝜏-push-back-b ↦ 𝑒-push-b,
+    𝜏-push-back-c ↦ 𝑒-push-c,
     𝜏-indy ↦ ⟦
       φ ↦ Φ.jeo.opcode.invokedynamic,
       v0 ↦ "apply",
-      v1 ↦ "(II)Ljava/util/function/Function;",
+      v1 ↦ "(III)Ljava/util/function/Function;",
       h2 ↦ ⟦
         φ ↦ Φ.jeo.handle,
         v0 ↦ 6,
@@ -163,6 +190,8 @@ where:
   - meta: 𝜏-push-back-a
     function: random-tau
   - meta: 𝜏-push-back-b
+    function: random-tau
+  - meta: 𝜏-push-back-c
     function: random-tau
   - meta: 𝜏-indy
     function: random-tau

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/449-unfused-three-capturing-filter-to-invokedynamic.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/449-unfused-three-capturing-filter-to-invokedynamic.phr
@@ -2,38 +2,33 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-# The multi-capture twin of 443. Reverts a TWO-int-capture map distill (folded by
-# 316) that never fused back to its native invokedynamic + Stream.map, replaying
-# both capture-pushes and rebuilding the "(II)" factory descriptor. 443 only
-# reverts a LONE single-capture map (its state and body are closed on ONE boxing
-# append and ONE fetch); a lone two-capture map — e.g. `map(n -> n + p + q)` with
-# no neighbour to fuse, as in `loneMultiMap` ending in a terminal `.count()` —
-# fails 443's single-append pattern and used to be emitted as a standalone
-# mapMulti, which is strictly slower than the native Stream.map the JVM already
-# has. This rule closes that gap for the two-capture case.
+# The filter twin of 448 (and the three-capture twin of 444 / 447). Reverts a
+# THREE-int-capture primitive-filter distill (folded by 314) that never fused
+# back to its native invokedynamic + Stream.filter, replaying all three
+# capture-pushes and rebuilding the "(III)" factory descriptor. 447 only reverts
+# a LONE two-capture filter (closed on EXACTLY two boxing appends and two
+# fetches); a lone three-capture filter — e.g. `filter(n -> n > a && n < b && n
+# != c)` with no neighbour to fuse (ending in a terminal such as `.count()`) —
+# fails 447's two-append pattern and used to be emitted as a standalone
+# mapMulti, strictly slower than the native Stream.filter. This rule closes that
+# gap for the three-capture case.
 #
-# Both the state and the body match are CLOSED (no 𝐵-rest), enumerating EXACTLY
-# two boxing appends and EXACTLY two fetches plus a single park/reload/call. The
-# exact binding count is what makes the revert safe: a FUSED capturing map (two
-# operators joined by 401) carries TWO park/reload/call triples and a longer
-# state, so it cannot match this fixed-length pattern and is left for 502 — the
-# same never-touch-a-fused-distill guarantee 443 gets from its closed pattern,
-# only extended by one capture. A lone map with THREE captures is reverted by its
-# three-capture twin 448; FOUR OR MORE captures fail every closed append pattern
-# and are still emitted as a standalone mapMulti (a follow-up puzzle; see 112's
-# header). Both captured pushes (𝑒-push-a, 𝑒-push-b) are
-# recovered from the state and replayed before the indy in left-to-right order
-# (slot 0 = first capture); the target handle is read from the body's
-# invokestatic. The 𝜑-calculus fields the fold dropped (the Function SAM name,
-# the erased lambda-signature, the captured "(II)" interface) are constants for a
-# two-int-capture map over any reference element type, so they are reconstructed
-# literally; the SAM instantiated type "(LX;)LX;" is rebuilt from the distill's
-# bridge-input/bridge-output, matching 112's element-type-agnostic lift. The
-# reverted Stream.map carries `reverted ↦ Φ.true`: 112's invokeinterface pattern
-# is closed on the four-operand opcode jeo emits, so the fifth binding stops 112
-# re-lifting this map and the 112 → 316 → 446 cycle cannot spin (jeo ignores the
-# extra binding, exactly as for 443's single-capture map).
-name: unfused-multi-capturing-map-to-invokedynamic
+# Both the state and the body match are CLOSED, enumerating EXACTLY three boxing
+# appends and EXACTLY three fetches plus the single item-preserving dup,
+# park/reload and keep-guard 314 built (dup; astore 1; (fetch; intValue)×3;
+# aload 1; predicate; ifne; return; label; frame-item). The exact binding count
+# is what makes the revert safe: a FUSED filter (two operators joined by 401)
+# carries two park/reload/predicate triples and a longer state, so it cannot
+# match this fixed-length pattern and is left for 502 — the same
+# never-touch-a-fused-distill guarantee 444 / 447 get, extended by one more
+# capture. A lone filter with FOUR OR MORE captures fails this three-append
+# pattern and is still emitted as a standalone mapMulti (a follow-up puzzle; see
+# 112's header). All three pushes are replayed in left-to-right order; the
+# Predicate SAM constants are reconstructed literally for the three-int-capture
+# Stream<Integer> case, and the reverted Stream.filter carries
+# `reverted ↦ Φ.true` so 113 cannot re-lift it (its invokeinterface pattern is
+# closed, the loop-break 442 / 444 / 447 rely on).
+name: unfused-three-capturing-filter-to-invokedynamic
 pattern: |
   ⟦
     𝐵-before,
@@ -42,7 +37,7 @@ pattern: |
       class ↦ 𝑒-class,
       bridge-input ↦ 𝑒-bridge-input,
       bridge-output ↦ 𝑒-bridge-output,
-      start ↦ "c-map",
+      start ↦ "c-filter",
       accepted ↦ 𝑒-accepted,
       returned ↦ 𝑒-returned,
       static ↦ 𝑒-static,
@@ -81,9 +76,27 @@ pattern: |
           i5 ↦ Φ.true
         ⟧,
         𝜏-pop-b ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+        𝜏-dup-c ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+        𝜏-load-c ↦ 𝑒-push-c,
+        𝜏-box-c ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokestatic,
+          i2 ↦ "java/lang/Integer",
+          i3 ↦ "valueOf",
+          i4 ↦ "(I)Ljava/lang/Integer;",
+          i5 ↦ Φ.false
+        ⟧,
+        𝜏-add-c ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          i2 ↦ "java/util/List",
+          i3 ↦ "add",
+          i4 ↦ "(Ljava/lang/Object;)Z",
+          i5 ↦ Φ.true
+        ⟧,
+        𝜏-pop-c ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
         ρ ↦ ∅
       ⟧,
       body ↦ ⟦
+        𝜏-itemdup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
         𝜏-park ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, i1 ↦ 1 ⟧,
         𝜏-fetch-a ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
         𝜏-unbox-a ↦ ⟦
@@ -101,6 +114,14 @@ pattern: |
           i3 ↦ "()I",
           i4 ↦ Φ.false
         ⟧,
+        𝜏-fetch-c ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
+        𝜏-unbox-c ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokevirtual,
+          i1 ↦ "java/lang/Integer",
+          i2 ↦ "intValue",
+          i3 ↦ "()I",
+          i4 ↦ Φ.false
+        ⟧,
         𝜏-reload ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
         𝜏-call ↦ ⟦
           φ ↦ Φ.jeo.opcode.invokestatic,
@@ -109,6 +130,13 @@ pattern: |
           i3 ↦ 𝑒-target-signature,
           i4 ↦ 𝑒-target-is-interface
         ⟧,
+        𝜏-ifne ↦ ⟦
+          φ ↦ Φ.jeo.opcode.ifne,
+          i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label ⟧
+        ⟧,
+        𝜏-return ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+        𝜏-label ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label ⟧,
+        𝜏-frame ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
         ρ ↦ ∅
       ⟧
     ⟧,
@@ -119,10 +147,11 @@ result: |
     𝐵-before,
     𝜏-push-back-a ↦ 𝑒-push-a,
     𝜏-push-back-b ↦ 𝑒-push-b,
+    𝜏-push-back-c ↦ 𝑒-push-c,
     𝜏-indy ↦ ⟦
       φ ↦ Φ.jeo.opcode.invokedynamic,
-      v0 ↦ "apply",
-      v1 ↦ "(II)Ljava/util/function/Function;",
+      v0 ↦ "test",
+      v1 ↦ "(III)Ljava/util/function/Predicate;",
       h2 ↦ ⟦
         φ ↦ Φ.jeo.handle,
         v0 ↦ 6,
@@ -131,7 +160,7 @@ result: |
         v3 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
         v4 ↦ Φ.false
       ⟧,
-      t3 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Object;)Ljava/lang/Object;" ⟧,
+      t3 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Object;)Z" ⟧,
       h4 ↦ ⟦
         φ ↦ Φ.jeo.handle,
         v0 ↦ 6,
@@ -142,11 +171,11 @@ result: |
       ⟧,
       t5 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ 𝑒-instantiated ⟧
     ⟧,
-    𝜏-map ↦ ⟦
+    𝜏-filter ↦ ⟦
       φ ↦ Φ.jeo.opcode.invokeinterface,
       v0 ↦ "java/util/stream/Stream",
-      v1 ↦ "map",
-      v2 ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;",
+      v1 ↦ "filter",
+      v2 ↦ "(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;",
       v3 ↦ Φ.true,
       reverted ↦ Φ.true
     ⟧,
@@ -158,13 +187,14 @@ where:
     args:
       - '"("'
       - 𝑒-bridge-input
-      - '")"'
-      - 𝑒-bridge-output
+      - '")Z"'
   - meta: 𝜏-push-back-a
     function: random-tau
   - meta: 𝜏-push-back-b
     function: random-tau
+  - meta: 𝜏-push-back-c
+    function: random-tau
   - meta: 𝜏-indy
     function: random-tau
-  - meta: 𝜏-map
+  - meta: 𝜏-filter
     function: random-tau

--- a/src/test/phino/448-unfused-three-capturing-map-to-invokedynamic.yml
+++ b/src/test/phino/448-unfused-three-capturing-map-to-invokedynamic.yml
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A three-int-capture map distill that never fused (closed state with EXACTLY
+# three boxing appends and a three-fetch park/reload body) is reverted to the
+# native invokedynamic + Stream.map, replaying ALL THREE captured pushes (iload
+# 0, iload 1, iload 2) in left-to-right order, rebuilding the "(III)" factory
+# descriptor and marking the call reverted ↦ Φ.true so 112 cannot re-lift it.
+# This is the never-pessimise guarantee for a lone `map(n -> n + p + q + r)` —
+# the three-capture analogue of 446.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/4xx/448-unfused-three-capturing-map-to-invokedynamic.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      op ↦ ⟦
+        φ ↦ Φ.hone.distill,
+        class ↦ "Foo",
+        bridge-input ↦ "Ljava/lang/Integer;",
+        bridge-output ↦ "Ljava/lang/Integer;",
+        start ↦ "c-map",
+        accepted ↦ "Ljava/lang/Integer;",
+        returned ↦ "Ljava/lang/Integer;",
+        static ↦ "true",
+        state ↦ ⟦
+          s1 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+          s2 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 0 ⟧,
+          s3 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "java/lang/Integer", i3 ↦ "valueOf", i4 ↦ "(I)Ljava/lang/Integer;", i5 ↦ Φ.false ⟧,
+          s4 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/List", i3 ↦ "add", i4 ↦ "(Ljava/lang/Object;)Z", i5 ↦ Φ.true ⟧,
+          s5 ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+          s6 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+          s7 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 1 ⟧,
+          s8 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "java/lang/Integer", i3 ↦ "valueOf", i4 ↦ "(I)Ljava/lang/Integer;", i5 ↦ Φ.false ⟧,
+          s9 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/List", i3 ↦ "add", i4 ↦ "(Ljava/lang/Object;)Z", i5 ↦ Φ.true ⟧,
+          s10 ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+          s11 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+          s12 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 2 ⟧,
+          s13 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "java/lang/Integer", i3 ↦ "valueOf", i4 ↦ "(I)Ljava/lang/Integer;", i5 ↦ Φ.false ⟧,
+          s14 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/List", i3 ↦ "add", i4 ↦ "(Ljava/lang/Object;)Z", i5 ↦ Φ.true ⟧,
+          s15 ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+          ρ ↦ ∅
+        ⟧,
+        body ↦ ⟦
+          b0 ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, i1 ↦ 1 ⟧,
+          b1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
+          b2 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, i1 ↦ "java/lang/Integer", i2 ↦ "intValue", i3 ↦ "()I", i4 ↦ Φ.false ⟧,
+          b3 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
+          b4 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, i1 ↦ "java/lang/Integer", i2 ↦ "intValue", i3 ↦ "()I", i4 ↦ Φ.false ⟧,
+          b5 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
+          b6 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, i1 ↦ "java/lang/Integer", i2 ↦ "intValue", i3 ↦ "()I", i4 ↦ Φ.false ⟧,
+          b7 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
+          b8 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i1 ↦ "Foo", i2 ↦ "lambda$run$0", i3 ↦ "(IIILjava/lang/Integer;)Ljava/lang/Integer;", i4 ↦ Φ.false ⟧,
+          ρ ↦ ∅
+        ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.jeo.opcode.invokedynamic, 𝐵-a, v1 ↦ "(III)Ljava/util/function/Function;", 𝐵-b ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "map", v2 ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;", v3 ↦ Φ.true, reverted ↦ Φ.true ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 0 ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 1 ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 2 ⟧
+  - ⟦ φ ↦ Φ.jeo.handle, 𝐵-e, v2 ↦ "lambda$run$0", 𝐵-f ⟧

--- a/src/test/phino/449-unfused-three-capturing-filter-to-invokedynamic.yml
+++ b/src/test/phino/449-unfused-three-capturing-filter-to-invokedynamic.yml
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The filter twin of 448: a three-int-capture filter distill that never fused
+# (closed state with EXACTLY three boxing appends and the dup/three-fetch guard
+# body 314 built) reverts to the native invokedynamic + Stream.filter, replaying
+# ALL THREE captured pushes (iload 0, iload 1, iload 2), rebuilding the "(III)"
+# factory descriptor and marking the call reverted ↦ Φ.true so 113 cannot
+# re-lift it. This is the never-pessimise guarantee for a lone
+# `filter(n -> n > a && n < b && n != c)`.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/4xx/449-unfused-three-capturing-filter-to-invokedynamic.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      op ↦ ⟦
+        φ ↦ Φ.hone.distill,
+        class ↦ "Foo",
+        bridge-input ↦ "Ljava/lang/Integer;",
+        bridge-output ↦ "Ljava/lang/Integer;",
+        start ↦ "c-filter",
+        accepted ↦ "Ljava/lang/Integer;",
+        returned ↦ "Ljava/lang/Integer;",
+        static ↦ "true",
+        state ↦ ⟦
+          s1 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+          s2 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 0 ⟧,
+          s3 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "java/lang/Integer", i3 ↦ "valueOf", i4 ↦ "(I)Ljava/lang/Integer;", i5 ↦ Φ.false ⟧,
+          s4 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/List", i3 ↦ "add", i4 ↦ "(Ljava/lang/Object;)Z", i5 ↦ Φ.true ⟧,
+          s5 ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+          s6 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+          s7 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 1 ⟧,
+          s8 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "java/lang/Integer", i3 ↦ "valueOf", i4 ↦ "(I)Ljava/lang/Integer;", i5 ↦ Φ.false ⟧,
+          s9 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/List", i3 ↦ "add", i4 ↦ "(Ljava/lang/Object;)Z", i5 ↦ Φ.true ⟧,
+          s10 ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+          s11 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+          s12 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 2 ⟧,
+          s13 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "java/lang/Integer", i3 ↦ "valueOf", i4 ↦ "(I)Ljava/lang/Integer;", i5 ↦ Φ.false ⟧,
+          s14 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/List", i3 ↦ "add", i4 ↦ "(Ljava/lang/Object;)Z", i5 ↦ Φ.true ⟧,
+          s15 ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+          ρ ↦ ∅
+        ⟧,
+        body ↦ ⟦
+          d ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+          b0 ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, i1 ↦ 1 ⟧,
+          b1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
+          b2 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, i1 ↦ "java/lang/Integer", i2 ↦ "intValue", i3 ↦ "()I", i4 ↦ Φ.false ⟧,
+          b3 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
+          b4 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, i1 ↦ "java/lang/Integer", i2 ↦ "intValue", i3 ↦ "()I", i4 ↦ Φ.false ⟧,
+          b5 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Integer" ⟧,
+          b6 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, i1 ↦ "java/lang/Integer", i2 ↦ "intValue", i3 ↦ "()I", i4 ↦ Φ.false ⟧,
+          b7 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
+          b8 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i1 ↦ "Foo", i2 ↦ "lambda$run$0", i3 ↦ "(IIILjava/lang/Integer;)Z", i4 ↦ Φ.false ⟧,
+          b9 ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L9" ⟧ ⟧,
+          b10 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+          b11 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L9" ⟧,
+          b12 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+          ρ ↦ ∅
+        ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.jeo.opcode.invokedynamic, 𝐵-a, v1 ↦ "(III)Ljava/util/function/Predicate;", 𝐵-b ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "filter", v2 ↦ "(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;", v3 ↦ Φ.true, reverted ↦ Φ.true ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 0 ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 1 ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 2 ⟧
+  - ⟦ φ ↦ Φ.jeo.handle, 𝐵-e, v2 ↦ "lambda$run$0", 𝐵-f ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/closure-three-lone.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/closure-three-lone.yml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# End-to-end proof that a LONE THREE-int-capture map AND a LONE three-int-capture
+# filter are never pessimised (issue #665, the three-capture twin of #663's
+# closure-multi-lone.yml). Neither operator has a neighbour to fuse with — the
+# map is followed only by a terminal reduce and the filter only by a terminal
+# count:
+#
+#   Stream.of(...).map(n -> n + p + q + r).reduce(0, (a, b) -> a + b)
+#   Stream.of(...).filter(n -> n > a && n < b && n != c).count()
+#
+# 112 / 113 lift each capturing operator (factory descriptor "(III)L…Function;" /
+# "(III)L…Predicate;") to a Φ.hone.{c-map,cp-filter}, 114 / 118 peel all three
+# `iload` pushes into the shared state, and 316 / 314 fold a lone stateful
+# distill. Because nothing fuses with them, lowering each to a mapMulti would add
+# an invokedynamic, a wrapper, an ArrayList and a List.get per element — strictly
+# slower than the native Stream.{map,filter}. 448 / 449 (the three-capture twins
+# of 446 / 447) revert each unfused three-capture distill back to its original
+# invokedynamic + Stream.{map,filter}, replaying ALL THREE captured pushes and
+# the "(III)" factory descriptor and marking the call reverted↦Φ.true so 112 /
+# 113 cannot re-lift it.
+#
+# invokedynamic: before = capturing map (1) + capturing filter (1) + the reduce
+# accumulator lambda (1) = 3; after = the reverted map indy + the reverted filter
+# indy + the untouched reduce lambda = 3. The count is UNCHANGED, proving both
+# lone capturing operators came out native rather than being lowered to a
+# (slower) mapMulti. The runtime line proves all three captures still reach their
+# lambdas: with p=10, q=20, r=5 the map sends {1..5} -> n+35 -> {36..40} summing
+# to 190; with a=2, b=6, c=4 the filter keeps {3,5} from {1..6}, a count of 2.
+java: |
+  package fusion;
+  import java.util.stream.*;
+  public class C {
+    static int mapRun(int p, int q, int r) {
+      return Stream.of(1, 2, 3, 4, 5)
+        .map(n -> n + p + q + r)
+        .reduce(0, (a, b) -> a + b);
+    }
+    static long filterRun(int a, int b, int c) {
+      return Stream.of(1, 2, 3, 4, 5, 6)
+        .filter(n -> n > a && n < b && n != c)
+        .count();
+    }
+    public static void main(String[] args) {
+      System.out.printf("The result is %d %d%n", mapRun(10, 20, 5), filterRun(2, 6, 4));
+    }
+  }
+before:
+  invokedynamic: 3
+after:
+  invokedynamic: 3
+log:
+  - "BUILD SUCCESS"
+  - "The result is 190 2"


### PR DESCRIPTION
Resolves #665 — the `@todo #663` puzzle in `112-capturing-invokedynamic-to-map.phr:99-108`.

## What

Generalises the lone-capture revert one step further along the established ladder: one capture (`443`/`444`) → two captures (`446`/`447`) → **three captures (`448`/`449`)**.

A lone capturing `map`/`filter` that never fuses with a neighbour is folded into a stateful distill (`316`/`314`) and would otherwise be emitted as a standalone `mapMulti` — strictly slower than the native `Stream.map`/`Stream.filter` the JVM already has. The new rules revert the three-int-capture case back to its original `invokedynamic` + `Stream.{map,filter}`.

- **`448-unfused-three-capturing-map-to-invokedynamic`** — the three-capture twin of `446`. Matches a CLOSED state/body of EXACTLY three boxing appends and three fetches, replays all three `iload` pushes and rebuilds the `(III)L…Function;` factory descriptor, marking the call `reverted ↦ Φ.true` so `112` cannot re-lift it.
- **`449-unfused-three-capturing-filter-to-invokedynamic`** — the filter twin (three-capture twin of `447`), same shape over `Stream.filter` / `Predicate`.

Because both patterns are closed on exactly three appends/fetches, a *fused* operator (two `park/reload/call` triples) cannot match and is left for `502` — the same never-touch-a-fused-distill guarantee `446`/`447` get, extended by one more capture.

## Tests

- Unit packs `src/test/phino/448-*.yml` and `449-*.yml`.
- End-to-end fixture `streams/closure-three-lone.yml`: lone `map(n -> n + p + q + r).reduce(...)` and `filter(n -> n > a && n < b && n != c).count()`; `invokedynamic` count unchanged **3 → 3** (proving neither is pessimised to a `mapMulti`), runtime result `190 2`.

I validated locally end-to-end (jeo 0.15.1 + phino 0.0.0.73): both lone three-capture operators revert to native (2 `reverted` markers, no `mapMulti`); removing `448`/`449` yields 2 `mapMulti`s instead; and the reverted output reassembles, verifies, and runs to `The result is 190 2`.

## Docs / puzzle

- Removed the resolved `@todo` text and re-filed the remaining deferred items (mixed-reference capture run; the lone **four-or-more**-capture revert) as `@todo #665`.
- Updated the headers of `112`, `443`, `444`, `446`, `447` and `CLAUDE.md` to reflect the three-capture revert.

Note: the lone four-or-more-capture revert remains a follow-up puzzle — the real fix there is to replace the one-rule-per-arity ladder with a single arity-agnostic revert that rebuilds the `(I^N)` descriptor for any N.


---
_Generated by [Claude Code](https://claude.ai/code/session_0147ERXMJTfYjuo9e6CYsV54)_