### PR TITLE
fix(streams): #704 keep boxed-primitive filter in the boxed domain

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/3xx/304-primitive-filter-to-distill.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/3xx/304-primitive-filter-to-distill.phr
@@ -54,17 +54,7 @@ result: |
         φ ↦ Φ.jeo.label,
         i1 ↦ 𝑒-label
       ⟧,
-      i6 ↦ ⟦
-        φ ↦ Φ.jeo.frame,
-        type ↦ 4,
-        nlocal ↦ 0,
-        locals ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
-        nstack ↦ 1,
-        stack ↦ ⟦
-          φ ↦ Φ.jeo.seq.of1,
-          item ↦ 𝑒-stack-item
-        ⟧
-      ⟧
+      i6 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧
     ⟧
   ⟧
 where:
@@ -74,19 +64,6 @@ where:
   - meta: 𝜏-opcode
     function: tau
     args: [𝑒-opcode]
-  - meta: 𝑒-stack-item
-    function: sed
-    args:
-      - 𝑒-returned
-      - '"s/^B$/byte/g"'
-      - '"s/^C$/char/g"'
-      - '"s/^D$/double/g"'
-      - '"s/^F$/float/g"'
-      - '"s/^I$/integer/g"'
-      - '"s/^J$/long/g"'
-      - '"s/^S$/short/g"'
-      - '"s/^Z$/boolean/g"'
-      - '"s/^L(.+);$/$1/g"'
   - meta: 𝑒-distill
     function: sed
     args:

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/412-distill-filter-returned-to-object.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/412-distill-filter-returned-to-object.phr
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Corrects the `returned` of a boxed-primitive FILTER distill that 411 could
+# not unwind back to a primitive (the #704 defect: a
+# LongStream.filter(...).boxed() whose trailing unbox was consumed by the
+# boxed(), so 411 never fires and the distill stays in the boxed domain with
+# bridge-input/bridge-output = Ljava/lang/Long;).
+#
+# 232 represents a boxed-primitive filter with a PRIMITIVE `returned` (the
+# predicate shape, e.g. J) even though, being a filter, it preserves its
+# element and actually leaves its bridge-output (the wrapper) on the stack.
+# That primitive `returned` is the right view while the box/unbox wrapping is
+# still removable — 411 keys off `accepted == returned` to unwind a genuinely
+# primitive pipeline — but once 411 has run and the distill is still boxed
+# (bridge-output is a wrapper), the primitive `returned` is a lie: 422 would
+# then append a Wrapper.valueOf to "re-box" a survivor that is already the
+# wrapper, and the keep-frame's one-slot reference would meet a two-slot
+# primitive re-box, failing verification.
+#
+# A filter is identified structurally by the Φ.hone.frame-item marker 304
+# leaves at its keep-label (a map distill has none), so this rule only
+# realigns filter distills, leaving boxed-primitive MAP distills — which DO
+# compute a fresh primitive and legitimately need 422's valueOf — untouched.
+# `accepted` stays primitive so 421 still unboxes the wrapper for the (J)Z
+# predicate; only `returned` is promoted to the bridge-output wrapper so 422
+# sees a type-preserving distill and adds nothing. Runs after 411 and before
+# 421/422.
+name: distill-filter-returned-to-object
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.distill,
+    class ↦ 𝑒-class,
+    bridge-input ↦ 𝑒-bridge-input,
+    bridge-output ↦ 𝑒-bridge-output,
+    start ↦ 𝑒-start,
+    accepted ↦ 𝑒-accepted,
+    returned ↦ 𝑒-returned,
+    static ↦ 𝑒-static,
+    state ↦ 𝑒-state,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-frame ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.distill,
+    class ↦ 𝑒-class,
+    bridge-input ↦ 𝑒-bridge-input,
+    bridge-output ↦ 𝑒-bridge-output,
+    start ↦ 𝑒-start,
+    accepted ↦ 𝑒-accepted,
+    returned ↦ 𝑒-bridge-output,
+    static ↦ 𝑒-static,
+    state ↦ 𝑒-state,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-frame ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+when:
+  and:
+    - matches:
+        - '^[BCDFIJSZ]$'
+        - 𝑒-returned
+    - matches:
+        - '^L.+;$'
+        - 𝑒-bridge-output

--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/506-distill-filter-frame.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/506-distill-filter-frame.phr
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Resolves the Φ.hone.frame-item marker that 304 leaves at a STATELESS
+# filter guard's keep-label, the non-capturing twin of how 503/504 resolve
+# the marker for stateful (captured) guards. A filter is type-transparent —
+# it returns the item it was given — so the keep-label's stackmap frame must
+# declare the item's real type. That type is the distill's bridge-input,
+# which is only fixed once 411 has decided whether the box/unbox round-trip
+# around the filter could be unwound back to a primitive: for an unwound
+# pipeline bridge-input is the primitive (e.g. J -> `long`), for one that
+# stayed boxed (a LongStream.filter(...).boxed() that 411 cannot unwind, the
+# defect of issue #704) it is the wrapper (Ljava/lang/Long; -> java/lang/Long).
+# 304 cannot know this when it runs (3xx, before 411), so it defers the frame
+# here. By 506 the distill has been lowered to a Φ.hone.distill-lambda (501)
+# whose bridge-input is final, and 511 has not yet wrapped it into a method
+# (506 < 511), so the marker never reaches jeo. A same-locals-1 frame is
+# enough — a stateless wrapper owns no per-call counter, unlike the full
+# frame 503/504 build for the captured case. Scoped to a distill-lambda
+# WITHOUT `captured`, so stateful keep-labels stay with 503/504.
+name: distill-filter-frame
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ 𝑒-static,
+    bridge-input ↦ 𝑒-bridge-input,
+    consumer ↦ 𝑒-consumer,
+    target-method ↦ 𝑒-target-method,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-frame ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ 𝑒-static,
+    bridge-input ↦ 𝑒-bridge-input,
+    consumer ↦ 𝑒-consumer,
+    target-method ↦ 𝑒-target-method,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-frame ↦ ⟦
+        φ ↦ Φ.jeo.frame,
+        type ↦ 4,
+        nlocal ↦ 0,
+        locals ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+        nstack ↦ 1,
+        stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, item ↦ 𝑒-frame-item ⟧
+      ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+where:
+  - meta: 𝑒-frame-item
+    function: sed
+    args:
+      - 𝑒-bridge-input
+      - '"s/^B$/byte/g"'
+      - '"s/^C$/char/g"'
+      - '"s/^D$/double/g"'
+      - '"s/^F$/float/g"'
+      - '"s/^I$/integer/g"'
+      - '"s/^J$/long/g"'
+      - '"s/^S$/short/g"'
+      - '"s/^Z$/boolean/g"'
+      - '"s/^L(.+);$/$1/g"'

--- a/src/test/phino/412-distill-filter-returned-to-object.yml
+++ b/src/test/phino/412-distill-filter-returned-to-object.yml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A boxed-primitive filter distill that 411 could not unwind (the #704 defect)
+# keeps a PRIMITIVE `returned` (J, the predicate shape) even though, being a
+# filter, it preserves its element and leaves its wrapper bridge-output
+# (Ljava/lang/Long;) on the stack. Once the distill is settled in the boxed
+# domain — bridge-output is a wrapper — 412 realigns `returned` to that wrapper
+# so 422 sees a type-preserving distill and never appends a stray
+# Long.valueOf(J). `accepted` stays primitive so 421 still unboxes for the
+# (J)Z predicate. The Φ.hone.frame-item marker in the body is what identifies
+# the distill as a filter (a map distill has none), so a boxed-primitive MAP
+# distill — which DOES leave a fresh primitive and needs 422 — is left alone.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/4xx/412-distill-filter-returned-to-object.phr
+input: |
+  {⟦
+    φ ↦ Φ.hone.distill,
+    class ↦ "Foo",
+    bridge-input ↦ "Ljava/lang/Long;",
+    bridge-output ↦ "Ljava/lang/Long;",
+    start ↦ "filter",
+    accepted ↦ "J",
+    returned ↦ "J",
+    static ↦ "true",
+    state ↦ ⟦ ρ ↦ ∅ ⟧,
+    body ↦ ⟦
+      i2 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$0", i4 ↦ "(J)Z", i5 ↦ Φ.false ⟧,
+      i3 ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L1" ⟧ ⟧,
+      i4 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      i5 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L1" ⟧,
+      i6 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.hone.distill, 𝐵-a, accepted ↦ "J", 𝐵-b ⟧
+  - ⟦ φ ↦ Φ.hone.distill, 𝐵-a, returned ↦ "Ljava/lang/Long;", 𝐵-b ⟧
+  - ⟦ 𝐵-c, 𝜏-frame ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧, 𝐵-d ⟧

--- a/src/test/phino/506-distill-filter-frame.yml
+++ b/src/test/phino/506-distill-filter-frame.yml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 506 resolves the Φ.hone.frame-item marker that 304 leaves at a stateless
+# filter guard's keep-label into a same-locals-1 stackmap frame whose single
+# stack item is the distill's final bridge-input. For a boxed-primitive filter
+# that stayed in the boxed domain (the #704 defect) bridge-input is the wrapper
+# Ljava/lang/Long;, so the frame must declare a one-slot java/lang/Long
+# reference — not the two-slot primitive `long` the predicate shape would
+# suggest. Scoped to a Φ.hone.distill-lambda WITHOUT `captured`, so stateful
+# keep-labels stay with 503/504. Here the lambda's bridge-input is the wrapper,
+# so the resolved frame's stack item is java/lang/Long.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/506-distill-filter-frame.phr
+input: |
+  {⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ "true",
+    bridge-input ↦ "Ljava/lang/Long;",
+    consumer ↦ "Ljava/util/function/Consumer;",
+    target-method ↦ "distill_1",
+    body ↦ ⟦
+      i1 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 0 ⟧,
+      i2 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+      i3 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, i1 ↦ "java/lang/Long", i2 ↦ "longValue", i3 ↦ "()J", i4 ↦ Φ.false ⟧,
+      i4 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$0", i4 ↦ "(J)Z", i5 ↦ Φ.false ⟧,
+      i5 ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L1" ⟧ ⟧,
+      i6 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      i7 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L1" ⟧,
+      i8 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.jeo.frame, type ↦ 4, 𝐵-e ⟧
+  - ⟦ φ ↦ Φ.jeo.seq.of1, item ↦ "java/lang/Long" ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/long-filter-boxed.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/long-filter-boxed.yml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Reproduction of issue #704: a primitive LongStream.filter(...).boxed() chain
+# whose boxed() is consumed by a reference-stream terminal (here collect), so
+# the filter stays in the boxed domain. 203 lifts the filter to a
+# primitive-filter, 211 splits it into box + boxed-primitive-filter + unbox,
+# and 232 promotes the boxed-primitive filter into a p-filter whose bridge-input
+# is the wrapper Ljava/lang/Long; while accepted/returned stay the primitive J.
+# Because the trailing .boxed() keeps the boxing alive, 411 never unwinds the
+# filter distill back to a primitive one, so the distill stays in the boxed
+# domain (bridge-input = Ljava/lang/Long;). The keep-frame and the survivor the
+# filter passes to its Consumer must therefore describe a one-slot
+# java/lang/Long reference, not a two-slot primitive long. Before the fix the
+# distill emitted a `long` keep-frame and re-boxed the survivor with a stray
+# Long.valueOf(J), so the optimized class failed JVM verification with
+# "Inconsistent stackmap frames at branch target 12 ... stack size doesn't
+# match" (the kept value is a one-slot Ljava/lang/Long; while the frame and the
+# valueOf assume a two-slot long). The deferred Φ.hone.frame-item marker (304,
+# resolved by 506 from the final bridge-input) and 412 (which realigns a
+# boxed filter distill's `returned` to its wrapper bridge-output so 422 adds no
+# valueOf) fix it.
+#
+# {1..10} filtered to multiples of 3 = {3, 6, 9}, summed back as long = 18. The
+# lone filter lowers to a single Stream.mapMulti, so invokedynamic stays at 1.
+java: |
+  package longfilterboxed;
+  import java.util.List;
+  import java.util.stream.Collectors;
+  import java.util.stream.LongStream;
+  public class X {
+    public static void main(String[] a) {
+      List<Long> kept = LongStream.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L)
+        .filter(n -> n % 3L == 0L)
+        .boxed()
+        .collect(Collectors.toList());
+      long sum = 0L;
+      for (final Long v : kept) {
+        sum += v;
+      }
+      System.out.printf("The result is %d\n", sum);
+    }
+  }
+log:
+  - "BUILD SUCCESS"
+  - "The result is 18"
+before:
+  invokedynamic: 1
+after:
+  invokedynamic: 1


### PR DESCRIPTION
Fixes #704.

## Problem

A primitive `filter(...).boxed()` chain whose `boxed()` is consumed by a reference-stream operation (e.g. `collect`, `forEach`, `count`) stays in the boxed domain:

- `203`→`211`→`232` turn the filter into a `Φ.hone.p-filter` whose `bridge-input`/`bridge-output` are the wrapper (`Ljava/lang/Long;`) while `accepted`/`returned` keep the **primitive** predicate shape `J`.
- Because the trailing `boxed()` keeps the boxing alive, `411` never unwinds the filter distill back to a primitive one, so the distill genuinely handles a one-slot `Ljava/lang/Long;` reference on the stack.
- But `304` emitted the keep-frame from `returned` (→ `long`, two slots) and `422` appended a `Long.valueOf(J)` as if re-boxing a primitive. The kept value is already a `Long`, so the optimized class failed JVM verification:

```
java.lang.VerifyError: Inconsistent stackmap frames at branch target 12
  Reason: Current frame's stack size doesn't match stackmap.
  Current Frame:  stack: { 'java/lang/Long', integer }
  Stackmap Frame: stack: { long, long_2nd }
```

## Fix

The keep value of a filter is its `bridge-input`, whose final shape is only known **after** `411` decides whether the box/unbox round-trip could be unwound. So:

- **`304`** now defers the keep-frame to a `Φ.hone.frame-item` marker (the non-capturing twin of what `314` already does).
- **`506`** (new, stateless twin of `503`/`504`) resolves that marker from the **final** `bridge-input` — the wrapper when the filter stayed boxed (`java/lang/Long`), the primitive when `411` unwound it (`long`).
- **`412`** (new) realigns a boxed filter distill's `returned` to its wrapper `bridge-output` (a filter preserves its element), so `422` sees a type-preserving distill and adds no redundant `valueOf`. `accepted` stays primitive so `421` still unboxes for the `(J)Z` predicate. It is scoped to filter distills via the `Φ.hone.frame-item` marker, leaving boxed-primitive **map** distills (which do compute a fresh primitive and need `422`) untouched.

The resulting distill body matches exactly what the issue says it should be: a `java/lang/Long` keep-frame and a survivor passed straight to `Consumer.accept(Object)` with no stray `valueOf`.

## Tests

- `src/test/resources/org/eolang/hone/optimize/streams/long-filter-boxed.yml` — end-to-end reproduction (`LongStream.filter(...).boxed().collect(...)`), now verifies and runs (`The result is 18`).
- `src/test/phino/412-distill-filter-returned-to-object.yml` and `src/test/phino/506-distill-filter-frame.yml` — single-rule packs for the two new rules.

## Validation (JDK 21, host phino 0.0.77, no Docker)

- All 48 single-rule phino packs pass (46 existing + 2 new).
- All non-Docker end-to-end `OptimizeMojoTest` cases pass.
- Direct pipeline checks: `LongStream.filter().boxed().collect()`, `...forEach()` now verify; non-boxed `Int/Long/Double` `filter().map().sum()`, object `filter`/`filter().map()` still verify and produce correct results.

## Known limitation

A *chained* boxed-primitive filter (`filter().boxed().filter()`) hits a separate, deeper inter-filter box/unbox issue (rules `221`/`252`/`282`) and is not fixed here — it was already broken before this change. This PR resolves the single-`filter().boxed()` case reported in #704.

https://claude.ai/code/session_01Hg1txmiF5dhvSPKjj3Q41F

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hg1txmiF5dhvSPKjj3Q41F)_