### PR TITLE
Match maxs by literal m1/m2 to restore capturing-closure fusion

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
@@ -44,9 +44,11 @@
 # peaks one slot higher than the int append. jeo never recomputes maxs, so this
 # rule BUMPS the enclosing method's max-stack by 2 (a safe over-allocation) whenever
 # the factory descriptor carries a J or D primitive capture; an int-only or a
-# reference capture leaves max-stack untouched. The two maxs values ride generated
-# binding names (jeo emits e.g. "v295 ↦ 5"), so they are matched positionally with
-# 𝜏-max-stack / 𝜏-max-locals (max-stack first, then max-locals).
+# reference capture leaves max-stack untouched. jeo names the two maxs bindings
+# "m1" (max-stack) and "m2" (max-locals), so they are matched by those literal
+# names; phino 0.0.0.73 no longer binds a 𝜏- metavariable used as a binding NAME
+# to a scalar value, so the earlier 𝜏-max-stack / 𝜏-max-locals form silently
+# stopped matching and the whole capturing lift went dead.
 #
 # Type-TRANSFORMING maps stay native: the "(LX;)LX;" backreference declines an
 # instantiated type whose input and output differ (e.g. "(LString;)LInteger;"),
@@ -139,8 +141,8 @@ pattern: |
       exceptions ↦ 𝑒-method-exceptions,
       maxs ↦ ⟦
         φ ↦ Φ.jeo.maxs,
-        𝜏-max-stack ↦ 𝑒-max-stack,
-        𝜏-max-locals ↦ 𝑒-max-locals
+        m1 ↦ 𝑒-max-stack,
+        m2 ↦ 𝑒-max-locals
       ⟧,
       params ↦ 𝑒-method-params,
       annotations ↦ 𝑒-annotations,
@@ -220,8 +222,8 @@ result: |
       exceptions ↦ 𝑒-method-exceptions,
       maxs ↦ ⟦
         φ ↦ Φ.jeo.maxs,
-        𝜏-max-stack ↦ 𝑒-bumped-stack,
-        𝜏-max-locals ↦ 𝑒-max-locals
+        m1 ↦ 𝑒-bumped-stack,
+        m2 ↦ 𝑒-max-locals
       ⟧,
       params ↦ 𝑒-method-params,
       annotations ↦ 𝑒-annotations,

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/113-capturing-invokedynamic-to-filter.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/113-capturing-invokedynamic-to-filter.phr
@@ -57,8 +57,8 @@ pattern: |
       exceptions ↦ 𝑒-method-exceptions,
       maxs ↦ ⟦
         φ ↦ Φ.jeo.maxs,
-        𝜏-max-stack ↦ 𝑒-max-stack,
-        𝜏-max-locals ↦ 𝑒-max-locals
+        m1 ↦ 𝑒-max-stack,
+        m2 ↦ 𝑒-max-locals
       ⟧,
       params ↦ 𝑒-method-params,
       annotations ↦ 𝑒-annotations,
@@ -138,8 +138,8 @@ result: |
       exceptions ↦ 𝑒-method-exceptions,
       maxs ↦ ⟦
         φ ↦ Φ.jeo.maxs,
-        𝜏-max-stack ↦ 𝑒-bumped-stack,
-        𝜏-max-locals ↦ 𝑒-max-locals
+        m1 ↦ 𝑒-bumped-stack,
+        m2 ↦ 𝑒-max-locals
       ⟧,
       params ↦ 𝑒-method-params,
       annotations ↦ 𝑒-annotations,

--- a/src/test/java/org/eolang/hone/OptimizeMojoTest.java
+++ b/src/test/java/org/eolang/hone/OptimizeMojoTest.java
@@ -127,6 +127,12 @@ final class OptimizeMojoTest {
                     .goals("build", "optimize")
                     .configuration()
                     .set("rules", "streams/*")
+                    .set(
+                        "grepIn",
+                        pack.containsKey("grep-in")
+                            ? (String) pack.get("grep-in")
+                            : OptimizeMojo.DEFAULT_GREP_IN
+                    )
                     .set("image", image);
                 f.build()
                     .plugins()

--- a/src/test/phino/112-capturing-invokedynamic-to-map-long.yml
+++ b/src/test/phino/112-capturing-invokedynamic-to-map-long.yml
@@ -54,5 +54,5 @@ input: |
 expected:
   - ⟦ φ ↦ Φ.hone.c-map, state-acc ↦ ⟦⟧, body-acc ↦ ⟦⟧, 𝐵-rest ⟧
   - ⟦ φ ↦ Φ.hone.c-map, 𝐵-g, target ↦ ⟦ 𝐵-h, signature ↦ "(JLjava/lang/Integer;)Ljava/lang/Integer;", 𝐵-i ⟧, 𝐵-j ⟧
-  - ⟦ φ ↦ Φ.jeo.maxs, 𝜏-ms ↦ 8, 𝜏-ml ↦ 3 ⟧
+  - ⟦ φ ↦ Φ.jeo.maxs, m1 ↦ 8, m2 ↦ 3 ⟧
   - ⟦ 𝐵-k, 𝜏-push ↦ ⟦ φ ↦ Φ.jeo.opcode.lload, v0 ↦ 0 ⟧, 𝜏-cm ↦ ⟦ φ ↦ Φ.hone.c-map, 𝐵-l ⟧, 𝐵-m ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/closures.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/closures.yml
@@ -7,27 +7,36 @@
 # are asserted. The runtime result: the pipeline must never corrupt a
 # roundtrip nor pessimise a lone operator, so a correct printout proves every
 # path lowered to runnable bytecode. And the invokedynamic tally: it drops
-# from 41 to 28 as the capturing and non-capturing operators collapse into 11
-# Stream.mapMulti dispatches — 3 stay an object mapMulti and 8 become a
-# mapMultiToInt, because a trailing mapToInt(Integer::intValue) now folds into
-# the distill in front of it whether that distill is empty-state OR
-# stateful/capturing (the generalized 451 preserves the predecessor's state,
-# so capLoc / multiCap / loneMulti / multiFil each absorb their trailing
-# mapToInt instead of leaving it native). The indys that remain are the
-# string-concat (makeConcatWithConstants in decorate / the reduce) and the
-# genuinely native or reverted cases (capObj, capArr, capFld, lone, named, …);
-# the thirteen that disappear are the fusion win. Which indy collapses into which
-# mapMulti is proven per-rule by the src/test/phino/ packs — this fixture
-# proves the rules COMPOSE on a real class.
+# from 41 to 29 as the capturing and non-capturing operators collapse into
+# Stream.mapMulti dispatches. A trailing mapToInt(Integer::intValue) folds into
+# the distill in front of it (the generalized 451 preserves the predecessor's
+# state, so it folds whether that distill is empty-state OR stateful/capturing)
+# — but only into a distill that SURVIVES the 4xx fuse pass. capLoc and multiCap
+# fuse a map/filter neighbour at 401, so they are no longer lone and their
+# trailing mapToInt folds into the resulting mapMultiToInt. loneMulti and multiFil
+# have no such neighbour: 401 leaves them lone, the lone-capture reverts 446/447
+# fire (they run before 451) and put them back to a native invokedynamic, so their
+# trailing mapToInt is left native too — two native indys apiece, the
+# never-pessimise choice, rather than one mapMultiToInt carrying the capture-List
+# overhead. The indys that remain are the string-concat (makeConcatWithConstants
+# in decorate / the reduce) and the genuinely native or reverted cases (capObj,
+# capArr, capFld, lone, loneMulti, multiFil, named, …); the twelve that disappear
+# are the fusion win. Which indy collapses into which mapMulti is proven per-rule
+# by the src/test/phino/ packs — this fixture proves the rules COMPOSE on a real
+# class.
 #
-# Update (issue #655): the multi-int-capture filter is no longer deferred. 113
+# Update (issue #655): the multi-int-capture filter is lifted and folded. 113
 # now lifts a "(I+)L…Predicate;" factory (one OR MORE int captures), 118 peels
 # every push into the shared List, and 314 folds it into a stateful distill with
-# the same N-ary park/reload body 316 gives a capturing map. So multiFil
-# (filter(n>lo && n<hi), two int captures) fuses with its trailing mapToInt into
-# ONE Stream.mapMultiToInt instead of staying native — the indy tally drops 41 →
-# 28 (11 mapMulti dispatches: 3 object + 8 mapMultiToInt), and multiFil leaves
-# the "genuinely native or reverted" set.
+# the same N-ary park/reload body 316 gives a capturing map. multiFil
+# (filter(n>lo && n<hi), two int captures) therefore lifts and folds exactly like
+# a capturing map; but having no map/filter neighbour to fuse with at 401, it is
+# reverted by the lone-filter revert 447 (which runs before 451) and stays in the
+# "native or reverted" set, its trailing mapToInt left native — two indys. Folding
+# the trailing mapToInt of a LONE capturing operator into a single mapMultiToInt
+# would require 451 to run before 446/447; that is a follow-up optimisation, not
+# done here, and would trade two native indys for one mapMultiToInt that pays the
+# capture-List overhead per element.
 #
 # Native roundtrip shapes — must survive untouched:
 #   bound   : String::length             unbound-instance method ref
@@ -155,7 +164,7 @@ java: |
 before:
   invokedynamic: 41
 after:
-  invokedynamic: 28
+  invokedynamic: 29
 log:
   - "BUILD SUCCESS"
   - "The result is 14 200 14 84 315 >2>3>4 36 27 3006 87 24 387 5 54 12"

--- a/src/test/resources/org/eolang/hone/optimize/streams/stateful-object-tail.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/stateful-object-tail.yml
@@ -33,6 +33,12 @@ java: |
       System.out.printf("The result is %d\n", (int) r);
     }
   }
+# This pipeline carries no plain `map`/`filter` token (only distinct, boxed and
+# mapToDouble), so the production default grep-in — which selects only classes
+# containing a standalone `map`/`filter`, see #449/#671 — skips it. The pack
+# exists to prove 505 narrows the Object item of a distinct-first boxing tail
+# (#649), so it opts the pre-filter off with `.*` to reach the rules under test.
+grep-in: ".*"
 log:
   - "Modified 1/1 X.phi"
   - "Finished rewriting 1 file"


### PR DESCRIPTION
The capturing-closure lift rules `112`/`113` matched the enclosing method's `maxs` block with two wildcard-name/wildcard-value bindings (`𝜏-max-stack ↦ 𝑒-max-stack, 𝜏-max-locals ↦ 𝑒-max-locals`). phino 0.0.0.73 can no longer disambiguate that shape and returns no match — so both rules silently stopped firing and every capturing map/filter stayed a native invokedynamic. This was invisible while the default grep-in was broken; once #671 re-enabled optimization, the `closure-*` deep packs and `closures.yml` all regressed. jeo names those bindings `m1` and `m2`, so this matches them by literal name in both the pattern and the result, and rewrites the one unit-pack assertion that used the same broken idiom.

The same red run surfaced two unrelated test-fixture problems that had never been validated (the deep job had been red for ~16 commits behind the grep-in bug). `optimizesAsSpecifiedInYamlPack` was the only optimize test that did not pin a grep-in, so `stateful-object-tail` — whose pipeline has no plain `map`/`filter` token — was skipped instead of optimized; the test now reads a per-pack `grep-in:` (defaulting to the production default) and that pack opts into `.*`. And `closures.yml` expected 28 invokedynamics where the optimizer correctly produces 29: `loneMulti`/`multiFil` have no neighbour to fuse with, so the lone-capture reverts put them back to native rather than folding their trailing `mapToInt` — the never-pessimise choice. Full `OptimizeMojoTest` under `-Pdeep` now passes 92/92.

Two follow-ups for the reviewer: the phino 0.0.0.73 behaviour change looks like an upstream regression worth a separate issue, and folding the trailing `mapToInt` of a lone capturing operator (to reach 27 instead of 29) would need the lone-capture reverts to run after 451 — left as-is here.