### PR TITLE
Fail loudly on phino errors; distinct class names for closure fixtures (#685)

### DIFF
--- a/src/main/resources/org/eolang/hone/scaffolding/rewrite.sh
+++ b/src/main/resources/org/eolang/hone/scaffolding/rewrite.sh
@@ -135,14 +135,17 @@ function rewrite_with_timeout {
   xi=${4}
   xo=${5}
   start=$(date '+%s.%N')
-  if ! timeout "${HONE_TIMEOUT}" "${0}" rewrite "$@"; then
+  code=0
+  timeout "${HONE_TIMEOUT}" "${0}" rewrite "$@" || code=$?
+  if [ "${code}" -ne 0 ]; then
     sec=$(perl -E "say int($(date '+%s.%N') - ${start})")
-    if [ "${sec}" -eq 0 ]; then
-      echo "Failure in ${idx} $(basename "${xi}") ($(du -sh "${xi}" | cut -f1))"
-      exit 1
+    if [ "${code}" -eq 124 ] || [ "${code}" -eq 137 ]; then
+      echo "Timeout in ${idx} $(basename "${xi}") ($(du -sh "${xi}" | cut -f1)) after ${sec} seconds"
+      cp "${xi}" "${xo}"
+    else
+      echo "Failure (exit code ${code}) in ${idx} $(basename "${xi}") ($(du -sh "${xi}" | cut -f1)) after ${sec} seconds; refusing to copy it through unoptimized" >&2
+      exit "${code}"
     fi
-    echo "Timeout in ${idx} $(basename "${xi}") ($(du -sh "${xi}" | cut -f1)) after ${sec} seconds"
-    cp "${xi}" "${xo}"
   fi
 }
 

--- a/src/test/resources/org/eolang/hone/optimize/streams/closure-long-filter.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/closure-long-filter.yml
@@ -30,7 +30,7 @@ java: |
   package fusion;
   import java.util.*;
   import java.util.stream.*;
-  public class C {
+  public class CLongFilter {
     static int run(long x) {
       return Stream.of(1, 2, 3, 4, 5)
         .filter(n -> n > x)

--- a/src/test/resources/org/eolang/hone/optimize/streams/closure-long.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/closure-long.yml
@@ -29,7 +29,7 @@ java: |
   package fusion;
   import java.util.*;
   import java.util.stream.*;
-  public class C {
+  public class CLong {
     static int run(long x) {
       return Stream.of(1, 2, 3, 4, 5)
         .map(n -> (int) (n + x))

--- a/src/test/resources/org/eolang/hone/optimize/streams/closure-multi-lone.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/closure-multi-lone.yml
@@ -25,7 +25,7 @@
 java: |
   package fusion;
   import java.util.stream.*;
-  public class C {
+  public class CMultiLone {
     static int mapRun(int p, int q) {
       return Stream.of(1, 2, 3, 4, 5)
         .map(n -> n + p + q)

--- a/src/test/resources/org/eolang/hone/optimize/streams/closure-reference-filter.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/closure-reference-filter.yml
@@ -28,7 +28,7 @@ java: |
   package fusion;
   import java.util.*;
   import java.util.stream.*;
-  public class CF {
+  public class CReferenceFilter {
     static int run(List<Integer> base) {
       return Stream.of(1, 2, 3, 4, 5)
         .filter(n -> base.contains(n))

--- a/src/test/resources/org/eolang/hone/optimize/streams/closure-reference-lone.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/closure-reference-lone.yml
@@ -23,7 +23,7 @@ java: |
   package fusion;
   import java.util.*;
   import java.util.stream.*;
-  public class C {
+  public class CReferenceLone {
     static int run(List<Integer> base) {
       return Stream.of(1, 2, 3, 4, 5)
         .map(n -> n + base.size())

--- a/src/test/resources/org/eolang/hone/optimize/streams/closure-reference.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/closure-reference.yml
@@ -28,7 +28,7 @@ java: |
   package fusion;
   import java.util.*;
   import java.util.stream.*;
-  public class C {
+  public class CReference {
     static int run(List<Integer> base) {
       return Stream.of(1, 2, 3, 4, 5)
         .map(n -> n + base.size())


### PR DESCRIPTION
Fixes #685.

The deep suite intermittently failed on the `fusion.C` closure-fusion
fixtures with `invokedynamic: 3` (the unoptimized javac count) instead of
the expected `2`. As the issue diagnoses, the root visibility problem is in
`rewrite.sh`: a swallowed phino error or a missed fusion surfaced only as a
wrong opcode count instead of a loud failure, and eight fixtures sharing the
class `fusion.C` made it impossible to attribute which one regressed.

This PR implements the two "smallest useful fixes" from the issue:

### 1. `rewrite.sh` fails loudly instead of copying through unoptimized

The timeout handler used a fragile `sec -eq 0` heuristic: if the failed
rewrite took less than a second it was a "failure" (`exit 1`), otherwise it
was treated as a "timeout" and the source was silently `cp`-ed through
unoptimized. Any phino crash taking longer than a second was therefore
misclassified as a timeout and hidden.

Now the handler captures the actual exit code and distinguishes a genuine
`timeout(1)` kill (exit `124`/`137`, still copied through for production
resilience) from a real rewrite failure (any other non-zero exit), which
aborts with the phino exit code and an explicit message on stderr. The real
phino error now shows up in the test log.

### 2. Distinct class names for the closure fixtures

Renamed the colliding fixtures so each `target/classes/.../<Class>.class`
failure message points at exactly one YAML pack:

| Fixture | Old class | New class |
| --- | --- | --- |
| `closure-long.yml` | `fusion.C` | `fusion.CLong` |
| `closure-long-filter.yml` | `fusion.C` | `fusion.CLongFilter` |
| `closure-multi-lone.yml` | `fusion.C` | `fusion.CMultiLone` |
| `closure-reference.yml` | `fusion.C` | `fusion.CReference` |
| `closure-reference-lone.yml` | `fusion.C` | `fusion.CReferenceLone` |
| `closure-reference-filter.yml` | `fusion.CF` | `fusion.CReferenceFilter` |

(`closure-string.yml`'s `fusion.T` and `closures.yml`'s `closures.X` were
already distinct and left unchanged.)

Per the issue, de-flaking the capturing-map fusion itself (should it prove
nondeterministic once the error is visible) is left as a follow-up. This is
separate from #684 and does not block it.

Verified locally: `shellcheck`, `bashate -i E006,E003`, and `yamllint` all
clean on the changed files.

https://claude.ai/code/session_016x7Ln3TcBuLD9adpwtgDWL

---
_Generated by [Claude Code](https://claude.ai/code/session_016x7Ln3TcBuLD9adpwtgDWL)_