### PR TITLE
Support multi-reference captures (#665)

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
@@ -23,14 +23,16 @@
 # state List" is what lets N captures (and any number of fused capturing
 # operators) reuse the distinct/skip machinery (502/512/521/601) verbatim.
 #
-# v1.4 scope (issues #636, #640, #647, #652): the captures admitted are either
-# one OR MORE category-1/2 PRIMITIVE captures (factory descriptor "([IJD]+)L…Function;",
-# every push a constant-index iload/lload/dload, gathered by 114 for int and by
-# its category-2 twins 116/117 for long/double) OR a SINGLE reference capture
-# (factory descriptor "(L…;)L…Function;", push an aload, gathered by the reference
-# branch 115) — the two are partitioned by the `or` in the interface guard, and a
-# mixed int/long/double run is gathered by 114/116/117 interleaving on their own
-# opcode. In both cases the map is type-PRESERVING over ANY reference element type:
+# v1.5 scope (issues #636, #640, #647, #652, #665): the captures admitted are ANY
+# non-empty run of category-1/2 PRIMITIVE captures (iload/lload/dload, gathered by
+# 114/116/117) and/or REFERENCE captures (aload, gathered by 115), in any mix and
+# any count — the single interface guard "\(([IJD]|L[^;]+;)+\)L…Function;" admits the
+# whole "(III)", "(L…;)", "(L…;L…;)", "(IL…;)" … space. 112 seeds the c-map's
+# `remaining` field with the factory's parens-free parameter codes; each peel strips
+# the rightmost code as it consumes the rightmost push (right-to-left), so when 115
+# fires the rightmost remaining code is exactly the element type of the reference it
+# is peeling — POSITIONAL extraction that types more than one reference, and mixed
+# primitive/reference runs, correctly. The map is type-PRESERVING over ANY reference element type:
 # the SAM instantiated type is matched as "(LX;)LX;" for any reference X (Integer,
 # String, …) via a backreference guard, and the element type X is sed-extracted
 # into 𝑒-bridge and threaded into all four bridge fields. The lambda$ target is a
@@ -88,11 +90,11 @@
 # problem (objectionary/phino#747) entirely, since we never need to tell a lone
 # distill from a fused one.
 #
-# @todo #665:45min Generalise the CAPTURE channel further: a MIXED multi-capture
-#  run that contains a reference (only a SINGLE lone reference is admitted today,
-#  in both the map (115) and the filter (119), because each reads the capture type
-#  out of target.signature's first L-type — a multi-reference run needs positional
-#  type extraction). This part is independent of phino and still doable here.
+# Multi-reference and mixed primitive/reference runs are done (issue #665): 115/119
+# read each reference's element type POSITIONALLY from the rightmost code of the
+# c-map's `remaining` field (seeded by 112/113, stripped one code per peel), so a run
+# carrying more than one reference — or a reference mixed with primitives — types
+# every capture correctly. See streams/closure-multi-reference.yml.
 name: capturing-invokedynamic-to-map
 pattern: |
   ⟦
@@ -210,6 +212,7 @@ result: |
           φ ↦ Φ.hone.c-map,
           state-acc ↦ ⟦ ρ ↦ ∅ ⟧,
           body-acc ↦ ⟦ ρ ↦ ∅ ⟧,
+          remaining ↦ 𝑒-remaining,
           class ↦ 𝑒-class,
           bridge-input ↦ 𝑒-bridge,
           bridge-output ↦ 𝑒-bridge,
@@ -237,13 +240,9 @@ when:
     - matches:
         - 'lambda\$.+'
         - 𝑒-target-method
-    - or:
-        - matches:
-            - '\([IJD]+\)Ljava/util/function/Function;'
-            - 𝑒-interface
-        - matches:
-            - '\(L[^;]+;\)Ljava/util/function/Function;'
-            - 𝑒-interface
+    - matches:
+        - '\(([IJD]|L[^;]+;)+\)Ljava/util/function/Function;'
+        - 𝑒-interface
     - matches:
         - '\((L[^;]+;)\)\1'
         - 𝑒-instantiated
@@ -252,6 +251,17 @@ where:
     function: sed
     args:
       - 𝑒-instantiated
+      - '"s/[(]//"'
+      - '"s/[)].*//"'
+  # The capture run's factory descriptor parameter codes, parens-free, e.g.
+  # "Ljava/util/List;Ljava/lang/String;" or "ILjava/util/List;". 114-122 strip the
+  # rightmost code per peel (right-to-left), so when the reference peel 115 fires the
+  # rightmost remaining code IS the element type of the reference it is peeling —
+  # positional extraction that admits more than one reference and mixed runs (#665).
+  - meta: 𝑒-remaining
+    function: sed
+    args:
+      - 𝑒-interface
       - '"s/[(]//"'
       - '"s/[)].*//"'
   # Bump the caller max-stack by 2 when a category-2 (J/D) primitive capture is

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/113-capturing-invokedynamic-to-filter.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/113-capturing-invokedynamic-to-filter.phr
@@ -17,11 +17,11 @@
 # the static lambda$ (int…, Integer) signature wants — the same N-ary shape 316
 # gives a capturing map.
 #
-# Scope: one OR MORE category-1/2 PRIMITIVE captures (factory descriptor
+# Scope: ANY non-empty run of category-1/2 PRIMITIVE captures (factory descriptor
 # "([IJD]+)L…Predicate;", every push a constant-index iload/lload/dload, gathered by
-# 118 for int and by its category-2 twins 120/122 for long/double) OR a SINGLE
-# reference capture (factory descriptor "(L…;)L…Predicate;", push an aload, gathered
-# by the reference branch 119), over a Stream<Integer> predicate (instantiated type
+# 118 for int and by its category-2 twins 120/122 for long/double) and/or REFERENCE
+# captures (push an aload, gathered by 119, each typed POSITIONALLY from the seeded
+# `remaining` field — issue #665), in any mix, over a Stream<Integer> predicate (instantiated type
 # "(Ljava/lang/Integer;)Z"), a handle-6 static lambda$ target. So `filter(n -> n > t)`
 # (one int capture), `filter(n -> n > lo && n < hi)` (two int captures),
 # `filter(n -> n > x)` over a captured long (one J capture) and
@@ -149,6 +149,7 @@ result: |
           φ ↦ Φ.hone.cp-filter,
           state-acc ↦ ⟦ ρ ↦ ∅ ⟧,
           body-acc ↦ ⟦ ρ ↦ ∅ ⟧,
+          remaining ↦ 𝑒-remaining,
           class ↦ 𝑒-class,
           bridge-input ↦ "Ljava/lang/Integer;",
           bridge-output ↦ "Ljava/lang/Integer;",
@@ -176,14 +177,19 @@ when:
     - matches:
         - 'lambda\$.+'
         - 𝑒-target-method
-    - or:
-        - matches:
-            - '\([IJD]+\)Ljava/util/function/Predicate;'
-            - 𝑒-interface
-        - matches:
-            - '\(L[^;]+;\)Ljava/util/function/Predicate;'
-            - 𝑒-interface
+    - matches:
+        - '\(([IJD]|L[^;]+;)+\)Ljava/util/function/Predicate;'
+        - 𝑒-interface
 where:
+  # The capture run's factory descriptor parameter codes, parens-free; 118-122
+  # strip the rightmost code per peel so 119 reads each reference's element type
+  # positionally — the filter mirror of 112's 𝑒-remaining (#665).
+  - meta: 𝑒-remaining
+    function: sed
+    args:
+      - 𝑒-interface
+      - '"s/[(]//"'
+      - '"s/[)].*//"'
   # Bump the caller max-stack by 2 when a category-2 (J/D) primitive capture is
   # present (its relocated 2-slot boxing append, 120/122, peaks one slot higher
   # than an int append); an int-only or reference capture bumps by 0. The same

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/114-c-map-peel-capture.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/114-c-map-peel-capture.phr
@@ -20,7 +20,11 @@
 # pop` (begins and ends at [list], peak 3, so any number of them — across this
 # operator and any fused neighbours — join without growing the caller's stack).
 # body-acc gains one `fetch; intValue` (521 turns the fetch into List.get(counter++)
-# at emit, the intValue unboxes it). 316 wraps the finished body-acc as
+# at emit, the intValue unboxes it). It also strips the rightmost code from the
+# c-map's `remaining` field (the parens-free factory params 112 seeded), keeping it
+# in lock-step with the push run so the reference peel 115 reads each capture's type
+# positionally (issue #665); 116/117 and the cp-filter twins 118/120/122 do the same.
+# 316 wraps the finished body-acc as
 # `astore 1; <fetches>; aload 1; invokestatic lambda$`, so the unboxed captures
 # sit below the parked item exactly as the lambda$ (int…, Integer) signature wants.
 #
@@ -36,6 +40,7 @@ pattern: |
       φ ↦ Φ.hone.c-map,
       state-acc ↦ ⟦ 𝐵-sacc, ρ ↦ ∅ ⟧,
       body-acc ↦ ⟦ 𝐵-bacc, ρ ↦ ∅ ⟧,
+      remaining ↦ 𝑒-rem,
       𝐵-cm-tail
     ⟧,
     𝐵-t
@@ -78,11 +83,17 @@ result: |
         𝐵-bacc,
         ρ ↦ ∅
       ⟧,
+      remaining ↦ 𝑒-rem-out,
       𝐵-cm-tail
     ⟧,
     𝐵-t
   ⟧
 where:
+  - meta: 𝑒-rem-out
+    function: sed
+    args:
+      - 𝑒-rem
+      - '"s/[IJD]$//"'
   - meta: 𝜏-dup
     function: random-tau
   - meta: 𝜏-load

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/115-c-map-peel-reference.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/115-c-map-peel-reference.phr
@@ -2,23 +2,26 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-# The reference-capture twin of 114. 112 admits a SINGLE reference capture
-# (factory descriptor "(L…;)L…Function;", e.g. `map(n -> n + base.size())` over a
-# captured List) and leaves the lone `aload k` push inline in front of the c-map
-# with two EMPTY accumulators; this rule folds it into the operator's shared-List
-# state, exactly as 114 does for an `iload` int push — only the boxing and the
-# unboxing drop out, because a reference is already an Object.
+# The reference-capture twin of 114. 112 admits one or more reference captures
+# (factory descriptor "(L…;)L…Function;", "(L…;L…;)L…Function;", or mixed with
+# primitives, e.g. `map(n -> n + a.size() + b.length())` over a captured List and
+# String) and leaves the `aload k` pushes inline in front of the c-map with two
+# EMPTY accumulators; this rule peels them one at a time (right-to-left, greedy-left)
+# into the operator's shared-List state, exactly as 114 does for an `iload` int push
+# — only the boxing and the unboxing drop out, because a reference is already an Object.
 #
 # state-acc gains `dup; aload k; List.add; pop` (no Integer.valueOf — the captured
 # reference goes straight into the List; the append begins and ends at [list],
 # peak 3, identical to 114's int append, so it joins any number of fused
 # neighbours without growing the caller's stack). body-acc gains a single
 # `fetch` whose `type` is the captured object's class (521 turns the fetch into
-# List.get(counter++) and a checkcast to that class; no unbox follows). The class
-# is sed-extracted from the c-map's target.signature — the lambda$ descriptor is
-# "(Lcapture;Lelement;)Lelement;", so its first L-type IS the capture type. This
-# is why only a SINGLE reference capture is supported: with one capture arg the
-# first L-type is unambiguous.
+# List.get(counter++) and a checkcast to that class; no unbox follows). The class is
+# read POSITIONALLY from the c-map's `remaining` field — the parens-free factory
+# parameter codes 112 seeded — via a tokenizing sed that returns its RIGHTMOST
+# reference code; this rule then strips that code so the next peel sees the next
+# capture. Because peeling is right-to-left, the rightmost remaining code is always
+# the capture being peeled, so more than one reference (and references mixed with
+# primitives) each get the right type (issue #665).
 #
 # 316 then wraps body-acc into the auto emit-shape `astore 1; <fetch>; aload 1;
 # invokestatic lambda$`, so the reloaded reference sits below the parked item
@@ -33,8 +36,7 @@ pattern: |
       φ ↦ Φ.hone.c-map,
       state-acc ↦ ⟦ 𝐵-sacc, ρ ↦ ∅ ⟧,
       body-acc ↦ ⟦ 𝐵-bacc, ρ ↦ ∅ ⟧,
-      𝐵-cm-mid,
-      target ↦ ⟦ 𝐵-tgt-head, signature ↦ 𝑒-sig, 𝐵-tgt-tail ⟧,
+      remaining ↦ 𝑒-rem,
       𝐵-cm-tail
     ⟧,
     𝐵-t
@@ -63,8 +65,7 @@ result: |
         𝐵-bacc,
         ρ ↦ ∅
       ⟧,
-      𝐵-cm-mid,
-      target ↦ ⟦ 𝐵-tgt-head, signature ↦ 𝑒-sig, 𝐵-tgt-tail ⟧,
+      remaining ↦ 𝑒-rem-out,
       𝐵-cm-tail
     ⟧,
     𝐵-t
@@ -73,9 +74,13 @@ where:
   - meta: 𝑒-captype
     function: sed
     args:
-      - 𝑒-sig
-      - '"s/[(]L//"'
-      - '"s/;.*//"'
+      - 𝑒-rem
+      - '"s/^([IJD]|L[^;]*;)*L([^;]*);$/$2/"'
+  - meta: 𝑒-rem-out
+    function: sed
+    args:
+      - 𝑒-rem
+      - '"s/L[^;]*;$//"'
   - meta: 𝜏-dup
     function: random-tau
   - meta: 𝜏-load

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/116-c-map-peel-long.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/116-c-map-peel-long.phr
@@ -27,6 +27,7 @@ pattern: |
       φ ↦ Φ.hone.c-map,
       state-acc ↦ ⟦ 𝐵-sacc, ρ ↦ ∅ ⟧,
       body-acc ↦ ⟦ 𝐵-bacc, ρ ↦ ∅ ⟧,
+      remaining ↦ 𝑒-rem,
       𝐵-cm-tail
     ⟧,
     𝐵-t
@@ -69,11 +70,17 @@ result: |
         𝐵-bacc,
         ρ ↦ ∅
       ⟧,
+      remaining ↦ 𝑒-rem-out,
       𝐵-cm-tail
     ⟧,
     𝐵-t
   ⟧
 where:
+  - meta: 𝑒-rem-out
+    function: sed
+    args:
+      - 𝑒-rem
+      - '"s/[IJD]$//"'
   - meta: 𝜏-dup
     function: random-tau
   - meta: 𝜏-load

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/117-c-map-peel-double.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/117-c-map-peel-double.phr
@@ -24,6 +24,7 @@ pattern: |
       φ ↦ Φ.hone.c-map,
       state-acc ↦ ⟦ 𝐵-sacc, ρ ↦ ∅ ⟧,
       body-acc ↦ ⟦ 𝐵-bacc, ρ ↦ ∅ ⟧,
+      remaining ↦ 𝑒-rem,
       𝐵-cm-tail
     ⟧,
     𝐵-t
@@ -66,11 +67,17 @@ result: |
         𝐵-bacc,
         ρ ↦ ∅
       ⟧,
+      remaining ↦ 𝑒-rem-out,
       𝐵-cm-tail
     ⟧,
     𝐵-t
   ⟧
 where:
+  - meta: 𝑒-rem-out
+    function: sed
+    args:
+      - 𝑒-rem
+      - '"s/[IJD]$//"'
   - meta: 𝜏-dup
     function: random-tau
   - meta: 𝜏-load

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/118-cp-filter-peel-capture.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/118-cp-filter-peel-capture.phr
@@ -38,6 +38,7 @@ pattern: |
       φ ↦ Φ.hone.cp-filter,
       state-acc ↦ ⟦ 𝐵-sacc, ρ ↦ ∅ ⟧,
       body-acc ↦ ⟦ 𝐵-bacc, ρ ↦ ∅ ⟧,
+      remaining ↦ 𝑒-rem,
       𝐵-cf-tail
     ⟧,
     𝐵-t
@@ -80,11 +81,17 @@ result: |
         𝐵-bacc,
         ρ ↦ ∅
       ⟧,
+      remaining ↦ 𝑒-rem-out,
       𝐵-cf-tail
     ⟧,
     𝐵-t
   ⟧
 where:
+  - meta: 𝑒-rem-out
+    function: sed
+    args:
+      - 𝑒-rem
+      - '"s/[IJD]$//"'
   - meta: 𝜏-dup
     function: random-tau
   - meta: 𝜏-load

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/119-cp-filter-peel-reference.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/119-cp-filter-peel-reference.phr
@@ -3,23 +3,26 @@
 ---
 # yamllint disable rule:line-length
 # The reference-capture twin of 118, and the cp-filter mirror of 115. 113 admits
-# a SINGLE reference capture (factory descriptor "(L…;)L…Predicate;", e.g.
-# `filter(n -> base.contains(n))` over a captured Collection) and leaves the lone
-# `aload k` push inline in front of the cp-filter with two EMPTY accumulators;
-# this rule folds it into the operator's shared-List state, exactly as 115 does
-# for a Φ.hone.c-map — only the boxing and the unboxing drop out, because a
-# reference is already an Object.
+# one or more reference captures (factory descriptor "(L…;)L…Predicate;",
+# "(L…;L…;)L…Predicate;", or mixed with primitives, e.g.
+# `filter(n -> a.contains(n) && b.startsWith(...))` over a captured Collection and
+# String) and leaves the `aload k` pushes inline in front of the cp-filter with two
+# EMPTY accumulators; this rule peels them one at a time (right-to-left) into the
+# operator's shared-List state, exactly as 115 does for a Φ.hone.c-map — only the
+# boxing and the unboxing drop out, because a reference is already an Object.
 #
 # state-acc gains `dup; aload k; List.add; pop` (no Integer.valueOf — the captured
 # reference goes straight into the List; the append begins and ends at [list],
 # peak 3, identical to 118's int append, so it joins any number of fused
 # neighbours without growing the caller's stack). body-acc gains a single `fetch`
 # whose `type` is the captured object's class (521 turns the fetch into
-# List.get(counter++) and a checkcast to that class; no unbox follows). The class
-# is sed-extracted from the cp-filter's target.signature — the lambda$ descriptor
-# is "(Lcapture;Lelement;)Z", so its first L-type IS the capture type. This is
-# why only a SINGLE reference capture is supported: with one capture arg the first
-# L-type is unambiguous (a multi-reference run needs positional extraction).
+# List.get(counter++) and a checkcast to that class; no unbox follows). The class is
+# read POSITIONALLY from the cp-filter's `remaining` field — the parens-free factory
+# parameter codes 113 seeded — via a tokenizing sed that returns its RIGHTMOST
+# reference code, which this rule then strips so the next peel sees the next capture.
+# Because peeling is right-to-left, the rightmost remaining code is always the
+# capture being peeled, so more than one reference (and references mixed with
+# primitives) each get the right type (issue #665).
 #
 # 314 then wraps body-acc into the auto emit-shape `dup; astore 1; <fetch>;
 # aload 1; invokestatic lambda$; ifne keep`, so the reloaded reference sits below
@@ -36,8 +39,7 @@ pattern: |
       φ ↦ Φ.hone.cp-filter,
       state-acc ↦ ⟦ 𝐵-sacc, ρ ↦ ∅ ⟧,
       body-acc ↦ ⟦ 𝐵-bacc, ρ ↦ ∅ ⟧,
-      𝐵-cf-mid,
-      target ↦ ⟦ 𝐵-tgt-head, signature ↦ 𝑒-sig, 𝐵-tgt-tail ⟧,
+      remaining ↦ 𝑒-rem,
       𝐵-cf-tail
     ⟧,
     𝐵-t
@@ -66,8 +68,7 @@ result: |
         𝐵-bacc,
         ρ ↦ ∅
       ⟧,
-      𝐵-cf-mid,
-      target ↦ ⟦ 𝐵-tgt-head, signature ↦ 𝑒-sig, 𝐵-tgt-tail ⟧,
+      remaining ↦ 𝑒-rem-out,
       𝐵-cf-tail
     ⟧,
     𝐵-t
@@ -76,9 +77,13 @@ where:
   - meta: 𝑒-captype
     function: sed
     args:
-      - 𝑒-sig
-      - '"s/[(]L//"'
-      - '"s/;.*//"'
+      - 𝑒-rem
+      - '"s/^([IJD]|L[^;]*;)*L([^;]*);$/$2/"'
+  - meta: 𝑒-rem-out
+    function: sed
+    args:
+      - 𝑒-rem
+      - '"s/L[^;]*;$//"'
   - meta: 𝜏-dup
     function: random-tau
   - meta: 𝜏-load

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/120-cp-filter-peel-long.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/120-cp-filter-peel-long.phr
@@ -28,6 +28,7 @@ pattern: |
       φ ↦ Φ.hone.cp-filter,
       state-acc ↦ ⟦ 𝐵-sacc, ρ ↦ ∅ ⟧,
       body-acc ↦ ⟦ 𝐵-bacc, ρ ↦ ∅ ⟧,
+      remaining ↦ 𝑒-rem,
       𝐵-cf-tail
     ⟧,
     𝐵-t
@@ -70,11 +71,17 @@ result: |
         𝐵-bacc,
         ρ ↦ ∅
       ⟧,
+      remaining ↦ 𝑒-rem-out,
       𝐵-cf-tail
     ⟧,
     𝐵-t
   ⟧
 where:
+  - meta: 𝑒-rem-out
+    function: sed
+    args:
+      - 𝑒-rem
+      - '"s/[IJD]$//"'
   - meta: 𝜏-dup
     function: random-tau
   - meta: 𝜏-load

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/122-cp-filter-peel-double.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/122-cp-filter-peel-double.phr
@@ -25,6 +25,7 @@ pattern: |
       φ ↦ Φ.hone.cp-filter,
       state-acc ↦ ⟦ 𝐵-sacc, ρ ↦ ∅ ⟧,
       body-acc ↦ ⟦ 𝐵-bacc, ρ ↦ ∅ ⟧,
+      remaining ↦ 𝑒-rem,
       𝐵-cf-tail
     ⟧,
     𝐵-t
@@ -67,11 +68,17 @@ result: |
         𝐵-bacc,
         ρ ↦ ∅
       ⟧,
+      remaining ↦ 𝑒-rem-out,
       𝐵-cf-tail
     ⟧,
     𝐵-t
   ⟧
 where:
+  - meta: 𝑒-rem-out
+    function: sed
+    args:
+      - 𝑒-rem
+      - '"s/[IJD]$//"'
   - meta: 𝜏-dup
     function: random-tau
   - meta: 𝜏-load

--- a/src/main/resources/org/eolang/hone/rules/streams/3xx/314-cp-filter-to-distill.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/3xx/314-cp-filter-to-distill.phr
@@ -39,6 +39,7 @@ pattern: |
     φ ↦ Φ.hone.cp-filter,
     state-acc ↦ ⟦ 𝐵-sacc, ρ ↦ ∅ ⟧,
     body-acc ↦ ⟦ 𝐵-bacc, ρ ↦ ∅ ⟧,
+    remaining ↦ 𝑒-remaining,
     class ↦ 𝑒-class,
     bridge-input ↦ 𝑒-bridge-input,
     bridge-output ↦ 𝑒-bridge-output,

--- a/src/main/resources/org/eolang/hone/rules/streams/3xx/316-c-map-to-distill.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/3xx/316-c-map-to-distill.phr
@@ -34,6 +34,7 @@ pattern: |
     φ ↦ Φ.hone.c-map,
     state-acc ↦ ⟦ 𝐵-sacc, ρ ↦ ∅ ⟧,
     body-acc ↦ ⟦ 𝐵-bacc, ρ ↦ ∅ ⟧,
+    remaining ↦ 𝑒-remaining,
     class ↦ 𝑒-class,
     bridge-input ↦ 𝑒-bridge-input,
     bridge-output ↦ 𝑒-bridge-output,

--- a/src/test/phino/112-capturing-invokedynamic-to-map-multi-reference.yml
+++ b/src/test/phino/112-capturing-invokedynamic-to-map-multi-reference.yml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A capturing map invokedynamic with TWO reference captures of different types —
+# factory descriptor "(Ljava/util/List;Ljava/lang/String;)L…Function;", two aload
+# pushes, a handle-6 static lambda$ target — is lifted to a Φ.hone.c-map. 112's
+# relaxed interface guard "\(([IJD]|L[^;]+;)+\)…" admits the multi-reference run
+# (the old two-branch guard admitted at most a single reference) and seeds the
+# c-map's `remaining` field with the parens-free factory params, so 115 can later
+# type each reference positionally. The two accumulators come out EMPTY; the aloads
+# stay inline for 115 to peel.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
+input: |
+  {⟦
+    φ ↦ Φ.jeo.class,
+    version ↦ 68,
+    access ↦ 33,
+    modifiers ↦ ⟦ φ ↦ Φ.jeo.modifiers, static ↦ Φ.false ⟧,
+    name ↦ "Foo",
+    supername ↦ "java/lang/Object",
+    interfaces ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+    m$run ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 8,
+      modifiers ↦ ⟦ φ ↦ Φ.jeo.modifiers, static ↦ Φ.true ⟧,
+      name ↦ "run",
+      descriptor ↦ "(Ljava/util/List;Ljava/lang/String;)I",
+      signature ↦ "",
+      exceptions ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, m1 ↦ 6, m2 ↦ 2 ⟧,
+      params ↦ ⟦ φ ↦ Φ.jeo.params ⟧,
+      annotations ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      body ↦ ⟦
+        i20 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 0 ⟧,
+        i21 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 1 ⟧,
+        i23 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokedynamic,
+          v0 ↦ "apply",
+          v1 ↦ "(Ljava/util/List;Ljava/lang/String;)Ljava/util/function/Function;",
+          h2 ↦ ⟦ φ ↦ Φ.jeo.handle, v0 ↦ 6, v1 ↦ "java/lang/invoke/LambdaMetafactory", v2 ↦ "metafactory", v3 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;", v4 ↦ Φ.false ⟧,
+          t3 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Object;)Ljava/lang/Object;" ⟧,
+          h4 ↦ ⟦ φ ↦ Φ.jeo.handle, v0 ↦ 6, v1 ↦ "Foo", v2 ↦ "lambda$run$0", v3 ↦ "(Ljava/util/List;Ljava/lang/String;Ljava/lang/Integer;)Ljava/lang/Integer;", v4 ↦ Φ.false ⟧,
+          t5 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Integer;)Ljava/lang/Integer;" ⟧
+        ⟧,
+        i24 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "map", v2 ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;", v3 ↦ Φ.true ⟧
+      ⟧,
+      trycatchblocks ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      local-variable-table ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.hone.c-map, state-acc ↦ ⟦⟧, body-acc ↦ ⟦⟧, 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.hone.c-map, 𝐵-g, remaining ↦ "Ljava/util/List;Ljava/lang/String;", 𝐵-h ⟧
+  - ⟦ 𝐵-k, 𝜏-last ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 1 ⟧, 𝜏-cm ↦ ⟦ φ ↦ Φ.hone.c-map, 𝐵-l ⟧, 𝐵-m ⟧

--- a/src/test/phino/114-c-map-peel-capture.yml
+++ b/src/test/phino/114-c-map-peel-capture.yml
@@ -22,6 +22,7 @@ input: |
         φ ↦ Φ.hone.c-map,
         state-acc ↦ ⟦⟧,
         body-acc ↦ ⟦⟧,
+        remaining ↦ "II",
         class ↦ "Foo",
         bridge-input ↦ "Ljava/lang/Integer;",
         bridge-output ↦ "Ljava/lang/Integer;",

--- a/src/test/phino/115-c-map-peel-reference-multi.yml
+++ b/src/test/phino/115-c-map-peel-reference-multi.yml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 115 peels MORE THAN ONE reference capture, typing each POSITIONALLY (issue #665).
+# The input mimics 112's output for `map(n -> n + a.size() + b.length())` capturing
+# a List `a` (slot 0) and a String `b` (slot 1): a Φ.hone.c-map with two EMPTY
+# accumulators, the two `aload` pushes inline, and `remaining` seeded with the
+# parens-free factory params "Ljava/util/List;Ljava/lang/String;". 115 peels
+# right-to-left, so it reads `b` first — the RIGHTMOST code of `remaining`, i.e.
+# java/lang/String — strips that code, then reads `a` as java/util/List. Because
+# body-acc PREPENDS, the finished body-acc fetches read java/util/List THEN
+# java/lang/String (left-to-right, slot 0 first). A "first L-type" reader would type
+# BOTH as java/util/List; the distinct types here are the positional-extraction
+# proof. After fixpoint `remaining` is drained to "".
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/1xx/115-c-map-peel-reference.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      p ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "map", v2 ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;", v3 ↦ Φ.true ⟧,
+      a ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 0 ⟧,
+      b ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 1 ⟧,
+      cm ↦ ⟦
+        φ ↦ Φ.hone.c-map,
+        state-acc ↦ ⟦⟧,
+        body-acc ↦ ⟦⟧,
+        remaining ↦ "Ljava/util/List;Ljava/lang/String;",
+        class ↦ "Foo",
+        bridge-input ↦ "Ljava/lang/Integer;",
+        bridge-output ↦ "Ljava/lang/Integer;",
+        accepted ↦ "Ljava/lang/Integer;",
+        returned ↦ "Ljava/lang/Integer;",
+        static ↦ "true",
+        target ↦ ⟦ handle ↦ 6, class ↦ "Foo", method ↦ "lambda$run$0", signature ↦ "(Ljava/util/List;Ljava/lang/String;Ljava/lang/Integer;)Ljava/lang/Integer;", is-interface ↦ Φ.false ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.hone.c-map, 𝐵-a, body-acc ↦ ⟦ 𝜏-f1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/util/List" ⟧, 𝜏-f2 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/String" ⟧, 𝐵-br ⟧, 𝐵-c ⟧
+  - ⟦ φ ↦ Φ.hone.c-map, state-acc ↦ ⟦ 𝜏-d1 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧, 𝜏-l1 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 0 ⟧, 𝐵-sr ⟧, 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.hone.c-map, 𝐵-x, remaining ↦ "", 𝐵-y ⟧
+  - ⟦ 𝐵-z, 𝜏-cm ↦ ⟦ φ ↦ Φ.hone.c-map, 𝐵-cr ⟧, ρ ↦ ∅ ⟧

--- a/src/test/phino/115-c-map-peel-reference.yml
+++ b/src/test/phino/115-c-map-peel-reference.yml
@@ -22,6 +22,7 @@ input: |
         φ ↦ Φ.hone.c-map,
         state-acc ↦ ⟦⟧,
         body-acc ↦ ⟦⟧,
+        remaining ↦ "Ljava/util/List;",
         class ↦ "Foo",
         bridge-input ↦ "Ljava/lang/Integer;",
         bridge-output ↦ "Ljava/lang/Integer;",

--- a/src/test/phino/116-c-map-peel-long.yml
+++ b/src/test/phino/116-c-map-peel-long.yml
@@ -21,6 +21,7 @@ input: |
         φ ↦ Φ.hone.c-map,
         state-acc ↦ ⟦⟧,
         body-acc ↦ ⟦⟧,
+        remaining ↦ "JJ",
         class ↦ "Foo",
         bridge-input ↦ "Ljava/lang/Integer;",
         bridge-output ↦ "Ljava/lang/Integer;",

--- a/src/test/phino/117-c-map-peel-double.yml
+++ b/src/test/phino/117-c-map-peel-double.yml
@@ -18,6 +18,7 @@ input: |
         φ ↦ Φ.hone.c-map,
         state-acc ↦ ⟦⟧,
         body-acc ↦ ⟦⟧,
+        remaining ↦ "D",
         class ↦ "Foo",
         bridge-input ↦ "Ljava/lang/Integer;",
         bridge-output ↦ "Ljava/lang/Integer;",

--- a/src/test/phino/118-cp-filter-peel-capture.yml
+++ b/src/test/phino/118-cp-filter-peel-capture.yml
@@ -23,6 +23,7 @@ input: |
         φ ↦ Φ.hone.cp-filter,
         state-acc ↦ ⟦⟧,
         body-acc ↦ ⟦⟧,
+        remaining ↦ "II",
         class ↦ "Foo",
         bridge-input ↦ "Ljava/lang/Integer;",
         bridge-output ↦ "Ljava/lang/Integer;",

--- a/src/test/phino/119-cp-filter-peel-reference.yml
+++ b/src/test/phino/119-cp-filter-peel-reference.yml
@@ -23,6 +23,7 @@ input: |
         φ ↦ Φ.hone.cp-filter,
         state-acc ↦ ⟦⟧,
         body-acc ↦ ⟦⟧,
+        remaining ↦ "Ljava/util/List;",
         class ↦ "Foo",
         bridge-input ↦ "Ljava/lang/Integer;",
         bridge-output ↦ "Ljava/lang/Integer;",

--- a/src/test/phino/120-cp-filter-peel-long.yml
+++ b/src/test/phino/120-cp-filter-peel-long.yml
@@ -21,6 +21,7 @@ input: |
         φ ↦ Φ.hone.cp-filter,
         state-acc ↦ ⟦⟧,
         body-acc ↦ ⟦⟧,
+        remaining ↦ "JJ",
         class ↦ "Foo",
         bridge-input ↦ "Ljava/lang/Integer;",
         bridge-output ↦ "Ljava/lang/Integer;",

--- a/src/test/phino/122-cp-filter-peel-double.yml
+++ b/src/test/phino/122-cp-filter-peel-double.yml
@@ -19,6 +19,7 @@ input: |
         φ ↦ Φ.hone.cp-filter,
         state-acc ↦ ⟦⟧,
         body-acc ↦ ⟦⟧,
+        remaining ↦ "D",
         class ↦ "Foo",
         bridge-input ↦ "Ljava/lang/Integer;",
         bridge-output ↦ "Ljava/lang/Integer;",

--- a/src/test/phino/314-cp-filter-to-distill.yml
+++ b/src/test/phino/314-cp-filter-to-distill.yml
@@ -37,6 +37,7 @@ input: |
       b4 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, i1 ↦ "java/lang/Integer", i2 ↦ "intValue", i3 ↦ "()I", i4 ↦ Φ.false ⟧,
       ρ ↦ ∅
     ⟧,
+    remaining ↦ "",
     class ↦ "Foo",
     bridge-input ↦ "Ljava/lang/Integer;",
     bridge-output ↦ "Ljava/lang/Integer;",

--- a/src/test/phino/316-c-map-to-distill.yml
+++ b/src/test/phino/316-c-map-to-distill.yml
@@ -35,6 +35,7 @@ input: |
       b4 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, i1 ↦ "java/lang/Integer", i2 ↦ "intValue", i3 ↦ "()I", i4 ↦ Φ.false ⟧,
       ρ ↦ ∅
     ⟧,
+    remaining ↦ "",
     class ↦ "Foo",
     bridge-input ↦ "Ljava/lang/Integer;",
     bridge-output ↦ "Ljava/lang/Integer;",

--- a/src/test/resources/org/eolang/hone/optimize/streams/closure-multi-reference.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/closure-multi-reference.yml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# End-to-end proof that capturing-lambda fusion admits MORE THAN ONE reference
+# capture, with each reference typed POSITIONALLY (issue #665). The first map
+# captures two effectively-final references of DIFFERENT types — a List and a
+# String — read inside the lambda:
+#
+#   Stream.of(...).map(n -> n + a.size() + b.length()).map(n -> n * 2).reduce(0, ...)
+#
+# javac compiles the factory descriptor as "(Ljava/util/List;Ljava/lang/String;)L…Function;"
+# and the lambda$ as "(Ljava/util/List;Ljava/lang/String;Ljava/lang/Integer;)Ljava/lang/Integer;".
+# 112's relaxed interface guard admits the two-reference run and seeds the c-map's
+# `remaining` field with the parens-free factory params; 115 peels the two `aload`
+# pushes right-to-left, reading EACH reference's element type from the rightmost
+# code of `remaining` (so `b` is typed java/lang/String and `a` java/util/List, not
+# both java/util/List) and stripping that code per peel. 316 folds a stateful
+# distill and 401 fuses it with the following NON-capturing map (n -> n * 2).
+# 502/512/521/601 emit one Stream.mapMulti whose wrapper reads the two captures back
+# with the right checkcasts and calls List.size() and String.length() per element.
+#
+# This is the case a "first L-type" reader would miscompile: a wrong type on the
+# String capture would checkcast it to List and blow up at runtime, so the correct
+# printout is the positional-extraction oracle. With a.size() == 3 and
+# b.length() == 2 the map sends {1,2,3,4,5} -> n+5 -> {6,7,8,9,10} -> *2 ->
+# {12,14,16,18,20} -> sum == 80.
+#
+# invokedynamic: before = map(capturing two refs) + map + reduce-accumulator lambda
+# = 3; after = the single fused mapMulti + the untouched reduce lambda = 2.
+java: |
+  package fusion;
+  import java.util.*;
+  import java.util.stream.*;
+  public class C {
+    static int run(List<Integer> a, String b) {
+      return Stream.of(1, 2, 3, 4, 5)
+        .map(n -> n + a.size() + b.length())
+        .map(n -> n * 2)
+        .reduce(0, (x, y) -> x + y);
+    }
+    public static void main(String[] args) {
+      System.out.printf("The result is %d%n", run(Arrays.asList(7, 8, 9), "pq"));
+    }
+  }
+before:
+  invokedynamic: 3
+after:
+  invokedynamic: 2
+log:
+  - "BUILD SUCCESS"
+  - "The result is 80"


### PR DESCRIPTION
The capturing-lambda fusion channel could only handle a single reference capture. The reference peels (115/119) read the captured type from the lambda target signature's first `L`-type, which is fine for one reference but ambiguous the moment a run carries two — both would resolve to the first type and the second `checkcast` would blow up.

This threads a `remaining` field through the channel: 112/113 seed it with the factory descriptor's parens-free parameter codes, and every peel strips the rightmost code as it consumes the rightmost push (peels run right-to-left). So when a reference peel fires, the rightmost remaining code is exactly the type of the reference being peeled. 115/119 read it with an ERE tokenizing sed that stays correct when class names contain `L`/`I`/`J`/`D` and when a primitive sits immediately left of the reference. The lift guards collapse from a two-branch "primitives OR a single reference" into one "any non-empty run of primitives and/or references" match, so multi-reference and mixed primitive/reference runs all fuse. 314/316 bind and drop `remaining`, so the folded distill is unchanged downstream.

The new end-to-end fixture `closure-multi-reference.yml` captures a `List` and a `String` of different types in one map (3→2 invokedynamic, prints 80); the correct runtime is the positional-extraction oracle, since a first-L-type reader would `ClassCastException`. Verified with `mvn -Pdeep clean test` — 67 OptimizeMojoTest cases pass (24 fixtures + 43 packs).

Stacked on #680 (the revert-ladder removal), which it builds on; GitHub will retarget this to master once #680 merges. Closes #665.