### PR TITLE
#671 Make default grep-in ERE-compatible

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -566,10 +566,10 @@ captures over Integer):
   marginally slower than native, and rarer than a lone one- or two-capture
   operator. Reverting it is **not** a matter of writing the next ladder rung: an
   arity-agnostic lone-vs-fused revert is not expressible with phino 0.0.0.73,
-  because a variadic `𝐵-` group backtracks over every split (`Matcher.hs:86`), so
-  one pattern matches a fused two-operator body as readily as a lone one — only
-  enumerating the EXACT capture count pins the `reload` position that tells them
-  apart. The real unblock is a phino counted-repetition matcher (filed as
+  because a variadic `𝐵-` group backtracks over every split (`Matcher.hs:86`),
+  so one pattern matches a fused two-operator body as readily as a lone one —
+  only enumerating the EXACT capture count pins the `reload` position that tells
+  them apart. The real unblock is a phino counted-repetition matcher (filed as
   `objectionary/phino#747`); until it lands, a lone three-or-more-capture
   operator stays a `mapMulti`.
 
@@ -629,8 +629,8 @@ and bumps the caller max-stack by 2 exactly as `112` does for the map,
 `cp-filter` mirrors of `116`/`117`), and `314` folds them into a stateful
 distill — see `streams/closure-long-filter.yml`.
 
-Deferred puzzles (each extends the same shared-List channel): a MULTI-reference /
-mixed-with-reference capture run (needs positional capture-type extraction);
+Deferred puzzles (each extends the same shared-List channel): a MULTI-reference
+/ mixed-with-reference capture run (needs positional capture-type extraction);
 `this`-field captures; and capturing `peek`/`mapToX`. The lone-THREE-OR-MORE-capture
 map/filter revert is **blocked upstream**, not deferred work to do here: an
 arity-agnostic lone-vs-fused revert is not expressible with phino 0.0.0.73 (a

--- a/src/main/java/org/eolang/hone/OptimizeMojo.java
+++ b/src/main/java/org/eolang/hone/OptimizeMojo.java
@@ -77,12 +77,19 @@ public final class OptimizeMojo extends AbstractMojo {
      * happen to appear as a prefix or suffix of a longer byte sequence
      * (e.g. <tt>"mapped/X"</tt> or <tt>"filtered"</tt>). See issue #449.</p>
      *
-     * <p>Uses negative lookbehind/lookahead to match complete hex-encoded method names
-     * only (not substrings like "6M-61-70" inside "6M-61-70-70-65-64-2F-58").</p>
+     * <p>The bytes are anchored between the closing <tt>&gt;</tt> of the
+     * opening tag and the opening <tt>&lt;</tt> of the closing tag, so the
+     * alternatives match only complete hex-encoded method names (not
+     * substrings like <tt>6D-61-70</tt> inside <tt>6D-61-70-70-65-64-2F-58</tt>).
+     * This keeps the pattern within POSIX ERE (the dialect understood by
+     * {@code grep -E} in {@code rewrite.sh}), unlike PCRE lookaround, which
+     * {@code grep -E} cannot parse — a mismatch that previously made
+     * {@code grep} reject every class and skip optimization entirely
+     * (see #671).</p>
      *
      * @since 0.19.0
      */
-    static final String DEFAULT_GREP_IN = "(?<!-)(66-69-6C-74-65-72|6D-61-70)(?!-)";
+    static final String DEFAULT_GREP_IN = ">(66-69-6C-74-65-72|6D-61-70)<";
 
     /**
      * Splitter for comma-separated values (with optional whitespace).

--- a/src/test/java/org/eolang/hone/OptimizeMojoTest.java
+++ b/src/test/java/org/eolang/hone/OptimizeMojoTest.java
@@ -1287,47 +1287,72 @@ final class OptimizeMojoTest {
     }
 
     @Test
-    void matchesStandaloneMapByteSequenceInDefaultGrepIn() {
+    void matchesStandaloneMapByteSequenceInDefaultGrepIn(@Mktmp final Path dir)
+        throws IOException {
         MatcherAssert.assertThat(
             "default grep-in must match a standalone 'map' byte sequence",
-            Pattern.compile(OptimizeMojo.DEFAULT_GREP_IN).matcher(
-                "<o as=\"α0\">6D-61-70</o>"
-            ).find(),
+            OptimizeMojoTest.grepInMatches(dir, "<o as=\"α0\">6D-61-70</o>"),
             Matchers.is(true)
         );
     }
 
     @Test
-    void matchesStandaloneFilterByteSequenceInDefaultGrepIn() {
+    void matchesStandaloneFilterByteSequenceInDefaultGrepIn(@Mktmp final Path dir)
+        throws IOException {
         MatcherAssert.assertThat(
             "default grep-in must match a standalone 'filter' byte sequence",
-            Pattern.compile(OptimizeMojo.DEFAULT_GREP_IN).matcher(
-                "<o as=\"α0\">66-69-6C-74-65-72</o>"
-            ).find(),
+            OptimizeMojoTest.grepInMatches(dir, "<o as=\"α0\">66-69-6C-74-65-72</o>"),
             Matchers.is(true)
         );
     }
 
     @Test
-    void ignoresMapBytesEmbeddedInLongerStringInDefaultGrepIn() {
+    void ignoresMapBytesEmbeddedInLongerStringInDefaultGrepIn(@Mktmp final Path dir)
+        throws IOException {
         MatcherAssert.assertThat(
             "default grep-in must not match 'map' bytes embedded in 'mapped/X' (see #449)",
-            Pattern.compile(OptimizeMojo.DEFAULT_GREP_IN).matcher(
-                "<o as=\"α0\">6D-61-70-70-65-64-2F-58</o>"
-            ).find(),
+            OptimizeMojoTest.grepInMatches(dir, "<o as=\"α0\">6D-61-70-70-65-64-2F-58</o>"),
             Matchers.is(false)
         );
     }
 
     @Test
-    void ignoresFilterBytesEmbeddedInLongerStringInDefaultGrepIn() {
+    void ignoresFilterBytesEmbeddedInLongerStringInDefaultGrepIn(@Mktmp final Path dir)
+        throws IOException {
         MatcherAssert.assertThat(
             "default grep-in must not match 'filter' bytes embedded in 'filtered'",
-            Pattern.compile(OptimizeMojo.DEFAULT_GREP_IN).matcher(
-                "<o as=\"α0\">66-69-6C-74-65-72-65-64</o>"
-            ).find(),
+            OptimizeMojoTest.grepInMatches(dir, "<o as=\"α0\">66-69-6C-74-65-72-65-64</o>"),
             Matchers.is(false)
         );
+    }
+
+    @Test
+    void rejectsMapToIntByteSequenceInDefaultGrepIn(@Mktmp final Path dir)
+        throws IOException {
+        MatcherAssert.assertThat(
+            "default grep-in must not match the 'mapToInt' byte sequence (see #671)",
+            OptimizeMojoTest.grepInMatches(dir, "<o as=\"α0\">6D-61-70-54-6F-49-6E-74</o>"),
+            Matchers.is(false)
+        );
+    }
+
+    /**
+     * Runs the default {@code grep-in} pattern through the very tool that
+     * consumes it in {@code rewrite.sh} ({@code grep -E}), so the pattern's
+     * dialect is validated against its real consumer rather than against
+     * {@link java.util.regex.Pattern} (see #671).
+     * @param dir Temporary directory to hold the sample file
+     * @param content The line of XMIR to grep through
+     * @return TRUE if {@code grep -E} finds a match
+     * @throws IOException If the sample file cannot be written
+     */
+    private static boolean grepInMatches(final Path dir, final String content)
+        throws IOException {
+        final Path file = dir.resolve("sample.xmir");
+        Files.write(file, content.getBytes(StandardCharsets.UTF_8));
+        return new Jaxec(
+            "grep", "-qE", OptimizeMojo.DEFAULT_GREP_IN, file.toString()
+        ).withCheck(false).execUnsafe().code() == 0;
     }
 
     @Test


### PR DESCRIPTION
Fixes #671.

## Problem

`DEFAULT_GREP_IN` was `(?<!-)(66-69-6C-74-65-72|6D-61-70)(?!-)`, using PCRE negative lookbehind/lookahead. But `rewrite.sh:79` consumes it with `grep -qE` (POSIX ERE), which cannot parse lookaround:

```
grep: warning: ? at start of expression
```

`grep` then matched nothing and exited non-zero, so `! grep -qE ...` was always true — **every class was copied through unchanged and optimization was skipped entirely**.

## Fix

Anchor the hex-byte alternatives between the XML tag boundaries (`>` … `<`) that delimit a complete PHI bytes literal inside an `.xmir`:

```
>(66-69-6C-74-65-72|6D-61-70)<
```

This stays within POSIX ERE (`grep -E` parses it cleanly) while still matching only a standalone `map`/`filter` token and rejecting `mapToInt`, `mapped/X`, and `filtered` — satisfying #449. `grep -qE` is kept, so no `-P`/PCRE portability dependency is introduced.

## Tests

The four grep-in unit tests previously validated the pattern with `java.util.regex`, which masked the dialect mismatch. They now run the pattern through its **real consumer** (`grep -E`) so this cannot recur (related: #516). Added one more case asserting `mapToInt` is rejected.

```
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
```

https://claude.ai/code/session_01RsBj3QHkaqkCPwX9cmCMqd

---
_Generated by [Claude Code](https://claude.ai/code/session_01RsBj3QHkaqkCPwX9cmCMqd)_