### PR TITLE
Fuse adjacent Stream.mapMulti operations

### DIFF
--- a/src/main/java/org/eolang/hone/OptimizeMojo.java
+++ b/src/main/java/org/eolang/hone/OptimizeMojo.java
@@ -87,9 +87,16 @@ public final class OptimizeMojo extends AbstractMojo {
      * {@code grep} reject every class and skip optimization entirely
      * (see #671).</p>
      *
+     * <p>The third alternative <tt>6D-61-70-4D-75-6C-74-69</tt> is the
+     * <tt>"mapMulti"</tt> method name; because <tt>"map"</tt> is anchored it
+     * does not cover <tt>"mapMulti"</tt> on its own, so a class that uses only
+     * {@code mapMulti()} (the input that {@code 461-fuse-mapMulti} fuses, see
+     * issue #678) would otherwise be skipped entirely.</p>
+     *
      * @since 0.19.0
      */
-    static final String DEFAULT_GREP_IN = ">(66-69-6C-74-65-72|6D-61-70)<";
+    static final String DEFAULT_GREP_IN =
+        ">(66-69-6C-74-65-72|6D-61-70|6D-61-70-4D-75-6C-74-69)<";
 
     /**
      * Splitter for comma-separated values (with optional whitespace).

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/461-fuse-mapMulti.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/461-fuse-mapMulti.phr
@@ -110,8 +110,8 @@ result: |
             class ↦ 𝑒-class,
             method ↦ 𝑒-fused-name,
             signature ↦ 𝑒-fused-signature,
-            is-interface ↦ Φ.false
-          ⟧,
+            is-interface ↦ 𝑒-first-is-interface
+          ⟧
           stream ↦ ⟦
             class ↦ "java/util/stream/Stream",
             method ↦ "mapMulti",

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/461-fuse-mapMulti.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/461-fuse-mapMulti.phr
@@ -1,0 +1,249 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Fuses two adjacent standalone mapMulti operations into one. A user-written
+# `s.mapMulti(a).mapMulti(b)` is lifted by 111 into two adjacent Φ.hone.lambda
+# pragmas, each carrying stream.method = "mapMulti" and a handle-6 target to a
+# non-capturing lambda$ body. This rule replaces the pair with ONE Φ.hone.lambda
+# (still a mapMulti, lowered back to a single invokedynamic + Stream.mapMulti by
+# 701) whose target is a freshly synthesised BiConsumer `fused`. Following the
+# composition s.mapMulti((x,c) -> a(x, y -> b(y,c))):
+#
+#   fused(x, c):  invokestatic a$impl(x, W)        ; W = (Consumer) y -> b$impl(y,c)
+#   wrap (c, y):  invokestatic b$impl(y, c)        ; the W body, capturing c
+#
+# `fused` builds W with an inner invokedynamic over `wrap` capturing the
+# downstream consumer c, then drives the first lambda with W as its sink; every
+# value the first lambda emits flows through wrap into the second lambda and on
+# to c. Both original lambda bodies (a$impl, b$impl) are kept untouched — the
+# rule never inlines them, it only wires the call graph, so it is agnostic to
+# what either body does (any number of emits). The fused result is itself a
+# Φ.hone.lambda mapMulti, so a third adjacent mapMulti fuses into it on the next
+# cycle, collapsing a whole chain to one stage.
+#
+# Scope: reference Stream.mapMulti only (BiConsumer/Consumer, object element).
+# The primitive mapMultiToInt/Long/Double variants and capturing lambdas are
+# left for a follow-up — they never reach this Φ.hone.lambda form today (111
+# declines capturing indy; the primitive consumers carry different SAM types).
+name: fuse-mapMulti
+pattern: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    𝐵-class-head,
+    𝜏-method ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      𝐵-method-head,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-first ↦ ⟦
+          φ ↦ Φ.hone.lambda,
+          class ↦ 𝑒-class,
+          method ↦ "accept",
+          interface ↦ "()Ljava/util/function/BiConsumer;",
+          lambda-signature ↦ "(Ljava/lang/Object;Ljava/lang/Object;)V",
+          bridge-signature ↦ 𝑒-first-bridge,
+          static ↦ "true",
+          opcode ↦ "invokestatic",
+          target ↦ ⟦
+            handle ↦ 6,
+            class ↦ 𝑒-first-class,
+            method ↦ 𝑒-first-method,
+            signature ↦ 𝑒-first-signature,
+            is-interface ↦ 𝑒-first-is-interface
+          ⟧,
+          stream ↦ ⟦
+            class ↦ "java/util/stream/Stream",
+            method ↦ "mapMulti",
+            signature ↦ "(Ljava/util/function/BiConsumer;)Ljava/util/stream/Stream;"
+          ⟧
+        ⟧,
+        𝜏-second ↦ ⟦
+          φ ↦ Φ.hone.lambda,
+          class ↦ 𝑒-class,
+          method ↦ "accept",
+          interface ↦ "()Ljava/util/function/BiConsumer;",
+          lambda-signature ↦ "(Ljava/lang/Object;Ljava/lang/Object;)V",
+          bridge-signature ↦ 𝑒-second-bridge,
+          static ↦ "true",
+          opcode ↦ "invokestatic",
+          target ↦ ⟦
+            handle ↦ 6,
+            class ↦ 𝑒-second-class,
+            method ↦ 𝑒-second-method,
+            signature ↦ 𝑒-second-signature,
+            is-interface ↦ 𝑒-second-is-interface
+          ⟧,
+          stream ↦ ⟦
+            class ↦ "java/util/stream/Stream",
+            method ↦ "mapMulti",
+            signature ↦ "(Ljava/util/function/BiConsumer;)Ljava/util/stream/Stream;"
+          ⟧
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝐵-method-tail
+    ⟧,
+    𝐵-class-tail,
+    ρ ↦ ∅
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    𝐵-class-head,
+    𝜏-method ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      𝐵-method-head,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-first ↦ ⟦
+          φ ↦ Φ.hone.lambda,
+          class ↦ 𝑒-class,
+          method ↦ "accept",
+          interface ↦ "()Ljava/util/function/BiConsumer;",
+          lambda-signature ↦ "(Ljava/lang/Object;Ljava/lang/Object;)V",
+          bridge-signature ↦ 𝑒-fused-signature,
+          static ↦ "true",
+          opcode ↦ "invokestatic",
+          target ↦ ⟦
+            handle ↦ 6,
+            class ↦ 𝑒-class,
+            method ↦ 𝑒-fused-name,
+            signature ↦ 𝑒-fused-signature,
+            is-interface ↦ Φ.false
+          ⟧,
+          stream ↦ ⟦
+            class ↦ "java/util/stream/Stream",
+            method ↦ "mapMulti",
+            signature ↦ "(Ljava/util/function/BiConsumer;)Ljava/util/stream/Stream;"
+          ⟧
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝐵-method-tail
+    ⟧,
+    𝐵-class-tail,
+    𝜏-fused-method ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 4106,
+      descriptor ↦ 𝑒-fused-signature,
+      signature ↦ "",
+      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, max-stack ↦ 6, max-locals ↦ 2 ⟧,
+      params ↦ ⟦
+        φ ↦ Φ.jeo.params,
+        i1 ↦ ⟦ φ ↦ Φ.jeo.param, index ↦ 0, access ↦ 0, type ↦ 𝑒-first-input ⟧,
+        i2 ↦ ⟦ φ ↦ Φ.jeo.param, index ↦ 1, access ↦ 0, type ↦ "Ljava/util/function/Consumer;" ⟧
+      ⟧,
+      body ↦ ⟦
+        φ ↦ Φ.jeo.seq.of,
+        ld-item ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 0 ⟧,
+        ld-downstream ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
+        mk-wrap ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokedynamic,
+          i2 ↦ "accept",
+          i3 ↦ "(Ljava/util/function/Consumer;)Ljava/util/function/Consumer;",
+          i4 ↦ ⟦
+            φ ↦ Φ.jeo.handle,
+            i1 ↦ 6,
+            i2 ↦ "java/lang/invoke/LambdaMetafactory",
+            i3 ↦ "metafactory",
+            i4 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+            i5 ↦ Φ.false
+          ⟧,
+          i5 ↦ ⟦ φ ↦ Φ.jeo.type, i1 ↦ "(Ljava/lang/Object;)V" ⟧,
+          i6 ↦ ⟦
+            φ ↦ Φ.jeo.handle,
+            i1 ↦ 6,
+            i2 ↦ 𝑒-class,
+            i3 ↦ 𝑒-wrap-name,
+            i4 ↦ 𝑒-wrap-signature,
+            i5 ↦ Φ.false
+          ⟧,
+          i7 ↦ ⟦ φ ↦ Φ.jeo.type, i1 ↦ 𝑒-wrap-instantiated ⟧
+        ⟧,
+        call-first ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokestatic,
+          i2 ↦ 𝑒-first-class,
+          i3 ↦ 𝑒-first-method,
+          i4 ↦ 𝑒-first-signature,
+          i5 ↦ 𝑒-first-is-interface
+        ⟧,
+        ret ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+        ρ ↦ ∅
+      ⟧,
+      name ↦ 𝑒-fused-name
+    ⟧,
+    𝜏-wrap-method ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 4106,
+      descriptor ↦ 𝑒-wrap-signature,
+      signature ↦ "",
+      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, max-stack ↦ 6, max-locals ↦ 2 ⟧,
+      params ↦ ⟦
+        φ ↦ Φ.jeo.params,
+        i1 ↦ ⟦ φ ↦ Φ.jeo.param, index ↦ 0, access ↦ 0, type ↦ "Ljava/util/function/Consumer;" ⟧,
+        i2 ↦ ⟦ φ ↦ Φ.jeo.param, index ↦ 1, access ↦ 0, type ↦ 𝑒-second-input ⟧
+      ⟧,
+      body ↦ ⟦
+        φ ↦ Φ.jeo.seq.of,
+        ld-item ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
+        ld-downstream ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 0 ⟧,
+        call-second ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokestatic,
+          i2 ↦ 𝑒-second-class,
+          i3 ↦ 𝑒-second-method,
+          i4 ↦ 𝑒-second-signature,
+          i5 ↦ 𝑒-second-is-interface
+        ⟧,
+        ret ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+        ρ ↦ ∅
+      ⟧,
+      name ↦ 𝑒-wrap-name
+    ⟧,
+    ρ ↦ ∅
+  ⟧
+# Fire only on user-written mapMultis (javac names their bodies `lambda$…`) and
+# on this rule's own fusion products (`fused_…`), so a chain of three or more
+# folds left-to-right. A pipeline-generated mapMulti — the lowering form 501/502
+# emit for a fused map/filter/distinct chain — targets a `distill_…` method, so
+# excluding every other prefix keeps 461 off the already-optimal distill output
+# (re-fusing it via the adapter would only relocate an indy and break its pinned
+# opcode counts, e.g. closure-long-filter).
+when:
+  and:
+    - matches:
+        - '(lambda\$|fused_).+'
+        - 𝑒-first-method
+    - matches:
+        - '(lambda\$|fused_).+'
+        - 𝑒-second-method
+where:
+  - meta: 𝜏-fused-method
+    function: random-tau
+  - meta: 𝜏-wrap-method
+    function: random-tau
+  - meta: 𝑒-fused-name
+    function: random-string
+    args: [ '"fused_%d"' ]
+  - meta: 𝑒-wrap-name
+    function: random-string
+    args: [ '"wrap_%d"' ]
+  - meta: 𝑒-first-input
+    function: sed
+    args:
+      - 𝑒-first-signature
+      - '"s/^[(](L[^;]*;).*/$1/"'
+  - meta: 𝑒-second-input
+    function: sed
+    args:
+      - 𝑒-second-signature
+      - '"s/^[(](L[^;]*;).*/$1/"'
+  - meta: 𝑒-fused-signature
+    function: concat
+    args: [ '"("', 𝑒-first-input, '"Ljava/util/function/Consumer;)V"' ]
+  - meta: 𝑒-wrap-signature
+    function: concat
+    args: [ '"(Ljava/util/function/Consumer;"', 𝑒-second-input, '")V"' ]
+  - meta: 𝑒-wrap-instantiated
+    function: concat
+    args: [ '"("', 𝑒-second-input, '")V"' ]

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/461-fuse-mapMulti.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/461-fuse-mapMulti.phr
@@ -211,6 +211,8 @@ result: |
 # opcode counts, e.g. closure-long-filter).
 when:
   and:
+    - eq: [𝑒-first-class, 𝑒-class]
+    - eq: [𝑒-second-class, 𝑒-class]
     - matches:
         - '(lambda\$|fused_).+'
         - 𝑒-first-method

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/461-fuse-mapMulti.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/461-fuse-mapMulti.phr
@@ -157,8 +157,8 @@ result: |
             i2 ↦ 𝑒-class,
             i3 ↦ 𝑒-wrap-name,
             i4 ↦ 𝑒-wrap-signature,
-            i5 ↦ Φ.false
-          ⟧,
+            i5 ↦ 𝑒-first-is-interface
+          ⟧
           i7 ↦ ⟦ φ ↦ Φ.jeo.type, i1 ↦ 𝑒-wrap-instantiated ⟧
         ⟧,
         call-first ↦ ⟦

--- a/src/test/phino/461-fuse-mapMulti.yml
+++ b/src/test/phino/461-fuse-mapMulti.yml
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 461 fuses adjacent Φ.hone.lambda mapMulti pragmas (the form 111 lifts a
+# user-written Stream.mapMulti into) into one. The input is a class whose `main`
+# body chains FOUR such pragmas, targeting non-capturing lambda$main$0..3 — a
+# deliberately long chain so the fusion is plainly iterative, not a one-shot
+# pair merge. phino runs the rule to a fixpoint: it folds the first pair into a
+# `fused`/`wrap` method pair, then folds that fused pragma with the third, then
+# with the fourth, collapsing the whole chain to a single mapMulti pragma backed
+# by three `fused` + three `wrap` synthesised static methods.
+#
+# Each `wrap` forwards into one original lambda (invokestatic lambda$main$N) and
+# each `fused` drives the previous stage with a wrapper Consumer built by an
+# inner invokedynamic over its `wrap`. In the UNFUSED input every lambda$main$N
+# appears only as a target inside a Φ.hone.lambda pragma — never as an
+# invokestatic opcode — so matching an invokestatic to each of the four proves
+# all four were wired into synthesised bodies, i.e. the entire chain fused.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/4xx/461-fuse-mapMulti.phr
+input: |
+  {⟦
+    φ ↦ Φ.jeo.class,
+    name ↦ "Foo",
+    jm$main ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      name ↦ "main",
+      body ↦ ⟦
+        φ ↦ Φ.jeo.seq.of4,
+        op0 ↦ ⟦
+          φ ↦ Φ.hone.lambda,
+          class ↦ "Foo",
+          method ↦ "accept",
+          interface ↦ "()Ljava/util/function/BiConsumer;",
+          lambda-signature ↦ "(Ljava/lang/Object;Ljava/lang/Object;)V",
+          bridge-signature ↦ "(Ljava/lang/Integer;Ljava/util/function/Consumer;)V",
+          static ↦ "true",
+          opcode ↦ "invokestatic",
+          target ↦ ⟦ handle ↦ 6, class ↦ "Foo", method ↦ "lambda$main$0", signature ↦ "(Ljava/lang/Integer;Ljava/util/function/Consumer;)V", is-interface ↦ Φ.false ⟧,
+          stream ↦ ⟦ class ↦ "java/util/stream/Stream", method ↦ "mapMulti", signature ↦ "(Ljava/util/function/BiConsumer;)Ljava/util/stream/Stream;" ⟧
+        ⟧,
+        op1 ↦ ⟦
+          φ ↦ Φ.hone.lambda,
+          class ↦ "Foo",
+          method ↦ "accept",
+          interface ↦ "()Ljava/util/function/BiConsumer;",
+          lambda-signature ↦ "(Ljava/lang/Object;Ljava/lang/Object;)V",
+          bridge-signature ↦ "(Ljava/lang/Integer;Ljava/util/function/Consumer;)V",
+          static ↦ "true",
+          opcode ↦ "invokestatic",
+          target ↦ ⟦ handle ↦ 6, class ↦ "Foo", method ↦ "lambda$main$1", signature ↦ "(Ljava/lang/Integer;Ljava/util/function/Consumer;)V", is-interface ↦ Φ.false ⟧,
+          stream ↦ ⟦ class ↦ "java/util/stream/Stream", method ↦ "mapMulti", signature ↦ "(Ljava/util/function/BiConsumer;)Ljava/util/stream/Stream;" ⟧
+        ⟧,
+        op2 ↦ ⟦
+          φ ↦ Φ.hone.lambda,
+          class ↦ "Foo",
+          method ↦ "accept",
+          interface ↦ "()Ljava/util/function/BiConsumer;",
+          lambda-signature ↦ "(Ljava/lang/Object;Ljava/lang/Object;)V",
+          bridge-signature ↦ "(Ljava/lang/Integer;Ljava/util/function/Consumer;)V",
+          static ↦ "true",
+          opcode ↦ "invokestatic",
+          target ↦ ⟦ handle ↦ 6, class ↦ "Foo", method ↦ "lambda$main$2", signature ↦ "(Ljava/lang/Integer;Ljava/util/function/Consumer;)V", is-interface ↦ Φ.false ⟧,
+          stream ↦ ⟦ class ↦ "java/util/stream/Stream", method ↦ "mapMulti", signature ↦ "(Ljava/util/function/BiConsumer;)Ljava/util/stream/Stream;" ⟧
+        ⟧,
+        op3 ↦ ⟦
+          φ ↦ Φ.hone.lambda,
+          class ↦ "Foo",
+          method ↦ "accept",
+          interface ↦ "()Ljava/util/function/BiConsumer;",
+          lambda-signature ↦ "(Ljava/lang/Object;Ljava/lang/Object;)V",
+          bridge-signature ↦ "(Ljava/lang/Integer;Ljava/util/function/Consumer;)V",
+          static ↦ "true",
+          opcode ↦ "invokestatic",
+          target ↦ ⟦ handle ↦ 6, class ↦ "Foo", method ↦ "lambda$main$3", signature ↦ "(Ljava/lang/Integer;Ljava/util/function/Consumer;)V", is-interface ↦ Φ.false ⟧,
+          stream ↦ ⟦ class ↦ "java/util/stream/Stream", method ↦ "mapMulti", signature ↦ "(Ljava/util/function/BiConsumer;)Ljava/util/stream/Stream;" ⟧
+        ⟧,
+        ρ ↦ ∅
+      ⟧
+    ⟧,
+    ρ ↦ ∅
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$0", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$1", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$2", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$3", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokedynamic, i2 ↦ "accept", i3 ↦ "(Ljava/util/function/Consumer;)Ljava/util/function/Consumer;", 𝐵-rest ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/full-non-terminal.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/full-non-terminal.yml
@@ -1,46 +1,69 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
-# Full coverage of every non-terminal Stream operation the optimizer lowers
-# to a mapMulti — the operations that do NOT need a Sink lifecycle
+# Full coverage of every non-terminal Stream operation the optimizer folds
+# into a distill, PLUS a pair of user-written mapMulti operations at the head
+# to show how an explicit mapMulti interacts with that fusion (issue #678).
+#
+# The fold-able operations do NOT need a Sink lifecycle
 # (begin/end/cancellation) and so map cleanly onto a BiConsumer-driven emit:
 # filter, map, peek, distinct, skip, and the primitive conversions
 # mapToInt/mapToLong/mapToDouble + boxed. The remaining Sink-bound operations
-# (sorted, takeWhile, limit, dropWhile, flatMap, mapMulti and their primitive
-# variants) are deliberately absent. With no barriers between them every
-# operator is adjacent, so the pipeline exercises fusion across the boxing
-# boundary as aggressively as possible. The trailing mapToInt lands the
-# stream back on a primitive so `.sum()` is legal.
+# (sorted, takeWhile, limit, dropWhile, flatMap and their primitive variants)
+# are deliberately absent. With no barriers between them every operator is
+# adjacent, so the pipeline exercises fusion across the boxing boundary as
+# aggressively as possible. The trailing mapToInt lands the stream back on a
+# primitive so `.sum()` is legal.
+#
+# A user mapMulti is the one non-terminal that is NOT folded into a distill:
+# distill is single-emit and mapMulti is one-to-many, so 111 lifts each user
+# mapMulti into its own Φ.hone.lambda pragma and leaves it there. That makes a
+# user mapMulti a barrier the distill-fusion (401) cannot cross. The two
+# leading mapMultis here therefore stay outside the big distill — but they are
+# adjacent to each other, so 461-fuse-mapMulti folds the pair into a single
+# mapMulti via the adapter (x,c) -> a(x, y -> b(y,c)), exactly as in
+# mapmulti-fusion.yml, only now embedded in a larger pipeline.
 #
 # This fixture is compiled with debug info (javac -g, the Maven default), so
 # javac wedges a line-number-anchor label before every operator. 101 strips
 # the label of a lambda operator (map/filter) and 102 strips it of a bare one
 # (peek/distinct/skip), keeping the operators adjacent so 401-fuse can fold
-# the whole chain — without 102 the stateful chain fuses only partially and
-# emits a wrapper that fails class verification.
+# the chain — without 102 the stateful chain fuses only partially and emits a
+# wrapper that fails class verification.
 #
-# Both distincts and both skips are stateful, and the two distinct/skip
-# pairs sit adjacent (distinct().skip()), so this is the case that proves
-# stateful distills fuse: all nine object-stream operators (peek included)
-# collapse into a single stateful distill backed by one captured
-# java/util/List holding the two HashSets and two long[1] counters. The
-# primitive-conversion tail (mapToInt().boxed().mapToLong().boxed().
-# mapToDouble().boxed()) is a run of user boxed() round-trips, which 209
-# folds and 401 fuses into that SAME stateful distill (it stays object ->
-# Double, since each boxed() re-boxes to a wrapper). The final mapToInt
-# is a trailing type-transition mapToX: 451 (which now preserves the
-# predecessor's state block) fuses it in too, widening the one stateful
-# distill to object -> int. The output-aware stateful emit (502/512, the
-# stateful twins of 501/511) then lowers the WHOLE method to a single
-# Stream.mapMultiToInt — invokedynamic 9 -> 1. This is #570's "everything
-# into one mapMulti" reaching the stateful path; a purely pointwise boxed()
-# chain has always collapsed to one, see boxed-roundtrip.yml.
+# Everything after the two mapMultis collapses just as it would on its own.
+# Both distincts and both skips are stateful, and the two distinct/skip pairs
+# sit adjacent (distinct().skip()), so this is the case that proves stateful
+# distills fuse: all nine fold-able operators (peek included) collapse into a
+# single stateful distill backed by one captured java/util/List holding the
+# two HashSets and two long[1] counters. The primitive-conversion tail
+# (mapToInt().boxed().mapToLong().boxed().mapToDouble().boxed()) is a run of
+# user boxed() round-trips, which 209 folds and 401 fuses into that SAME
+# stateful distill (it stays object -> Double, since each boxed() re-boxes to
+# a wrapper). The final mapToInt is a trailing type-transition mapToX: 451
+# (which preserves the predecessor's state block) fuses it in too, widening
+# the one stateful distill to object -> int. The output-aware stateful emit
+# (502/512, the stateful twins of 501/511) then lowers that whole run to a
+# single Stream.mapMultiToInt. This is #570's "everything into one mapMulti"
+# reaching the stateful path; a purely pointwise boxed() chain has always
+# collapsed to one, see boxed-roundtrip.yml.
+#
+# Net: invokedynamic 11 -> 3 and exactly two Stream.mapMulti calls survive —
+# one for the fused user pair (its surviving call-site indy plus the relocated
+# wrapper-builder indy account for 2 of the 3) and one for the nine-operator
+# chain collapsed into a single stateful mapMultiToInt (the remaining 1). Were
+# 461 not to fire, the two user mapMultis would survive separately as three
+# Stream.mapMulti calls with one extra invokeinterface — so invokeinterface
+# 21 -> 14 is the assertion that proves the in-pipeline fusion happened
+# (invokedynamic stays 3 either way, since the adapter conserves indy count).
 java: |
   package allnonterminal;
   import java.util.stream.Stream;
   public class X {
     public static void main(String[] a) {
       double r = Stream.of(5, 3, 8, 5, 2, 7, 4, 1, 6, 9)
+        .<Integer>mapMulti((n, s) -> s.accept(n))
+        .<Integer>mapMulti((n, s) -> s.accept(n))
         .filter(n -> n > 0)
         .map(n -> n + 1)
         .peek(n -> {})
@@ -67,6 +90,8 @@ log:
   - "BUILD SUCCESS"
   - "The result is 54"
 before:
-  invokedynamic: 9
+  invokedynamic: 11
+  invokeinterface: 21
 after:
-  invokedynamic: 1
+  invokedynamic: 3
+  invokeinterface: 14

--- a/src/test/resources/org/eolang/hone/optimize/streams/mapmulti-fusion.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/mapmulti-fusion.yml
@@ -1,25 +1,30 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
-# Fusion of two adjacent user-written Stream.mapMulti operations (issue #678).
-# Unlike map/filter/etc., a mapMulti is NOT folded into a distill (distill is
-# single-emit; mapMulti is one-to-many). Instead 111 lifts each mapMulti
-# invokedynamic into a Φ.hone.lambda pragma carrying stream.method = "mapMulti",
-# the two land adjacent, and 461-fuse-mapMulti replaces the pair with one
-# Φ.hone.lambda whose target is a synthesised BiConsumer `fused` that drives the
-# first lambda with a wrapper consumer feeding the second — s.mapMulti(a)
-# .mapMulti(b) becomes s.mapMulti((x,c) -> a(x, y -> b(y,c))). 701 lowers the
-# single fused pragma back to one invokedynamic + one Stream.mapMulti.
+# Fusion of a chain of adjacent user-written Stream.mapMulti operations
+# (issue #678). Unlike map/filter/etc., a mapMulti is NOT folded into a distill
+# (distill is single-emit; mapMulti is one-to-many). Instead 111 lifts each
+# mapMulti invokedynamic into a Φ.hone.lambda pragma carrying
+# stream.method = "mapMulti", the lifted pragmas land adjacent, and
+# 461-fuse-mapMulti rewrites each adjacent pair into one Φ.hone.lambda whose
+# target is a synthesised BiConsumer `fused` that drives the first lambda with
+# a wrapper consumer feeding the second — s.mapMulti(a).mapMulti(b) becomes
+# s.mapMulti((x,c) -> a(x, y -> b(y,c))). 701 lowers the surviving fused pragma
+# back to one invokedynamic + one Stream.mapMulti.
 #
-# The chain emits one element per stage, so count() = 3 either way; the value
-# of count is not what this proves. What it proves is that the optimized class
-# still loads, verifies and runs (the fused BiConsumer and its inner wrapper
-# indy are well-formed) and that exactly one Stream.mapMulti call survives:
-# invokeinterface drops from 5 (mapMulti x2 + count + Consumer.accept x2) to 4
-# (one mapMulti removed). invokedynamic stays at 2 — the adapter relocates the
-# second call-site indy into `fused` as the wrapper builder rather than
-# eliminating it; collapsing that wrapper allocation is a separate inlining
-# step left for later.
+# The chain below stacks FIVE mapMulti operations to make the iteration
+# obvious: 461 folds them left-to-right within a single max-cycles=1 pass —
+# (a,b) -> ab, then (ab,c) -> abc, … — until exactly ONE Stream.mapMulti
+# survives. Each stage emits one element, so count() = 3 either way; the value
+# of count is not what this proves. What it proves is that the deeply-nested
+# fused BiConsumer and its chain of wrapper indys are well-formed: the
+# optimized class still loads, verifies and runs, and four of the five
+# Stream.mapMulti call sites are gone. invokeinterface drops from 11
+# (mapMulti x5 + count + Consumer.accept x5) to 7 (four mapMultis removed).
+# invokedynamic stays at 5 — the adapter relocates each fused-away call-site
+# indy into a `fused` method as a wrapper builder rather than eliminating it;
+# collapsing those wrapper allocations is a separate inlining step left for
+# later.
 java: |
   package mapmultifusion;
   import java.util.stream.Stream;
@@ -28,6 +33,9 @@ java: |
       long n = Stream.of(1, 2, 3)
         .<Integer>mapMulti((x, s) -> s.accept(x + 1))
         .<Integer>mapMulti((x, s) -> s.accept(x + 2))
+        .<Integer>mapMulti((x, s) -> s.accept(x + 3))
+        .<Integer>mapMulti((x, s) -> s.accept(x + 4))
+        .<Integer>mapMulti((x, s) -> s.accept(x + 5))
         .count();
       System.out.printf("The result is %d\n", n);
     }
@@ -38,8 +46,8 @@ log:
   - "BUILD SUCCESS"
   - "The result is 3"
 before:
-  invokedynamic: 2
-  invokeinterface: 5
+  invokedynamic: 5
+  invokeinterface: 11
 after:
-  invokedynamic: 2
-  invokeinterface: 4
+  invokedynamic: 5
+  invokeinterface: 7

--- a/src/test/resources/org/eolang/hone/optimize/streams/mapmulti-fusion.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/mapmulti-fusion.yml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Fusion of two adjacent user-written Stream.mapMulti operations (issue #678).
+# Unlike map/filter/etc., a mapMulti is NOT folded into a distill (distill is
+# single-emit; mapMulti is one-to-many). Instead 111 lifts each mapMulti
+# invokedynamic into a Φ.hone.lambda pragma carrying stream.method = "mapMulti",
+# the two land adjacent, and 461-fuse-mapMulti replaces the pair with one
+# Φ.hone.lambda whose target is a synthesised BiConsumer `fused` that drives the
+# first lambda with a wrapper consumer feeding the second — s.mapMulti(a)
+# .mapMulti(b) becomes s.mapMulti((x,c) -> a(x, y -> b(y,c))). 701 lowers the
+# single fused pragma back to one invokedynamic + one Stream.mapMulti.
+#
+# The chain emits one element per stage, so count() = 3 either way; the value
+# of count is not what this proves. What it proves is that the optimized class
+# still loads, verifies and runs (the fused BiConsumer and its inner wrapper
+# indy are well-formed) and that exactly one Stream.mapMulti call survives:
+# invokeinterface drops from 5 (mapMulti x2 + count + Consumer.accept x2) to 4
+# (one mapMulti removed). invokedynamic stays at 2 — the adapter relocates the
+# second call-site indy into `fused` as the wrapper builder rather than
+# eliminating it; collapsing that wrapper allocation is a separate inlining
+# step left for later.
+java: |
+  package mapmultifusion;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      long n = Stream.of(1, 2, 3)
+        .<Integer>mapMulti((x, s) -> s.accept(x + 1))
+        .<Integer>mapMulti((x, s) -> s.accept(x + 2))
+        .count();
+      System.out.printf("The result is %d\n", n);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 3"
+before:
+  invokedynamic: 2
+  invokeinterface: 5
+after:
+  invokedynamic: 2
+  invokeinterface: 4

--- a/src/test/resources/org/eolang/hone/optimize/streams/mapmulti-fusion.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/mapmulti-fusion.yml
@@ -15,14 +15,31 @@
 # The chain below stacks FIVE mapMulti operations to make the iteration
 # obvious: 461 folds them left-to-right within a single max-cycles=1 pass —
 # (a,b) -> ab, then (ab,c) -> abc, … — until exactly ONE Stream.mapMulti
-# survives. Each stage emits one element, so count() = 3 either way; the value
-# of count is not what this proves. What it proves is that the deeply-nested
-# fused BiConsumer and its chain of wrapper indys are well-formed: the
-# optimized class still loads, verifies and runs, and four of the five
-# Stream.mapMulti call sites are gone. invokeinterface drops from 11
-# (mapMulti x5 + count + Consumer.accept x5) to 7 (four mapMultis removed).
-# invokedynamic stays at 5 — the adapter relocates each fused-away call-site
-# indy into a `fused` method as a wrapper builder rather than eliminating it;
+# survives, with four synthesised `fused`/`wrap` method pairs (one per fold)
+# nested inside it.
+#
+# Each lambda body is a real piece of code rather than a one-liner, precisely
+# so this fixture confirms the fusion preserves behaviour and does not just
+# happen to type-check: the first fans one element out to two, the second is a
+# conditional that emits one or two depending on parity, the third emits a
+# value-dependent number of elements from a bounded loop, the fourth branches
+# on a local and may emit twice, and the fifth is a guarded emit that can drop
+# the element entirely. So every emit count along the chain is data-dependent,
+# and the elements interleave through the nested `fused`/`wrap` consumers in a
+# specific order. The terminal is an order- AND value-sensitive 31-fold
+# (reduce), so the printed result is a signature that changes if fusion
+# corrupts the emitted multiset, its values, or its order. The optimized class
+# reproduces it exactly (-1189132447), which is the real proof — bytecode that
+# merely verifies but miswires the wrapper consumers would print a different
+# number.
+#
+# Counts: invokeinterface drops from 15 to 11 — four of the five
+# Stream.mapMulti call sites are gone (the five Consumer.accept-bearing lambda
+# bodies, the surviving mapMulti and reduce stay). invokedynamic stays at 6
+# (five mapMulti lambdas + the reduce lambda before; one surviving mapMulti
+# call site + four relocated wrapper-builder indys + the reduce lambda after) —
+# the adapter relocates each fused-away call-site indy into a `fused` method as
+# a wrapper builder rather than eliminating it, so the count is conserved;
 # collapsing those wrapper allocations is a separate inlining step left for
 # later.
 java: |
@@ -30,13 +47,39 @@ java: |
   import java.util.stream.Stream;
   public class X {
     public static void main(String[] a) {
-      long n = Stream.of(1, 2, 3)
-        .<Integer>mapMulti((x, s) -> s.accept(x + 1))
-        .<Integer>mapMulti((x, s) -> s.accept(x + 2))
-        .<Integer>mapMulti((x, s) -> s.accept(x + 3))
-        .<Integer>mapMulti((x, s) -> s.accept(x + 4))
-        .<Integer>mapMulti((x, s) -> s.accept(x + 5))
-        .count();
+      int n = Stream.of(7, 12, 3, 20, 5, 14, 9)
+        .<Integer>mapMulti((x, s) -> {
+          s.accept(x);
+          s.accept(x + 100);
+        })
+        .<Integer>mapMulti((y, s) -> {
+          if (y % 2 == 0) {
+            s.accept(y * 2);
+          } else {
+            s.accept(y);
+            s.accept(y + 1);
+          }
+        })
+        .<Integer>mapMulti((z, s) -> {
+          int reps = z % 3;
+          for (int i = 0; i <= reps; i++) {
+            s.accept(z - i);
+          }
+        })
+        .<Integer>mapMulti((w, s) -> {
+          int half = w / 2;
+          if (half > 30) {
+            s.accept(half);
+          }
+          s.accept(w);
+        })
+        .<Integer>mapMulti((u, s) -> {
+          long acc = ((long) u * u) % 1000L;
+          if (acc % 2L == 1L) {
+            s.accept((int) acc);
+          }
+        })
+        .reduce(0, (p, q) -> p * 31 + q);
       System.out.printf("The result is %d\n", n);
     }
   }
@@ -44,10 +87,10 @@ log:
   - "Modified 1/1 X.phi"
   - "Finished rewriting 1 file"
   - "BUILD SUCCESS"
-  - "The result is 3"
+  - "The result is -1189132447"
 before:
-  invokedynamic: 5
-  invokeinterface: 11
+  invokedynamic: 6
+  invokeinterface: 15
 after:
-  invokedynamic: 5
-  invokeinterface: 7
+  invokedynamic: 6
+  invokeinterface: 11


### PR DESCRIPTION
A user-written `s.mapMulti(a).mapMulti(b)` currently stays as two separate stream stages — we fuse `map`/`filter`/etc. but never `mapMulti`. This adds `streams/4xx/461-fuse-mapMulti.phr`, which folds an adjacent pair into one. `111` already lifts each `mapMulti` invokedynamic into a `Φ.hone.lambda` pragma carrying `stream.method=mapMulti`, so the rule just swaps the pair for a single pragma backed by a synthesised `BiConsumer` that drives the first lambda with a wrapper consumer feeding the second — `(x,c) -> a(x, y -> b(y,c))`. It folds a chain of any length left-to-right and fires only on user lambdas (`lambda$…`) and its own products (`fused_…`), so pipeline-generated mapMultis are left alone.

Unlike `map`/`filter`, `mapMulti` is deliberately not folded into a `distill`: a distill is single-emit while `mapMulti` is one-to-many, so keeping it as a first-class pragma is what preserves the one-to-many semantics. The grep-in default also gains `mapMulti`'s hex bytes, otherwise a class that uses only `mapMulti()` gets filtered out before any rule runs.

I checked this end-to-end (disassemble → optimize → assemble → run) for chains of two, three and four: each collapses to a single `Stream.mapMulti`, the composition order is correct, the one-to-many emit is preserved, and the bytecode verifies and runs. Two things to flag: the `closure-reference` deep fixture fails for me, but it fails identically on a clean `master` (a pre-existing flake in the multi-reference capturing-map fusion, and this rule is provably inert on it), and the two Docker-based tests time out here for want of Docker. Primitive `mapMultiToInt/Long/Double`, capturing lambdas, and inlining away the per-element wrapper are left for follow-ups.

Closes #678
