### PR TITLE
Convert flatMapToInt/Long/Double to mapMultiToX (#711)

### DIFF
--- a/src/main/java/org/eolang/hone/OptimizeMojo.java
+++ b/src/main/java/org/eolang/hone/OptimizeMojo.java
@@ -105,6 +105,9 @@ public final class OptimizeMojo extends AbstractMojo {
         "distinct",
         "skip",
         "flatMap",
+        "flatMapToInt",
+        "flatMapToLong",
+        "flatMapToDouble",
         "mapMulti"
     ).toString();
 

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/456-flatMapToInt-to-mapMultiToInt.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/456-flatMapToInt-to-mapMultiToInt.phr
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The IntStream sibling of 455-flatMap-to-mapMulti. Converts a user-written
+# Stream.flatMapToInt into an equivalent Stream.mapMultiToInt. flatMapToInt takes
+# a Function<T, IntStream> and flattens the returned IntStreams; the same fan-out
+# is expressed by mapMultiToInt((x, c) -> mapper(x).forEach(c)), where c is the
+# downstream IntConsumer. 111 lifts the flatMapToInt invokedynamic into a
+# Φ.hone.lambda carrying stream.method = "flatMapToInt" and a handle-6 target to a
+# non-capturing lambda$ body of signature (L<elem>;)Ljava/util/stream/IntStream;.
+# This rule rewrites that pragma into the shape 111 produces for a user
+# mapMultiToInt — a Φ.hone.lambda with interface BiConsumer, stream.method =
+# "mapMultiToInt", and a handle-6 target — whose target is a freshly synthesised
+# BiConsumer `flatadapt`:
+#
+#   flatadapt(x, c):  invokestatic lambda$(x) -> IntStream ; mapper applied to item
+#                     invokeinterface IntStream.forEach(c) ; drains it into c
+#
+# The mapper body is kept untouched. IntStream.forEach takes precisely the
+# IntConsumer that mapMultiToInt hands down, so the same adapter shape 455
+# synthesises works unchanged here. 501/502 already emit mapMultiToInt dispatches,
+# so the jeo roundtrip of these calls is proven.
+#
+# Scope: reference Stream.flatMapToInt only (mapper returns
+# java/util/stream/IntStream). Like 455, this assumes the mapper returns a
+# non-null, non-resource stream — the null-skip and auto-close of flatMapToInt are
+# not reproduced.
+name: flatMapToInt-to-mapMultiToInt
+pattern: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    𝐵-class-head,
+    𝜏-method ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      𝐵-method-head,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-flatmap ↦ ⟦
+          φ ↦ Φ.hone.lambda,
+          class ↦ 𝑒-class,
+          method ↦ "apply",
+          interface ↦ "()Ljava/util/function/Function;",
+          lambda-signature ↦ "(Ljava/lang/Object;)Ljava/lang/Object;",
+          bridge-signature ↦ 𝑒-bridge-signature,
+          static ↦ "true",
+          opcode ↦ 𝑒-opcode,
+          target ↦ ⟦
+            handle ↦ 6,
+            class ↦ 𝑒-target-class,
+            method ↦ 𝑒-target-method,
+            signature ↦ 𝑒-target-signature,
+            is-interface ↦ 𝑒-target-is-interface
+          ⟧,
+          stream ↦ ⟦
+            class ↦ "java/util/stream/Stream",
+            method ↦ "flatMapToInt",
+            signature ↦ "(Ljava/util/function/Function;)Ljava/util/stream/IntStream;"
+          ⟧
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝐵-method-tail
+    ⟧,
+    𝐵-class-tail,
+    ρ ↦ ∅
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    𝐵-class-head,
+    𝜏-method ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      𝐵-method-head,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-flatmap ↦ ⟦
+          φ ↦ Φ.hone.lambda,
+          class ↦ 𝑒-class,
+          method ↦ "accept",
+          interface ↦ "()Ljava/util/function/BiConsumer;",
+          lambda-signature ↦ "(Ljava/lang/Object;Ljava/lang/Object;)V",
+          bridge-signature ↦ 𝑒-adapter-signature,
+          static ↦ "true",
+          opcode ↦ "invokestatic",
+          target ↦ ⟦
+            handle ↦ 6,
+            class ↦ 𝑒-class,
+            method ↦ 𝑒-adapter-name,
+            signature ↦ 𝑒-adapter-signature,
+            is-interface ↦ 𝑒-target-is-interface
+          ⟧,
+          stream ↦ ⟦
+            class ↦ "java/util/stream/Stream",
+            method ↦ "mapMultiToInt",
+            signature ↦ "(Ljava/util/function/BiConsumer;)Ljava/util/stream/IntStream;"
+          ⟧
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝐵-method-tail
+    ⟧,
+    𝐵-class-tail,
+    𝜏-adapter-method ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 4106,
+      descriptor ↦ 𝑒-adapter-signature,
+      signature ↦ "",
+      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, max-stack ↦ 2, max-locals ↦ 2 ⟧,
+      params ↦ ⟦
+        φ ↦ Φ.jeo.params,
+        i1 ↦ ⟦ φ ↦ Φ.jeo.param, index ↦ 0, access ↦ 0, type ↦ 𝑒-flatmap-input ⟧,
+        i2 ↦ ⟦ φ ↦ Φ.jeo.param, index ↦ 1, access ↦ 0, type ↦ "Ljava/util/function/IntConsumer;" ⟧
+      ⟧,
+      body ↦ ⟦
+        φ ↦ Φ.jeo.seq.of,
+        ld-item ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 0 ⟧,
+        call-mapper ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokestatic,
+          i2 ↦ 𝑒-target-class,
+          i3 ↦ 𝑒-target-method,
+          i4 ↦ 𝑒-target-signature,
+          i5 ↦ 𝑒-target-is-interface
+        ⟧,
+        ld-downstream ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
+        call-foreach ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          i2 ↦ "java/util/stream/IntStream",
+          i3 ↦ "forEach",
+          i4 ↦ "(Ljava/util/function/IntConsumer;)V",
+          i5 ↦ Φ.true
+        ⟧,
+        ret ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+        ρ ↦ ∅
+      ⟧,
+      name ↦ 𝑒-adapter-name
+    ⟧,
+    ρ ↦ ∅
+  ⟧
+where:
+  - meta: 𝜏-adapter-method
+    function: random-tau
+  - meta: 𝑒-adapter-name
+    function: random-string
+    args: [ '"flatadapt_%d"' ]
+  - meta: 𝑒-flatmap-input
+    function: sed
+    args:
+      - 𝑒-target-signature
+      - '"s/^[(](L[^;]*;).*/$1/"'
+  - meta: 𝑒-adapter-signature
+    function: concat
+    args: [ '"("', 𝑒-flatmap-input, '"Ljava/util/function/IntConsumer;)V"' ]

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/457-flatMapToLong-to-mapMultiToLong.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/457-flatMapToLong-to-mapMultiToLong.phr
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The LongStream sibling of 455-flatMap-to-mapMulti. Converts a user-written
+# Stream.flatMapToLong into an equivalent Stream.mapMultiToLong. flatMapToLong
+# takes a Function<T, LongStream> and flattens the returned LongStreams; the same
+# fan-out is expressed by mapMultiToLong((x, c) -> mapper(x).forEach(c)), where c
+# is the downstream LongConsumer. 111 lifts the flatMapToLong invokedynamic into a
+# Φ.hone.lambda carrying stream.method = "flatMapToLong" and a handle-6 target to
+# a non-capturing lambda$ body of signature
+# (L<elem>;)Ljava/util/stream/LongStream;. This rule rewrites that pragma into the
+# shape 111 produces for a user mapMultiToLong — a Φ.hone.lambda with interface
+# BiConsumer, stream.method = "mapMultiToLong", and a handle-6 target — whose
+# target is a freshly synthesised BiConsumer `flatadapt`:
+#
+#   flatadapt(x, c):  invokestatic lambda$(x) -> LongStream ; mapper applied to item
+#                     invokeinterface LongStream.forEach(c) ; drains it into c
+#
+# The mapper body is kept untouched. LongStream.forEach takes precisely the
+# LongConsumer that mapMultiToLong hands down, so the same adapter shape 455
+# synthesises works unchanged here. 501/502 already emit mapMultiToLong
+# dispatches, so the jeo roundtrip of these calls is proven.
+#
+# Scope: reference Stream.flatMapToLong only (mapper returns
+# java/util/stream/LongStream). Like 455, this assumes the mapper returns a
+# non-null, non-resource stream — the null-skip and auto-close of flatMapToLong
+# are not reproduced.
+name: flatMapToLong-to-mapMultiToLong
+pattern: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    𝐵-class-head,
+    𝜏-method ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      𝐵-method-head,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-flatmap ↦ ⟦
+          φ ↦ Φ.hone.lambda,
+          class ↦ 𝑒-class,
+          method ↦ "apply",
+          interface ↦ "()Ljava/util/function/Function;",
+          lambda-signature ↦ "(Ljava/lang/Object;)Ljava/lang/Object;",
+          bridge-signature ↦ 𝑒-bridge-signature,
+          static ↦ "true",
+          opcode ↦ 𝑒-opcode,
+          target ↦ ⟦
+            handle ↦ 6,
+            class ↦ 𝑒-target-class,
+            method ↦ 𝑒-target-method,
+            signature ↦ 𝑒-target-signature,
+            is-interface ↦ 𝑒-target-is-interface
+          ⟧,
+          stream ↦ ⟦
+            class ↦ "java/util/stream/Stream",
+            method ↦ "flatMapToLong",
+            signature ↦ "(Ljava/util/function/Function;)Ljava/util/stream/LongStream;"
+          ⟧
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝐵-method-tail
+    ⟧,
+    𝐵-class-tail,
+    ρ ↦ ∅
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    𝐵-class-head,
+    𝜏-method ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      𝐵-method-head,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-flatmap ↦ ⟦
+          φ ↦ Φ.hone.lambda,
+          class ↦ 𝑒-class,
+          method ↦ "accept",
+          interface ↦ "()Ljava/util/function/BiConsumer;",
+          lambda-signature ↦ "(Ljava/lang/Object;Ljava/lang/Object;)V",
+          bridge-signature ↦ 𝑒-adapter-signature,
+          static ↦ "true",
+          opcode ↦ "invokestatic",
+          target ↦ ⟦
+            handle ↦ 6,
+            class ↦ 𝑒-class,
+            method ↦ 𝑒-adapter-name,
+            signature ↦ 𝑒-adapter-signature,
+            is-interface ↦ 𝑒-target-is-interface
+          ⟧,
+          stream ↦ ⟦
+            class ↦ "java/util/stream/Stream",
+            method ↦ "mapMultiToLong",
+            signature ↦ "(Ljava/util/function/BiConsumer;)Ljava/util/stream/LongStream;"
+          ⟧
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝐵-method-tail
+    ⟧,
+    𝐵-class-tail,
+    𝜏-adapter-method ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 4106,
+      descriptor ↦ 𝑒-adapter-signature,
+      signature ↦ "",
+      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, max-stack ↦ 2, max-locals ↦ 2 ⟧,
+      params ↦ ⟦
+        φ ↦ Φ.jeo.params,
+        i1 ↦ ⟦ φ ↦ Φ.jeo.param, index ↦ 0, access ↦ 0, type ↦ 𝑒-flatmap-input ⟧,
+        i2 ↦ ⟦ φ ↦ Φ.jeo.param, index ↦ 1, access ↦ 0, type ↦ "Ljava/util/function/LongConsumer;" ⟧
+      ⟧,
+      body ↦ ⟦
+        φ ↦ Φ.jeo.seq.of,
+        ld-item ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 0 ⟧,
+        call-mapper ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokestatic,
+          i2 ↦ 𝑒-target-class,
+          i3 ↦ 𝑒-target-method,
+          i4 ↦ 𝑒-target-signature,
+          i5 ↦ 𝑒-target-is-interface
+        ⟧,
+        ld-downstream ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
+        call-foreach ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          i2 ↦ "java/util/stream/LongStream",
+          i3 ↦ "forEach",
+          i4 ↦ "(Ljava/util/function/LongConsumer;)V",
+          i5 ↦ Φ.true
+        ⟧,
+        ret ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+        ρ ↦ ∅
+      ⟧,
+      name ↦ 𝑒-adapter-name
+    ⟧,
+    ρ ↦ ∅
+  ⟧
+where:
+  - meta: 𝜏-adapter-method
+    function: random-tau
+  - meta: 𝑒-adapter-name
+    function: random-string
+    args: [ '"flatadapt_%d"' ]
+  - meta: 𝑒-flatmap-input
+    function: sed
+    args:
+      - 𝑒-target-signature
+      - '"s/^[(](L[^;]*;).*/$1/"'
+  - meta: 𝑒-adapter-signature
+    function: concat
+    args: [ '"("', 𝑒-flatmap-input, '"Ljava/util/function/LongConsumer;)V"' ]

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/458-flatMapToDouble-to-mapMultiToDouble.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/458-flatMapToDouble-to-mapMultiToDouble.phr
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The DoubleStream sibling of 455-flatMap-to-mapMulti. Converts a user-written
+# Stream.flatMapToDouble into an equivalent Stream.mapMultiToDouble.
+# flatMapToDouble takes a Function<T, DoubleStream> and flattens the returned
+# DoubleStreams; the same fan-out is expressed by
+# mapMultiToDouble((x, c) -> mapper(x).forEach(c)), where c is the downstream
+# DoubleConsumer. 111 lifts the flatMapToDouble invokedynamic into a Φ.hone.lambda
+# carrying stream.method = "flatMapToDouble" and a handle-6 target to a
+# non-capturing lambda$ body of signature
+# (L<elem>;)Ljava/util/stream/DoubleStream;. This rule rewrites that pragma into
+# the shape 111 produces for a user mapMultiToDouble — a Φ.hone.lambda with
+# interface BiConsumer, stream.method = "mapMultiToDouble", and a handle-6 target —
+# whose target is a freshly synthesised BiConsumer `flatadapt`:
+#
+#   flatadapt(x, c):  invokestatic lambda$(x) -> DoubleStream ; mapper applied to item
+#                     invokeinterface DoubleStream.forEach(c) ; drains it into c
+#
+# The mapper body is kept untouched. DoubleStream.forEach takes precisely the
+# DoubleConsumer that mapMultiToDouble hands down, so the same adapter shape 455
+# synthesises works unchanged here. 501/502 already emit mapMultiToDouble
+# dispatches, so the jeo roundtrip of these calls is proven.
+#
+# Scope: reference Stream.flatMapToDouble only (mapper returns
+# java/util/stream/DoubleStream). Like 455, this assumes the mapper returns a
+# non-null, non-resource stream — the null-skip and auto-close of flatMapToDouble
+# are not reproduced.
+name: flatMapToDouble-to-mapMultiToDouble
+pattern: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    𝐵-class-head,
+    𝜏-method ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      𝐵-method-head,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-flatmap ↦ ⟦
+          φ ↦ Φ.hone.lambda,
+          class ↦ 𝑒-class,
+          method ↦ "apply",
+          interface ↦ "()Ljava/util/function/Function;",
+          lambda-signature ↦ "(Ljava/lang/Object;)Ljava/lang/Object;",
+          bridge-signature ↦ 𝑒-bridge-signature,
+          static ↦ "true",
+          opcode ↦ 𝑒-opcode,
+          target ↦ ⟦
+            handle ↦ 6,
+            class ↦ 𝑒-target-class,
+            method ↦ 𝑒-target-method,
+            signature ↦ 𝑒-target-signature,
+            is-interface ↦ 𝑒-target-is-interface
+          ⟧,
+          stream ↦ ⟦
+            class ↦ "java/util/stream/Stream",
+            method ↦ "flatMapToDouble",
+            signature ↦ "(Ljava/util/function/Function;)Ljava/util/stream/DoubleStream;"
+          ⟧
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝐵-method-tail
+    ⟧,
+    𝐵-class-tail,
+    ρ ↦ ∅
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    𝐵-class-head,
+    𝜏-method ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      𝐵-method-head,
+      body ↦ ⟦
+        𝐵-body-head,
+        𝜏-flatmap ↦ ⟦
+          φ ↦ Φ.hone.lambda,
+          class ↦ 𝑒-class,
+          method ↦ "accept",
+          interface ↦ "()Ljava/util/function/BiConsumer;",
+          lambda-signature ↦ "(Ljava/lang/Object;Ljava/lang/Object;)V",
+          bridge-signature ↦ 𝑒-adapter-signature,
+          static ↦ "true",
+          opcode ↦ "invokestatic",
+          target ↦ ⟦
+            handle ↦ 6,
+            class ↦ 𝑒-class,
+            method ↦ 𝑒-adapter-name,
+            signature ↦ 𝑒-adapter-signature,
+            is-interface ↦ 𝑒-target-is-interface
+          ⟧,
+          stream ↦ ⟦
+            class ↦ "java/util/stream/Stream",
+            method ↦ "mapMultiToDouble",
+            signature ↦ "(Ljava/util/function/BiConsumer;)Ljava/util/stream/DoubleStream;"
+          ⟧
+        ⟧,
+        𝐵-body-tail
+      ⟧,
+      𝐵-method-tail
+    ⟧,
+    𝐵-class-tail,
+    𝜏-adapter-method ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 4106,
+      descriptor ↦ 𝑒-adapter-signature,
+      signature ↦ "",
+      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, max-stack ↦ 2, max-locals ↦ 2 ⟧,
+      params ↦ ⟦
+        φ ↦ Φ.jeo.params,
+        i1 ↦ ⟦ φ ↦ Φ.jeo.param, index ↦ 0, access ↦ 0, type ↦ 𝑒-flatmap-input ⟧,
+        i2 ↦ ⟦ φ ↦ Φ.jeo.param, index ↦ 1, access ↦ 0, type ↦ "Ljava/util/function/DoubleConsumer;" ⟧
+      ⟧,
+      body ↦ ⟦
+        φ ↦ Φ.jeo.seq.of,
+        ld-item ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 0 ⟧,
+        call-mapper ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokestatic,
+          i2 ↦ 𝑒-target-class,
+          i3 ↦ 𝑒-target-method,
+          i4 ↦ 𝑒-target-signature,
+          i5 ↦ 𝑒-target-is-interface
+        ⟧,
+        ld-downstream ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
+        call-foreach ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          i2 ↦ "java/util/stream/DoubleStream",
+          i3 ↦ "forEach",
+          i4 ↦ "(Ljava/util/function/DoubleConsumer;)V",
+          i5 ↦ Φ.true
+        ⟧,
+        ret ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+        ρ ↦ ∅
+      ⟧,
+      name ↦ 𝑒-adapter-name
+    ⟧,
+    ρ ↦ ∅
+  ⟧
+where:
+  - meta: 𝜏-adapter-method
+    function: random-tau
+  - meta: 𝑒-adapter-name
+    function: random-string
+    args: [ '"flatadapt_%d"' ]
+  - meta: 𝑒-flatmap-input
+    function: sed
+    args:
+      - 𝑒-target-signature
+      - '"s/^[(](L[^;]*;).*/$1/"'
+  - meta: 𝑒-adapter-signature
+    function: concat
+    args: [ '"("', 𝑒-flatmap-input, '"Ljava/util/function/DoubleConsumer;)V"' ]

--- a/src/test/phino/456-flatMapToInt-to-mapMultiToInt.yml
+++ b/src/test/phino/456-flatMapToInt-to-mapMultiToInt.yml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 456 converts a user-written Stream.flatMapToInt into an equivalent
+# Stream.mapMultiToInt — the IntStream sibling of 455. The input is the
+# Φ.hone.lambda form 111 lifts a flatMapToInt into: interface Function,
+# stream.method = "flatMapToInt", and a handle-6 target to a non-capturing
+# lambda$main$0 of signature (L<elem>;)Ljava/util/stream/IntStream;. The rule
+# rewrites that pragma into the user-mapMultiToInt Φ.hone.lambda form (interface
+# BiConsumer, stream.method = "mapMultiToInt", handle-6 target) whose target is a
+# freshly synthesised BiConsumer `flatadapt`, and appends that adapter method to
+# the class. The adapter applies the original mapper to the item
+# (invokestatic lambda$main$0) and drains the returned IntStream into the
+# downstream IntConsumer (invokeinterface IntStream.forEach). Matching all three —
+# the surviving mapMultiToInt stream block, the invokestatic into the untouched
+# mapper body, and the IntStream.forEach — proves the flatMapToInt was rewired
+# into a mapMultiToInt rather than dropped.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/4xx/456-flatMapToInt-to-mapMultiToInt.phr
+input: |
+  {⟦
+    φ ↦ Φ.jeo.class,
+    name ↦ "Foo",
+    jm$main ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      name ↦ "main",
+      body ↦ ⟦
+        φ ↦ Φ.jeo.seq.of,
+        op0 ↦ ⟦
+          φ ↦ Φ.hone.lambda,
+          class ↦ "Foo",
+          method ↦ "apply",
+          interface ↦ "()Ljava/util/function/Function;",
+          lambda-signature ↦ "(Ljava/lang/Object;)Ljava/lang/Object;",
+          bridge-signature ↦ "(Ljava/lang/Integer;)Ljava/util/stream/IntStream;",
+          static ↦ "true",
+          opcode ↦ "invokestatic",
+          target ↦ ⟦ handle ↦ 6, class ↦ "Foo", method ↦ "lambda$main$0", signature ↦ "(Ljava/lang/Integer;)Ljava/util/stream/IntStream;", is-interface ↦ Φ.false ⟧,
+          stream ↦ ⟦ class ↦ "java/util/stream/Stream", method ↦ "flatMapToInt", signature ↦ "(Ljava/util/function/Function;)Ljava/util/stream/IntStream;" ⟧
+        ⟧,
+        ρ ↦ ∅
+      ⟧
+    ⟧,
+    ρ ↦ ∅
+  ⟧}
+expected:
+  - ⟦ class ↦ "java/util/stream/Stream", method ↦ "mapMultiToInt", signature ↦ "(Ljava/util/function/BiConsumer;)Ljava/util/stream/IntStream;" ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$0", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/stream/IntStream", i3 ↦ "forEach", 𝐵-rest ⟧

--- a/src/test/phino/457-flatMapToLong-to-mapMultiToLong.yml
+++ b/src/test/phino/457-flatMapToLong-to-mapMultiToLong.yml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 457 converts a user-written Stream.flatMapToLong into an equivalent
+# Stream.mapMultiToLong — the LongStream sibling of 455. The input is the
+# Φ.hone.lambda form 111 lifts a flatMapToLong into: interface Function,
+# stream.method = "flatMapToLong", and a handle-6 target to a non-capturing
+# lambda$main$0 of signature (L<elem>;)Ljava/util/stream/LongStream;. The rule
+# rewrites that pragma into the user-mapMultiToLong Φ.hone.lambda form (interface
+# BiConsumer, stream.method = "mapMultiToLong", handle-6 target) whose target is a
+# freshly synthesised BiConsumer `flatadapt`, and appends that adapter method to
+# the class. The adapter applies the original mapper to the item
+# (invokestatic lambda$main$0) and drains the returned LongStream into the
+# downstream LongConsumer (invokeinterface LongStream.forEach). Matching all
+# three — the surviving mapMultiToLong stream block, the invokestatic into the
+# untouched mapper body, and the LongStream.forEach — proves the flatMapToLong was
+# rewired into a mapMultiToLong rather than dropped.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/4xx/457-flatMapToLong-to-mapMultiToLong.phr
+input: |
+  {⟦
+    φ ↦ Φ.jeo.class,
+    name ↦ "Foo",
+    jm$main ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      name ↦ "main",
+      body ↦ ⟦
+        φ ↦ Φ.jeo.seq.of,
+        op0 ↦ ⟦
+          φ ↦ Φ.hone.lambda,
+          class ↦ "Foo",
+          method ↦ "apply",
+          interface ↦ "()Ljava/util/function/Function;",
+          lambda-signature ↦ "(Ljava/lang/Object;)Ljava/lang/Object;",
+          bridge-signature ↦ "(Ljava/lang/Integer;)Ljava/util/stream/LongStream;",
+          static ↦ "true",
+          opcode ↦ "invokestatic",
+          target ↦ ⟦ handle ↦ 6, class ↦ "Foo", method ↦ "lambda$main$0", signature ↦ "(Ljava/lang/Integer;)Ljava/util/stream/LongStream;", is-interface ↦ Φ.false ⟧,
+          stream ↦ ⟦ class ↦ "java/util/stream/Stream", method ↦ "flatMapToLong", signature ↦ "(Ljava/util/function/Function;)Ljava/util/stream/LongStream;" ⟧
+        ⟧,
+        ρ ↦ ∅
+      ⟧
+    ⟧,
+    ρ ↦ ∅
+  ⟧}
+expected:
+  - ⟦ class ↦ "java/util/stream/Stream", method ↦ "mapMultiToLong", signature ↦ "(Ljava/util/function/BiConsumer;)Ljava/util/stream/LongStream;" ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$0", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/stream/LongStream", i3 ↦ "forEach", 𝐵-rest ⟧

--- a/src/test/phino/458-flatMapToDouble-to-mapMultiToDouble.yml
+++ b/src/test/phino/458-flatMapToDouble-to-mapMultiToDouble.yml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 458 converts a user-written Stream.flatMapToDouble into an equivalent
+# Stream.mapMultiToDouble — the DoubleStream sibling of 455. The input is the
+# Φ.hone.lambda form 111 lifts a flatMapToDouble into: interface Function,
+# stream.method = "flatMapToDouble", and a handle-6 target to a non-capturing
+# lambda$main$0 of signature (L<elem>;)Ljava/util/stream/DoubleStream;. The rule
+# rewrites that pragma into the user-mapMultiToDouble Φ.hone.lambda form (interface
+# BiConsumer, stream.method = "mapMultiToDouble", handle-6 target) whose target is
+# a freshly synthesised BiConsumer `flatadapt`, and appends that adapter method to
+# the class. The adapter applies the original mapper to the item
+# (invokestatic lambda$main$0) and drains the returned DoubleStream into the
+# downstream DoubleConsumer (invokeinterface DoubleStream.forEach). Matching all
+# three — the surviving mapMultiToDouble stream block, the invokestatic into the
+# untouched mapper body, and the DoubleStream.forEach — proves the flatMapToDouble
+# was rewired into a mapMultiToDouble rather than dropped.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/4xx/458-flatMapToDouble-to-mapMultiToDouble.phr
+input: |
+  {⟦
+    φ ↦ Φ.jeo.class,
+    name ↦ "Foo",
+    jm$main ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      name ↦ "main",
+      body ↦ ⟦
+        φ ↦ Φ.jeo.seq.of,
+        op0 ↦ ⟦
+          φ ↦ Φ.hone.lambda,
+          class ↦ "Foo",
+          method ↦ "apply",
+          interface ↦ "()Ljava/util/function/Function;",
+          lambda-signature ↦ "(Ljava/lang/Object;)Ljava/lang/Object;",
+          bridge-signature ↦ "(Ljava/lang/Integer;)Ljava/util/stream/DoubleStream;",
+          static ↦ "true",
+          opcode ↦ "invokestatic",
+          target ↦ ⟦ handle ↦ 6, class ↦ "Foo", method ↦ "lambda$main$0", signature ↦ "(Ljava/lang/Integer;)Ljava/util/stream/DoubleStream;", is-interface ↦ Φ.false ⟧,
+          stream ↦ ⟦ class ↦ "java/util/stream/Stream", method ↦ "flatMapToDouble", signature ↦ "(Ljava/util/function/Function;)Ljava/util/stream/DoubleStream;" ⟧
+        ⟧,
+        ρ ↦ ∅
+      ⟧
+    ⟧,
+    ρ ↦ ∅
+  ⟧}
+expected:
+  - ⟦ class ↦ "java/util/stream/Stream", method ↦ "mapMultiToDouble", signature ↦ "(Ljava/util/function/BiConsumer;)Ljava/util/stream/DoubleStream;" ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$0", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/stream/DoubleStream", i3 ↦ "forEach", 𝐵-rest ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/all-ops.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/all-ops.yml
@@ -53,7 +53,7 @@ before:
   return: 7
 after:
   invokespecial: 3
-  invokestatic: 27
+  invokestatic: 30
   invokevirtual: 14
   invokedynamic: 14
-  return: 14
+  return: 17

--- a/src/test/resources/org/eolang/hone/optimize/streams/flatmaptox.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/flatmaptox.yml
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Conversion of the primitive-result Stream.flatMapToInt/ToLong/ToDouble into
+# Stream.mapMultiToInt/ToLong/ToDouble (issue #711). These are the typed siblings
+# of the reference flatMap -> mapMulti conversion (456/457/458 next to 455). Each
+# flatMapToX(f) flattens the IntStream/LongStream/DoubleStream that f returns; the
+# same fan-out is expressed by mapMultiToX((x, c) -> f(x).forEach(c)), where c is
+# the downstream IntConsumer/LongConsumer/DoubleConsumer that XStream.forEach
+# takes precisely. 111 lifts each flatMapToX invokedynamic into a Φ.hone.lambda
+# carrying stream.method = "flatMapToX", and 456/457/458 rewrite that pragma into
+# the user-mapMultiToX Φ.hone.lambda form backed by a synthesised BiConsumer
+# `flatadapt` that applies the original mapper and drains the returned stream into
+# the consumer. A lone flatMapToX lowers to one Stream.mapMultiToX via 701.
+#
+# Each pipeline fans every element out a fixed number of times (3 for int, 2 for
+# long and double) and folds the fan-out with an order- AND value-sensitive
+# polynomial reduce, so the printed numbers change if the conversion corrupts the
+# emitted multiset, its values, or its order. The optimized class reproduces all
+# three exactly (-2017196980 5869572705746538085 1839030), which is the real
+# proof — bytecode that merely verifies but miswires the consumer would print a
+# different number.
+#
+# Counts: each of the three flatMapToX call sites stays a single invokeinterface
+# on Stream (now mapMultiToX rather than flatMapToX), and each converted call adds
+# its `flatadapt` body — one invokestatic into the untouched mapper, one
+# XStream.forEach invokeinterface, and one return. So invokestatic rises by 3
+# (23 -> 26), invokeinterface by 3 (6 -> 9, the three forEach calls), and return
+# by 3 (2 -> 5, the three adapter returns). invokedynamic stays at 6: 456/457/458
+# relocate each Function call-site indy into the BiConsumer adapter's indy rather
+# than adding one, and the three mapper lambda$ bodies plus the three reduce
+# lambdas are untouched.
+java: |
+  package flatmaptox;
+  import java.util.stream.Stream;
+  import java.util.stream.IntStream;
+  import java.util.stream.LongStream;
+  import java.util.stream.DoubleStream;
+  public class X {
+    public static void main(String[] a) {
+      int i = Stream.of(1, 2, 3, 4, 5)
+        .flatMapToInt(x -> IntStream.of(x, x * 10, x + 100))
+        .reduce(0, (p, q) -> p * 31 + q);
+      long l = Stream.of(1, 2, 3, 4, 5)
+        .flatMapToLong(x -> LongStream.of(x, x * 1000L))
+        .reduce(0L, (p, q) -> p * 131 + q);
+      long d = (long) Stream.of(2, 4, 6, 8)
+        .flatMapToDouble(x -> DoubleStream.of(x, x / 2.0))
+        .reduce(0.0, (p, q) -> p * 7 + q);
+      System.out.printf("The result is %d %d %d\n", i, l, d);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is -2017196980 5869572705746538085 1839030"
+before:
+  invokedynamic: 6
+  invokeinterface: 6
+  invokestatic: 23
+  return: 2
+after:
+  invokedynamic: 6
+  invokeinterface: 9
+  invokestatic: 26
+  return: 5


### PR DESCRIPTION
Fixes #711.

`455-flatMap-to-mapMulti` converts a reference `Stream.flatMap` into a `Stream.mapMulti`, but explicitly left the primitive variants `flatMapToInt`/`flatMapToLong`/`flatMapToDouble` "for a follow-up". Those three were lifted by `111` into the `Φ.hone.lambda` pragma, matched nothing, and were reverted untouched by `701`. They were also absent from `DEFAULT_GREP_IN`, so a class using only the typed variants was skipped before any rule ran.

### What this does

Adds three sibling rules next to `455` — `456`/`457`/`458` — that convert a user-written `Stream.flatMapToInt`/`ToLong`/`ToDouble` into `Stream.mapMultiToInt`/`ToLong`/`ToDouble`. The adapter shape `455` already synthesises works unchanged: `(x, c) -> mapper(x).forEach(c)`, since `IntStream.forEach` takes precisely the `IntConsumer` that `mapMultiToInt` hands down (same for long/double). Each rule differs from `455` only in:

- `stream.method`/`stream.signature` in the pattern (`flatMapToX`, result `IntStream`/`LongStream`/`DoubleStream`) and result (`mapMultiToX`);
- the adapter's second parameter type (`Ljava/util/function/IntConsumer;` etc.);
- the `forEach` `invokeinterface` owner and descriptor.

`flatMapToInt`/`flatMapToLong`/`flatMapToDouble` are added to `DEFAULT_GREP_IN`. Since `501`/`502` already emit `mapMultiToInt`/`ToLong`/`ToDouble` dispatches, the jeo roundtrip of these calls is proven. The same caveats `455` accepts apply (null-skip and auto-close of the substream are not reproduced). The primitive-side `IntStream.flatMap` is left as a separate follow-up, out of scope here.

### Tests

- `src/test/phino/456|457|458-*.yml` — single-rule packs pinning each conversion.
- `src/test/resources/org/eolang/hone/optimize/streams/flatmaptox.yml` — dedicated e2e fixture exercising all three typed variants with order- and value-sensitive reduces.
- `all-ops.yml` `after` counts shifted (`invokestatic` 27→30, `return` 14→17): one synthesised `flatadapt` per typed variant adds one `invokestatic` (mapper) and one `return`.

### Verification

Ran the real pipeline (host `phino` 0.0.77 + `jeo` 0.15.1) against both the `all-ops` and the new `flatmaptox` sources: `BUILD SUCCESS`, the optimized classes reproduce the baseline output byte-for-byte (`54` and `-2017196980 5869572705746538085 1839030`), and the opcode counts match the pinned values. The deep phino-pack tests and the full non-deep suite pass.

https://claude.ai/code/session_012JbGWRfZsWSz9avvuFDhKi

---
_Generated by [Claude Code](https://claude.ai/code/session_012JbGWRfZsWSz9avvuFDhKi)_