### PR TITLE
fix(scaffolding): #700 require output XMIR before skipping rewrite

### DIFF
--- a/src/main/resources/org/eolang/hone/scaffolding/rewrite.sh
+++ b/src/main/resources/org/eolang/hone/scaffolding/rewrite.sh
@@ -71,8 +71,8 @@ function rewrite {
   mkdir -p "$(dirname "${phi}")"
   mkdir -p "$(dirname "${pho}")"
   mkdir -p "$(dirname "${xo}")"
-  if [ -f "${pho}" ] && [ "${pho}" -nt "${phi}" ]; then
-    echo "Target $(basename "${pho}") is newer than source $(basename "${phi}"); skipping transformation for ${idx}"
+  if [ -f "${pho}" ] && [ "${pho}" -nt "${phi}" ] && [ -f "${xo}" ] && [ "${xo}" -nt "${pho}" ]; then
+    echo "Target $(basename "${pho}") is newer than source $(basename "${phi}") and output $(basename "${xo}") is present; skipping transformation for ${idx}"
     return
   fi
   verbose "Next ${idx} XMIR is ${xi} ($(du -sh "${xi}" | cut -f1))"


### PR DESCRIPTION
Fixes #700.

## Problem

When a `phino` rewrite fails, a `-Phone` build could still finish `BUILD SUCCESS` and emit the original, unoptimized `.class`.

The up-to-date guard in `rewrite.sh` (line 74) returned as soon as the optimized phi `${pho}` was newer than the source phi `${phi}` — *before* the `phino rewrite --output=xmir … > "${xo}"` step at line 122. It never checked that the downstream output XMIR `${xo}` (the file `jeo:assemble` consumes) was actually produced. So when a half-finished `phi-optimized` from an earlier failed run was present, the rewrite was "skipped", `jeo:assemble` found nothing (`Total 0 files were assembled`), `hone-statistics.csv` contained only its header row, and the build went green with the bytecode unchanged.

## Fix

The guard now additionally requires that `${xo}` exists and is newer than `${pho}` before skipping:

```bash
if [ -f "${pho}" ] && [ "${pho}" -nt "${phi}" ] && [ -f "${xo}" ] && [ "${xo}" -nt "${pho}" ]; then
```

A half-finished prior run (missing or stale output XMIR) is now redone rather than accepted. On the redo, a genuine `phino` non-zero exit propagates through the existing hard-fail path (`rewrite.sh:146-147`, "refusing to copy it through unoptimized"), so the build fails loudly instead of silently shipping an unoptimized class.

## Scope notes

- The timeout pass-through (`rewrite.sh:142-144`) is left untouched: it is documented intended behavior (`OptimizeMojo.timeout`: "the file remains untouched … doesn't lead to runtime failure"), and per the issue the quiet pass-through should stay behind the future `mustOptimize=false` parameter proposed in #351.
- The existing `optimizesTwice` test is unaffected: on a clean prior run, `${xo}` is written after `${pho}`, so the new condition holds and the skip still occurs. The grep-in skip path also always produces `${xo}`, so any *complete* prior run satisfies the new condition.

https://claude.ai/code/session_014PBPVDcHZpK4ULqyJkr2dM

---
_Generated by [Claude Code](https://claude.ai/code/session_014PBPVDcHZpK4ULqyJkr2dM)_