### PR TITLE
test(#691): lock IndexOutOfBoundsException fix for empty hone-statistics.csv

### DIFF
--- a/src/test/java/org/eolang/hone/CSVTest.java
+++ b/src/test/java/org/eolang/hone/CSVTest.java
@@ -98,4 +98,26 @@ final class CSVTest {
             Matchers.is(0)
         );
     }
+
+    @Test
+    void parsesCompletelyEmptyCsv(@Mktmp final Path temp) throws Exception {
+        final Path path = temp.resolve("test.csv");
+        Files.write(path, new byte[0]);
+        MatcherAssert.assertThat(
+            "empty CSV has zero data rows without throwing IndexOutOfBoundsException",
+            new CSV(path).size(),
+            Matchers.is(0)
+        );
+    }
+
+    @Test
+    void countsZeroOnCompletelyEmptyCsv(@Mktmp final Path temp) throws Exception {
+        final Path path = temp.resolve("test.csv");
+        Files.write(path, new byte[0]);
+        MatcherAssert.assertThat(
+            "empty CSV reports zero matches without throwing IndexOutOfBoundsException",
+            new CSV(path).count("Changed", v -> Integer.parseInt(v) > 0),
+            Matchers.is(0)
+        );
+    }
 }

--- a/src/test/java/org/eolang/hone/CSVTest.java
+++ b/src/test/java/org/eolang/hone/CSVTest.java
@@ -101,7 +101,7 @@ final class CSVTest {
 
     @Test
     void parsesCompletelyEmptyCsv(@Mktmp final Path temp) throws Exception {
-        final Path path = temp.resolve("test.csv");
+        final Path path = temp.resolve("empty.csv");
         Files.write(path, new byte[0]);
         MatcherAssert.assertThat(
             "empty CSV has zero data rows without throwing IndexOutOfBoundsException",
@@ -112,7 +112,7 @@ final class CSVTest {
 
     @Test
     void countsZeroOnCompletelyEmptyCsv(@Mktmp final Path temp) throws Exception {
-        final Path path = temp.resolve("test.csv");
+        final Path path = temp.resolve("empty.csv");
         Files.write(path, new byte[0]);
         MatcherAssert.assertThat(
             "empty CSV reports zero matches without throwing IndexOutOfBoundsException",


### PR DESCRIPTION
Fixes #691.

## What was happening

The reported crash:

```
java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
    at java.util.LinkedList.get (LinkedList.java:488)
    at org.cactoos.list.ListEnvelope.get (ListEnvelope.java:46)
    at org.eolang.hone.CSV.<init> (CSV.java:59)
    at org.eolang.hone.CSV.<init> (CSV.java:49)
    at org.eolang.hone.OptimizeMojo.optimize (OptimizeMojo.java:386)
```

In the released code (e.g. `0.26.2`), `CSV` derived its headers from the first
data row:

```java
private CSV(final List<CSVRecord> records) {
    this(
        new ListOf<>(records.get(0).toMap().keySet()), // <-- crashes when empty
        CSV.rows(records)
    );
}
```

When `target/hone-statistics.csv` parsed to **zero records** (a completely
empty / 0‑byte file), `records.get(0)` blew up with `Index: 0, Size: 0`.

## Status of the fix

The parsing was already reworked on `master` (commit `baa450e`, #521) to derive
headers from `CSVParser.getHeaderNames()` instead of `records.get(0)`, which
removes the crash. However, only the **header‑only** case had a regression
test; the **completely‑empty file** — the most direct trigger of the exact
`Index: 0, Size: 0` exception — was not covered.

## What this PR does

Adds two regression tests in `CSVTest` for a 0‑byte `hone-statistics.csv`:

- `parsesCompletelyEmptyCsv` — `size()` is `0`
- `countsZeroOnCompletelyEmptyCsv` — `count(...)` is `0`

I verified these tests genuinely guard the regression: reverting `from()` to the
old `records.get(0)` logic makes both reproduce the exact
`IndexOutOfBoundsException: Index 0 out of bounds for length 0`; with the
current `getHeaderNames()` implementation they pass.

Note for users still hitting this on `0.26.2`: the code fix is on `master` but
not yet released — a new release is needed to ship it.

## Testing

```
mvn -Dtest=CSVTest,SummaryTest,OptimizeMojoTest test   # 18 tests, all green
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01QLPUpcMKP41MsPBF2LUf3h)_