### PR TITLE
fix(streams): #699 rename 422 tail transform to avoid duplicate i-transform

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/422-transform-distill-tail-to-object.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/422-transform-distill-tail-to-object.phr
@@ -29,7 +29,7 @@ result: |
     state ↦ 𝑒-state,
     body ↦ ⟦
       𝐵-body,
-      i-transform ↦ ⟦
+      o-transform ↦ ⟦
         φ ↦ Φ.jeo.opcode.invokestatic,
         i2 ↦ 𝑒-transform-class,
         i3 ↦ "valueOf",

--- a/src/test/phino/422-transform-distill-tail-to-object.yml
+++ b/src/test/phino/422-transform-distill-tail-to-object.yml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A distill that accepts an object (Ljava/lang/Long;), works on the primitive
+# (J) internally, and must hand an object (Ljava/lang/Long;) back needs BOTH
+# transforms: 421 unboxes the incoming Long at the head (invokevirtual
+# longValue) and 422 boxes the outgoing long at the tail (invokestatic
+# valueOf). Before #699 both rules appended a binding called `i-transform`, so
+# firing 421 and then 422 on the same body produced a duplicate `i-transform`
+# attribute and `phino rewrite` aborted the whole class. 422 now names its tail
+# binding `o-transform`, so the two transforms coexist and the rewrite
+# succeeds.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/4xx/421-transform-distill-head-to-object.phr
+  - src/main/resources/org/eolang/hone/rules/streams/4xx/422-transform-distill-tail-to-object.phr
+input: |
+  {⟦
+    foo ↦ ⟦
+      φ ↦ Φ.hone.distill,
+      class ↦ "Foo",
+      bridge-input ↦ "Ljava/lang/Long;",
+      bridge-output ↦ "Ljava/lang/Long;",
+      start ↦ "map",
+      accepted ↦ "J",
+      returned ↦ "J",
+      static ↦ "true",
+      state ↦ ⟦ ρ ↦ ∅ ⟧,
+      body ↦ ⟦
+        i2 ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_1 ⟧,
+        i3 ↦ ⟦ φ ↦ Φ.jeo.opcode.ladd ⟧,
+        ρ ↦ ∅
+      ⟧
+    ⟧,
+    ρ ↦ ∅
+  ⟧}
+expected:
+  # The head Long is unboxed (accepted now carries the object type) ...
+  - ⟦ φ ↦ Φ.hone.distill, 𝐵-a, accepted ↦ "Ljava/lang/Long;", 𝐵-b ⟧
+  # ... and the tail long is boxed (returned now carries the object type).
+  - ⟦ φ ↦ Φ.hone.distill, 𝐵-c, returned ↦ "Ljava/lang/Long;", 𝐵-d ⟧
+  # The body keeps the head unbox (invokevirtual longValue) ...
+  - ⟦ 𝐵-x, 𝜏-head ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, 𝐵-h ⟧, 𝐵-y ⟧
+  # ... and, under a distinct name, the tail box (invokestatic valueOf).
+  - ⟦ 𝐵-p, 𝜏-tail ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, 𝐵-t ⟧, 𝐵-q ⟧


### PR DESCRIPTION
Fixes #699.

## Problem

`422-transform-distill-tail-to-object` appended a body binding named `i-transform` — the **same** name `421-transform-distill-head-to-object` uses for its head unbox. A distill that accepts an object, works on the primitive internally, and must return an object (e.g. boxing `long`→`Long`, `(J)Ljava/lang/Long;`, at the tail of a fused chain) legitimately needs **both** rules:

- `421` inserts an `invokevirtual longValue` at the head (unbox the incoming `Long`),
- `422` appends an `invokestatic valueOf` at the tail (box the outgoing `long`).

Because both used the name `i-transform`, firing `421` then `422` on the same body produced a duplicate attribute and `phino rewrite` aborted with:

```
Couldn't build expression, Duplicated attribute 'i-transform' found in i-transform, i2, i3, i4, i5, i6, i-transform, ρ
```

Since the class is rewritten as one unit, the crash left **every** method in the class unoptimized.

## Fix

Name `422`'s tail binding `o-transform` instead of `i-transform`. Body opcodes are positional labels inside a `Φ.jeo.seq.of` (existing rules already use non-numeric names like `i-pop-item`, `i-return`), so the rename is purely a label change: the head transform (`i-transform`, before `𝐵-body`) and the tail transform (`o-transform`, after `𝐵-body`) keep their order and coexist without colliding.

I chose this over the guard suggested in the issue because the repro *needs* the tail box: guarding `422` off when `i-transform` is already present would drop that transform and leave the distill half-transformed (object bridge-output, primitive `returned`). Renaming keeps both optimizations and still guarantees the rewrite can never yield a duplicate attribute. (`422` already cannot fire twice on the same distill — after firing, `returned` becomes the object type and fails the `when` guard.)

## Test

Added `src/test/phino/422-transform-distill-tail-to-object.yml`, a single-rule pack that applies `421` and `422` together to a `Long`→`long`→`Long` distill. It asserts the rewrite succeeds (the regression: previously it aborted) and that both the head `invokevirtual` and tail `invokestatic` survive under distinct names. Run with `mvn -Pdeep test`.

https://claude.ai/code/session_01NFQSU9fVooSEn2LBxjAm4Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFQSU9fVooSEn2LBxjAm4Y)_