### PR TITLE
Count genuine stream optimizations in coverage "Edits" column

### DIFF
--- a/.github/hone-it.sh
+++ b/.github/hone-it.sh
@@ -75,17 +75,17 @@ apply_hone() {
   done < <(find "${base}" -type d -path '*/target/classes' -print0)
 }
 
-count_modified() {
+count_optimized() {
   local base=$1
-  local -a stats=()
-  while IFS= read -r -d '' f; do
-    stats+=("${f}")
-  done < <(find "${base}" -type f -path '*/target/hone-statistics.csv' -print0)
-  if [ "${#stats[@]}" -eq 0 ]; then
-    echo 0
-    return
-  fi
-  awk -F',' 'FNR == 1 { next } $(NF-1) + 0 > 0 { modified += 1 } END { print modified + 0 }' "${stats[@]}"
+  local total=0 after before a b
+  while IFS= read -r -d '' after; do
+    before=${after/\/target\/classes\//\/target\/classes-before-hone\/}
+    test -f "${before}" || continue
+    a=$(javap -c -p "${after}"  2>/dev/null | grep -cE 'java/util/stream/(Int|Long|Double)?Stream' || true)
+    b=$(javap -c -p "${before}" 2>/dev/null | grep -cE 'java/util/stream/(Int|Long|Double)?Stream' || true)
+    test "${a}" -lt "${b}" && total=$(( total + 1 ))
+  done < <(find "${base}" -type f -path '*/target/classes/*.class' -print0)
+  echo "${total}"
 }
 
 build_outcome() {
@@ -133,7 +133,7 @@ total=$(count_classes "${dir}")
 hstart=$(date +%s)
 apply_hone "${dir}"
 hone_seconds=$(( $(date +%s) - hstart ))
-count=$(count_modified "${dir}")
+count=$(count_optimized "${dir}")
 row="${row},${total},${count},${hone_seconds}"
 echo "warming up the test runner for honed ${repo}"
 timeout "${budget}" mvn "${flags[@]}" -f "${dir}" initialize surefire:test || true


### PR DESCRIPTION
Fixes #708.

## Problem

The coverage table's "Edits" column (`modified/streams`) was rendering numerators larger than denominators — `junit4 11/0`, `vavr 169/24`, `commons-collections 101/12` — which is impossible if the numerator means "stream classes optimised".

`count_modified` tallied rows in `hone-statistics.csv` where `Changed > 0`. But `Changed` is just the line diff between the input and output `.phi` of phino's rewrite pass, which is **not** stream-specific:

- `streams/1xx/151-remove-line-numbers.phr` strips `Φ.jeo.line-number` nodes from every debug-compiled class.
- The grep-in pre-filter (`OptimizeMojo.java`) admits any class with a `map`/`filter`/`mapMulti` method (such as `Optional.map`), not only `java.util.stream` users.

So classes with no stream bytecode get `Changed > 0` and are counted, while `count_streams` correctly reports zero (junit4, pre-Java-8, showing `11/0` is the proof).

## Fix

Replace `count_modified` with `count_optimized`, which compares the `java.util.stream` invoke count in `target/classes-before-hone` (the original javac bytecode) against `target/classes` (optimised), using the same regex as `count_streams`, and counts only classes where it dropped.

The jeo round-trip preserves invokes, so this is immune to round-trip churn, and it guarantees the numerator is a subset of the stream-class population (`NN ≤ MM`).


---
_Generated by [Claude Code](https://claude.ai/code/session_017TL48XTFuMUT5QWLWdjRgU)_