### PR TITLE
Fuse stream pipelines in instance methods, not only static ones

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/103-methodref-to-lambda.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/103-methodref-to-lambda.phr
@@ -53,7 +53,7 @@ pattern: |
       access ↦ 𝑒-method-access,
       modifiers ↦ ⟦
         𝐵-modifiers-before,
-        static ↦ Φ.true,
+        static ↦ 𝑒-static,
         𝐵-modifiers-after
       ⟧,
       name ↦ 𝑒-function,
@@ -130,7 +130,7 @@ result: |
       access ↦ 𝑒-method-access,
       modifiers ↦ ⟦
         𝐵-modifiers-before,
-        static ↦ Φ.true,
+        static ↦ 𝑒-static,
         𝐵-modifiers-after
       ⟧,
       name ↦ 𝑒-function,

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/104-static-methodref-to-lambda.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/104-static-methodref-to-lambda.phr
@@ -35,7 +35,7 @@ pattern: |
       access ↦ 𝑒-method-access,
       modifiers ↦ ⟦
         𝐵-modifiers-before,
-        static ↦ Φ.true,
+        static ↦ 𝑒-static,
         𝐵-modifiers-after
       ⟧,
       name ↦ 𝑒-function,
@@ -112,7 +112,7 @@ result: |
       access ↦ 𝑒-method-access,
       modifiers ↦ ⟦
         𝐵-modifiers-before,
-        static ↦ Φ.true,
+        static ↦ 𝑒-static,
         𝐵-modifiers-after
       ⟧,
       name ↦ 𝑒-function,

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/105-methodref-peek-to-lambda.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/105-methodref-peek-to-lambda.phr
@@ -47,7 +47,7 @@ pattern: |
       access ↦ 𝑒-method-access,
       modifiers ↦ ⟦
         𝐵-modifiers-before,
-        static ↦ Φ.true,
+        static ↦ 𝑒-static,
         𝐵-modifiers-after
       ⟧,
       name ↦ 𝑒-function,
@@ -132,7 +132,7 @@ result: |
       access ↦ 𝑒-method-access,
       modifiers ↦ ⟦
         𝐵-modifiers-before,
-        static ↦ Φ.true,
+        static ↦ 𝑒-static,
         𝐵-modifiers-after
       ⟧,
       name ↦ 𝑒-function,

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/111-invokedynamic-to-lambda.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/111-invokedynamic-to-lambda.phr
@@ -18,7 +18,7 @@ pattern: |
       access ↦ 𝑒-method-access,
       modifiers ↦ ⟦
         𝐵-modifiers-before,
-        static ↦ Φ.true,
+        static ↦ 𝑒-static,
         𝐵-modifiers-after
       ⟧,
       name ↦ 𝑒-function,
@@ -95,7 +95,7 @@ result: |
       access ↦ 𝑒-method-access,
       modifiers ↦ ⟦
         𝐵-modifiers-before,
-        static ↦ Φ.true,
+        static ↦ 𝑒-static,
         𝐵-modifiers-after
       ⟧,
       name ↦ 𝑒-function,

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
@@ -109,7 +109,7 @@ pattern: |
       access ↦ 𝑒-method-access,
       modifiers ↦ ⟦
         𝐵-modifiers-before,
-        static ↦ Φ.true,
+        static ↦ 𝑒-static,
         𝐵-modifiers-after
       ⟧,
       name ↦ 𝑒-function,
@@ -190,7 +190,7 @@ result: |
       access ↦ 𝑒-method-access,
       modifiers ↦ ⟦
         𝐵-modifiers-before,
-        static ↦ Φ.true,
+        static ↦ 𝑒-static,
         𝐵-modifiers-after
       ⟧,
       name ↦ 𝑒-function,

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/113-capturing-invokedynamic-to-filter.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/113-capturing-invokedynamic-to-filter.phr
@@ -48,7 +48,7 @@ pattern: |
       access ↦ 𝑒-method-access,
       modifiers ↦ ⟦
         𝐵-modifiers-before,
-        static ↦ Φ.true,
+        static ↦ 𝑒-static,
         𝐵-modifiers-after
       ⟧,
       name ↦ 𝑒-function,
@@ -129,7 +129,7 @@ result: |
       access ↦ 𝑒-method-access,
       modifiers ↦ ⟦
         𝐵-modifiers-before,
-        static ↦ Φ.true,
+        static ↦ 𝑒-static,
         𝐵-modifiers-after
       ⟧,
       name ↦ 𝑒-function,

--- a/src/test/phino/103-methodref-to-lambda-instance.yml
+++ b/src/test/phino/103-methodref-to-lambda-instance.yml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The instance-method counterpart of 103-methodref-to-lambda. The body is
+# identical to the static pack; only the enclosing method is non-static
+# (access without the ACC_STATIC bit, static -> Phi.false). 103 once pinned the
+# enclosing method as static, so a method-ref mapToInt inside an instance method
+# was left native and the whole pipeline stayed unfused (issue #689). The rule
+# must now desugar it exactly as for a static method: a fresh private-static
+# lambda$hone$N wrapper appears (the only Integer.intValue invokevirtual) and
+# the invokedynamic target handle is repointed at THIS class "T".
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/1xx/103-methodref-to-lambda.phr
+input: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    version ↦ 68,
+    access ↦ 33,
+    modifiers ↦ ⟦ φ ↦ Φ.jeo.modifiers, public ↦ Φ.true ⟧,
+    name ↦ "T",
+    supername ↦ "java/lang/Object",
+    interfaces ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+    m ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 1,
+      modifiers ↦ ⟦ φ ↦ Φ.jeo.modifiers, static ↦ Φ.false ⟧,
+      name ↦ "m",
+      descriptor ↦ "()V",
+      signature ↦ "",
+      exceptions ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, max-stack ↦ 2, max-locals ↦ 1 ⟧,
+      params ↦ ⟦ φ ↦ Φ.jeo.params ⟧,
+      annotations ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      body ↦ ⟦
+        φ ↦ Φ.jeo.seq.of,
+        p ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "map", v2 ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;", v3 ↦ Φ.true ⟧,
+        d ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokedynamic,
+          v0 ↦ "applyAsInt",
+          v1 ↦ "()Ljava/util/function/ToIntFunction;",
+          h2 ↦ ⟦ φ ↦ Φ.jeo.handle, v0 ↦ 6, v1 ↦ "java/lang/invoke/LambdaMetafactory", v2 ↦ "metafactory", v3 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;", v4 ↦ Φ.false ⟧,
+          t3 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Object;)I" ⟧,
+          h4 ↦ ⟦ φ ↦ Φ.jeo.handle, v0 ↦ 5, v1 ↦ "java/lang/Integer", v2 ↦ "intValue", v3 ↦ "()I", v4 ↦ Φ.false ⟧,
+          t5 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Integer;)I" ⟧
+        ⟧,
+        i ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "mapToInt", v2 ↦ "(Ljava/util/function/ToIntFunction;)Ljava/util/stream/IntStream;", v3 ↦ Φ.true ⟧
+      ⟧,
+      trycatchblocks ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      local-variable-table ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
+    ⟧
+  ⟧
+expected:
+  - ⟦ 𝐵-x, φ ↦ Φ.jeo.opcode.invokevirtual, 𝐵-y, 𝜏-m ↦ "intValue", 𝐵-z ⟧
+  - ⟦ 𝐵-a, φ ↦ Φ.jeo.handle, 𝐵-b, 𝜏-c ↦ "T", 𝐵-d ⟧

--- a/src/test/phino/112-capturing-invokedynamic-to-map-instance.yml
+++ b/src/test/phino/112-capturing-invokedynamic-to-map-instance.yml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The instance-method counterpart of 112-capturing-invokedynamic-to-map. The
+# body is identical to the static pack; only the enclosing method is non-static
+# (access without the ACC_STATIC bit, static -> Phi.false). 112 once pinned the
+# enclosing method as static, so a capturing map inside an instance method was
+# never lifted (issue #689). The rule must now lift the indy + invokeinterface
+# into a Φ.hone.c-map with two empty accumulators and the target lambda$
+# signature riding through verbatim, exactly as for a static method. This is a
+# pure pattern-match fragment exercising the non-static enclosing-method
+# dimension; it is not assembled or executed.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/1xx/112-capturing-invokedynamic-to-map.phr
+input: |
+  {⟦
+    φ ↦ Φ.jeo.class,
+    version ↦ 68,
+    access ↦ 33,
+    modifiers ↦ ⟦ φ ↦ Φ.jeo.modifiers, static ↦ Φ.false ⟧,
+    name ↦ "Foo",
+    supername ↦ "java/lang/Object",
+    interfaces ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+    m$run ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 0,
+      modifiers ↦ ⟦ φ ↦ Φ.jeo.modifiers, static ↦ Φ.false ⟧,
+      name ↦ "run",
+      descriptor ↦ "(III)J",
+      signature ↦ "",
+      exceptions ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, m1 ↦ 6, m2 ↦ 4 ⟧,
+      params ↦ ⟦ φ ↦ Φ.jeo.params ⟧,
+      annotations ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      body ↦ ⟦
+        i20 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 1 ⟧,
+        i21 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 2 ⟧,
+        i22 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 3 ⟧,
+        i23 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokedynamic,
+          v0 ↦ "apply",
+          v1 ↦ "(III)Ljava/util/function/Function;",
+          h2 ↦ ⟦ φ ↦ Φ.jeo.handle, v0 ↦ 6, v1 ↦ "java/lang/invoke/LambdaMetafactory", v2 ↦ "metafactory", v3 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;", v4 ↦ Φ.false ⟧,
+          t3 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Object;)Ljava/lang/Object;" ⟧,
+          h4 ↦ ⟦ φ ↦ Φ.jeo.handle, v0 ↦ 6, v1 ↦ "Foo", v2 ↦ "lambda$run$1", v3 ↦ "(IIILjava/lang/Integer;)Ljava/lang/Integer;", v4 ↦ Φ.false ⟧,
+          t5 ↦ ⟦ φ ↦ Φ.jeo.type, v0 ↦ "(Ljava/lang/Integer;)Ljava/lang/Integer;" ⟧
+        ⟧,
+        i24 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "map", v2 ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;", v3 ↦ Φ.true ⟧
+      ⟧,
+      trycatchblocks ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      local-variable-table ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.hone.c-map, state-acc ↦ ⟦⟧, body-acc ↦ ⟦⟧, 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.hone.c-map, 𝐵-g, target ↦ ⟦ 𝐵-h, signature ↦ "(IIILjava/lang/Integer;)Ljava/lang/Integer;", 𝐵-i ⟧, 𝐵-j ⟧
+  - ⟦ 𝐵-k, 𝜏-last ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, v0 ↦ 3 ⟧, 𝜏-cm ↦ ⟦ φ ↦ Φ.hone.c-map, 𝐵-l ⟧, 𝐵-m ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/instance-fusion.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/instance-fusion.yml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A point-wise pipeline must fuse the same way whether it lives in a static
+# method or in an instance method. The six front-door 1xx rules (103, 104,
+# 105, 111, 112, 113) lift a raw pipeline body out of its enclosing method;
+# they once pinned the enclosing method as static (static -> Phi.true), so the
+# identical body inside an instance method was never lifted and nothing
+# downstream fired. See issue #689. Here the pipeline sits in the instance
+# method sum() and main() drives it through a fresh X instance. The chain
+# .map(+1).map(+2).mapToInt(Integer::intValue).sum() collapses from three
+# invokedynamic factories (two maps and the method-ref mapToInt) to a single
+# mapMultiToInt dispatch, exactly as it does for a static method.
+java: |
+  package instance;
+  import java.util.stream.Stream;
+  public class X {
+    int sum() {
+      return Stream.of(1, 2, 3)
+        .map(n -> n + 1)
+        .map(n -> n + 2)
+        .mapToInt(Integer::intValue)
+        .sum();
+    }
+    public static void main(String[] a) {
+      System.out.printf("The result is %d%n", new X().sum());
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 15"
+before:
+  invokedynamic: 3
+  invokeinterface: 4
+after:
+  invokedynamic: 1
+  invokeinterface: 3


### PR DESCRIPTION
The six front-door `1xx` rules that lift a stream pipeline out of its
enclosing method (103, 104, 105, 111, 112, 113) matched the method's
modifiers with a hard-coded `static -> Phi.true`. This swaps that literal
for a metavariable that captures and reproduces the real flag, mirroring
what the `4xx` rules already do, so the pipeline lifts whether the
enclosing method is static or not.

A static and an instance method that hold the same pipeline compile to
byte-identical opcode bodies — only the `static` flag, `max-locals`, and
the lambda names differ. Because the front door insisted on a static
enclosing method, an instance pipeline was never lifted and every
downstream phase had nothing to fuse, so the same code that collapsed to
one `mapMultiToInt` in a static method stayed unfused in an instance one.

Verification was awkward locally: the Docker end-to-end test
`OptimizeMojoTest#optimizesAsSpecifiedInYamlPack` can't run on my machine
(a pre-existing `@Mktmp`-vs-parameterized resolver clash errors out all
fixtures before any body runs), so I checked the new `instance-fusion`
fixture by running the installed plugin on the host-phino path and
diffing the bytecode — before 3/4, after 1/3 invokedynamic/invokeinterface,
output 15. The host-phino pack suite (45 tests, including two new instance
packs) passes here; the Docker fixtures should run in CI as usual.

Closes #689