### PR TITLE
Fix #713: keep-frame for a head-unboxing-map filter must be the primitive survivor

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/412-distill-filter-returned-to-object.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/412-distill-filter-returned-to-object.phr
@@ -27,6 +27,23 @@
 # predicate; only `returned` is promoted to the bridge-output wrapper so 422
 # sees a type-preserving distill and adds nothing. Runs after 411 and before
 # 421/422.
+#
+# The promotion is correct only when the survivor the filter keeps is itself
+# the wrapper — i.e. the element enters the filter boxed and is unboxed only
+# transiently for the predicate (a lone boxed filter, the #704 shape, whose
+# `accepted` is the primitive predicate shape J). Once an object-to-primitive
+# map fuses in AHEAD of the filter (issue #713,
+# e.g. `mapToLong(Long::longValue).filter(...)`), that head map has already
+# moved the element permanently into the primitive domain: 401 carries the
+# head map's wrapper `accepted` onto the fused distill, the dup before the
+# predicate is a two-slot `dup2`, and the kept survivor is the primitive, not
+# the wrapper. Promoting `returned` there would make 422 skip its valueOf
+# re-box while 451 still appends the bridge longValue — a Long.longValue()
+# applied to a primitive long that is not a Long, failing verification. So the
+# guard also requires `accepted` to be primitive: a fused head map leaves it a
+# wrapper, which keeps this rule (and the re-box skip) off the #713 shape and
+# lets 422 box the primitive survivor exactly as it does for a filterless
+# distill.
 name: distill-filter-returned-to-object
 pattern: |
   ⟦
@@ -72,3 +89,6 @@ when:
     - matches:
         - '^L.+;$'
         - 𝑒-bridge-output
+    - matches:
+        - '^[BCDFIJSZ]$'
+        - 𝑒-accepted

--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/501-distill-to-mapMulti.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/501-distill-to-mapMulti.phr
@@ -76,6 +76,7 @@ result: |
       φ ↦ Φ.hone.distill-lambda,
       static ↦ 𝑒-static,
       bridge-input ↦ 𝑒-bridge-input,
+      returned ↦ 𝑒-returned,
       consumer ↦ 𝑒-consumer,
       target-method ↦ 𝑒-target-method,
       body ↦ 𝑒-body

--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/506-distill-filter-frame.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/506-distill-filter-frame.phr
@@ -2,33 +2,57 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-# Resolves the Φ.hone.frame-item marker that 304 leaves at a STATELESS
-# filter guard's keep-label, the non-capturing twin of how 503/504 resolve
-# the marker for stateful (captured) guards. A filter is type-transparent —
-# it returns the item it was given — so the keep-label's stackmap frame must
-# declare the item's real type. That type is the distill's bridge-input,
-# which is only fixed once 411 has decided whether the box/unbox round-trip
-# around the filter could be unwound back to a primitive: for an unwound
-# pipeline bridge-input is the primitive (e.g. J -> `long`), for one that
-# stayed boxed (a LongStream.filter(...).boxed() that 411 cannot unwind, the
-# defect of issue #704) it is the wrapper (Ljava/lang/Long; -> java/lang/Long).
-# 304 cannot know this when it runs (3xx, before 411), so it defers the frame
-# here. By 506 the distill has been lowered to a Φ.hone.distill-lambda (501)
-# whose bridge-input is final, and 511 has not yet wrapped it into a method
-# (506 < 511), so the marker never reaches jeo. A same-locals-1 frame is
-# enough — a stateless wrapper owns no per-call counter, unlike the full
-# frame 503/504 build for the captured case. Scoped to a distill-lambda
-# WITHOUT `captured`, so stateful keep-labels stay with 503/504.
+# Resolves the Φ.hone.frame-item marker that 304 leaves at a STATELESS filter
+# guard's keep-label, for the PRIMITIVE-predicate filters whose survivor is NOT
+# simply the distill's bridge-input. A filter is type-transparent — the kept
+# survivor is the element it tested — but where that element sits in the type
+# lattice depends on what fused around the filter, and 304 cannot know it when
+# it runs (3xx, before 411/412/451), so it defers the frame here. By 506 the
+# distill is a Φ.hone.distill-lambda (501) whose `returned` — the value actually
+# left on the stack — is final, and 511 has not yet wrapped it into a method, so
+# the marker never reaches jeo.
+#
+# This rule fires only when the filter's predicate takes a PRIMITIVE (its target
+# signature is `(<primitive>)Z`, matched in the body right before the keep
+# branch) AND the distill's bridge-input is a wrapper. Two shapes land here and
+# both want the frame derived from `returned`, not bridge-input:
+#   * #704 — a LongStream.filter(...).boxed() that stayed boxed: the element
+#     enters boxed, the predicate unboxes a transient copy and the dup keeps the
+#     wrapper, so the survivor is the wrapper. 412 has promoted `returned` to
+#     that wrapper, so `returned` (= Ljava/lang/Long; -> java/lang/Long) names it.
+#   * #713 — an object-to-primitive map (mapToLong(Long::longValue)) fused in
+#     AHEAD of the filter: the head map has permanently unboxed the element, the
+#     dup is a two-slot dup2, and the survivor is a primitive `long`. 412 leaves
+#     `returned` primitive there (its `accepted` is the wrapper), so `returned`
+#     (= J -> long) names it, while bridge-input would wrongly declare a one-slot
+#     java/lang/Long and fail JVM verification ("Inconsistent stackmap frames").
+# Every other marker — an OBJECT-predicate filter such as a boxed-roundtrip
+# `(Ljava/lang/Integer;)Z`, whose survivor IS bridge-input even though trailing
+# maps make `returned` a different (re-boxed or primitive) type — falls through
+# to 507, which derives from bridge-input. A same-locals-1 frame is enough — a
+# stateless wrapper owns no per-call counter. Scoped to a distill-lambda WITHOUT
+# `captured`, so stateful keep-labels stay with 503/504.
 name: distill-filter-frame
 pattern: |
   ⟦
     φ ↦ Φ.hone.distill-lambda,
     static ↦ 𝑒-static,
     bridge-input ↦ 𝑒-bridge-input,
+    returned ↦ 𝑒-returned,
     consumer ↦ 𝑒-consumer,
     target-method ↦ 𝑒-target-method,
     body ↦ ⟦
       𝐵-before,
+      𝜏-predicate ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokestatic,
+        i2 ↦ 𝑒-predicate-class,
+        i3 ↦ 𝑒-predicate-method,
+        i4 ↦ 𝑒-predicate-signature,
+        i5 ↦ 𝑒-predicate-is-interface
+      ⟧,
+      𝜏-ifne ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ 𝑒-ifne-target ⟧,
+      𝜏-return ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      𝜏-keep-label ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-keep-label ⟧,
       𝜏-frame ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
       𝐵-after,
       ρ ↦ ∅
@@ -39,10 +63,21 @@ result: |
     φ ↦ Φ.hone.distill-lambda,
     static ↦ 𝑒-static,
     bridge-input ↦ 𝑒-bridge-input,
+    returned ↦ 𝑒-returned,
     consumer ↦ 𝑒-consumer,
     target-method ↦ 𝑒-target-method,
     body ↦ ⟦
       𝐵-before,
+      𝜏-predicate ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokestatic,
+        i2 ↦ 𝑒-predicate-class,
+        i3 ↦ 𝑒-predicate-method,
+        i4 ↦ 𝑒-predicate-signature,
+        i5 ↦ 𝑒-predicate-is-interface
+      ⟧,
+      𝜏-ifne ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ 𝑒-ifne-target ⟧,
+      𝜏-return ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      𝜏-keep-label ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-keep-label ⟧,
       𝜏-frame ↦ ⟦
         φ ↦ Φ.jeo.frame,
         type ↦ 4,
@@ -55,11 +90,19 @@ result: |
       ρ ↦ ∅
     ⟧
   ⟧
+when:
+  and:
+    - matches:
+        - '^L.+;$'
+        - 𝑒-bridge-input
+    - matches:
+        - '^\([BCDFIJSZ]\)'
+        - 𝑒-predicate-signature
 where:
   - meta: 𝑒-frame-item
     function: sed
     args:
-      - 𝑒-bridge-input
+      - 𝑒-returned
       - '"s/^B$/byte/g"'
       - '"s/^C$/char/g"'
       - '"s/^D$/double/g"'

--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/507-distill-filter-frame-fallback.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/507-distill-filter-frame-fallback.phr
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# General fallback for the Φ.hone.frame-item marker that 304 leaves at a
+# STATELESS filter guard's keep-label: resolves it to a same-locals-1 stackmap
+# frame whose single stack item is the distill's `bridge-input`. This is the
+# right type for every filter whose survivor IS the element it received — the
+# common case — including a pure-primitive LongStream.filter (bridge-input J ->
+# `long`) and an OBJECT-predicate filter whose `(Ljava/lang/Integer;)Z` keeps a
+# wrapper survivor even when trailing maps drive the distill's `returned` to a
+# different (re-boxed or primitive) type (the boxed-roundtrip shape).
+#
+# Runs AFTER 506, which has already claimed the two PRIMITIVE-predicate shapes
+# whose survivor is not bridge-input (#704 boxed filter, #713 head-fused
+# unboxing map) and resolved their markers from `returned`. Whatever marker 506
+# left untouched lands here, so this rule needs no guard. By 507 the distill is
+# a Φ.hone.distill-lambda (501) whose bridge-input is final and 511 has not yet
+# wrapped it into a method, so the marker never reaches jeo. Scoped to a
+# distill-lambda WITHOUT `captured`, so stateful keep-labels stay with 503/504.
+name: distill-filter-frame-fallback
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ 𝑒-static,
+    bridge-input ↦ 𝑒-bridge-input,
+    returned ↦ 𝑒-returned,
+    consumer ↦ 𝑒-consumer,
+    target-method ↦ 𝑒-target-method,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-frame ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ 𝑒-static,
+    bridge-input ↦ 𝑒-bridge-input,
+    returned ↦ 𝑒-returned,
+    consumer ↦ 𝑒-consumer,
+    target-method ↦ 𝑒-target-method,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-frame ↦ ⟦
+        φ ↦ Φ.jeo.frame,
+        type ↦ 4,
+        nlocal ↦ 0,
+        locals ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+        nstack ↦ 1,
+        stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, item ↦ 𝑒-frame-item ⟧
+      ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+where:
+  - meta: 𝑒-frame-item
+    function: sed
+    args:
+      - 𝑒-bridge-input
+      - '"s/^B$/byte/g"'
+      - '"s/^C$/char/g"'
+      - '"s/^D$/double/g"'
+      - '"s/^F$/float/g"'
+      - '"s/^I$/integer/g"'
+      - '"s/^J$/long/g"'
+      - '"s/^S$/short/g"'
+      - '"s/^Z$/boolean/g"'
+      - '"s/^L(.+);$/$1/g"'

--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/511-distill-lambda-to-method.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/511-distill-lambda-to-method.phr
@@ -8,6 +8,7 @@ pattern: |
     φ ↦ Φ.hone.distill-lambda,
     static ↦ 𝑒-static,
     bridge-input ↦ 𝑒-bridge-input,
+    returned ↦ 𝑒-returned,
     consumer ↦ 𝑒-consumer,
     target-method ↦ 𝑒-target-method,
     body ↦ ⟦ 𝐵-body, ρ ↦ ∅ ⟧

--- a/src/test/phino/412-distill-filter-returned-kept-primitive.yml
+++ b/src/test/phino/412-distill-filter-returned-kept-primitive.yml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The #713 shape: an object-to-primitive map (mapToLong(Long::longValue)) has
+# fused in AHEAD of the filter, so 401 carries the head map's WRAPPER `accepted`
+# (Ljava/lang/Long;) onto the fused distill while bridge-input/bridge-output
+# stay the wrapper and `returned` stays the primitive J. The head map has
+# already moved the element permanently into the primitive domain (the dup is a
+# two-slot dup2, the kept survivor is a primitive long), so 412 must NOT promote
+# `returned` to the wrapper here: doing so would make 422 skip its valueOf
+# re-box while 451 still appends a Long.longValue() applied to a primitive long,
+# failing verification. The added `accepted` primitive guard keeps 412 off this
+# shape, leaving `returned` = J untouched so 422 boxes the primitive survivor as
+# it does for a filterless distill.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/4xx/412-distill-filter-returned-to-object.phr
+input: |
+  {⟦
+    φ ↦ Φ.hone.distill,
+    class ↦ "Foo",
+    bridge-input ↦ "Ljava/lang/Long;",
+    bridge-output ↦ "Ljava/lang/Long;",
+    start ↦ "map",
+    accepted ↦ "Ljava/lang/Long;",
+    returned ↦ "J",
+    static ↦ "true",
+    state ↦ ⟦ ρ ↦ ∅ ⟧,
+    body ↦ ⟦
+      i1 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$hone$0", i4 ↦ "(Ljava/lang/Long;)J", i5 ↦ Φ.false ⟧,
+      i ↦ ⟦ φ ↦ Φ.jeo.opcode.dup2 ⟧,
+      i2 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$0", i4 ↦ "(J)Z", i5 ↦ Φ.false ⟧,
+      i3 ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L1" ⟧ ⟧,
+      i4 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      i5 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L1" ⟧,
+      i6 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.hone.distill, 𝐵-a, returned ↦ "J", 𝐵-b ⟧

--- a/src/test/phino/506-distill-filter-frame-unboxed.yml
+++ b/src/test/phino/506-distill-filter-frame-unboxed.yml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The #713 shape, claimed by 506 (the PRIMITIVE-predicate specific rule): an
+# object-to-primitive map (mapToLong(Long::longValue)) has fused in AHEAD of the
+# filter, so the synthesized method still receives the wrapper (bridge-input =
+# Ljava/lang/Long;) but the head map has already unboxed the element, the dup
+# before the predicate is a two-slot dup2, and the survivor kept at the
+# keep-label is a two-slot `long`. The predicate is PRIMITIVE (J)Z and
+# bridge-input is a WRAPPER, so 506 fires and resolves the frame-item from the
+# primitive `returned` (J -> long) — 412 left it primitive because this shape's
+# `accepted` is a wrapper. Deriving from bridge-input (507's fallback, also
+# listed but never reached here) would wrongly declare a one-slot java/lang/Long
+# and fail JVM verification with "Inconsistent stackmap frames".
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/506-distill-filter-frame.phr
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/507-distill-filter-frame-fallback.phr
+input: |
+  {⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ "true",
+    bridge-input ↦ "Ljava/lang/Long;",
+    returned ↦ "J",
+    consumer ↦ "Ljava/util/function/LongConsumer;",
+    target-method ↦ "distill_1",
+    body ↦ ⟦
+      i1 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 0 ⟧,
+      i2 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$hone$0", i4 ↦ "(Ljava/lang/Long;)J", i5 ↦ Φ.false ⟧,
+      i3 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup2 ⟧,
+      i4 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$0", i4 ↦ "(J)Z", i5 ↦ Φ.false ⟧,
+      i5 ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L1" ⟧ ⟧,
+      i6 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      i7 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L1" ⟧,
+      i8 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.jeo.frame, type ↦ 4, 𝐵-e ⟧
+  - ⟦ φ ↦ Φ.jeo.seq.of1, item ↦ "long" ⟧

--- a/src/test/phino/506-distill-filter-frame.yml
+++ b/src/test/phino/506-distill-filter-frame.yml
@@ -2,22 +2,25 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-# 506 resolves the Φ.hone.frame-item marker that 304 leaves at a stateless
-# filter guard's keep-label into a same-locals-1 stackmap frame whose single
-# stack item is the distill's final bridge-input. For a boxed-primitive filter
-# that stayed in the boxed domain (the #704 defect) bridge-input is the wrapper
-# Ljava/lang/Long;, so the frame must declare a one-slot java/lang/Long
-# reference — not the two-slot primitive `long` the predicate shape would
-# suggest. Scoped to a Φ.hone.distill-lambda WITHOUT `captured`, so stateful
-# keep-labels stay with 503/504. Here the lambda's bridge-input is the wrapper,
-# so the resolved frame's stack item is java/lang/Long.
+# 506 (the PRIMITIVE-predicate specific rule) resolves the Φ.hone.frame-item
+# marker that 304 leaves at a stateless filter guard's keep-label into a
+# same-locals-1 stackmap frame whose single stack item is the distill's
+# `returned`. This #704 case — a boxed-primitive LongStream.filter(...).boxed()
+# that stayed boxed — has a PRIMITIVE predicate (J)Z and a WRAPPER bridge-input
+# Ljava/lang/Long;, so 506 claims it; 412 has promoted `returned` to that same
+# wrapper, so the survivor (the wrapper the dup kept) is declared as a one-slot
+# java/lang/Long. 507 (the fallback) is also listed but sees no marker left.
+# Scoped to a Φ.hone.distill-lambda WITHOUT `captured`, so stateful keep-labels
+# stay with 503/504.
 rules:
   - src/main/resources/org/eolang/hone/rules/streams/5xx/506-distill-filter-frame.phr
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/507-distill-filter-frame-fallback.phr
 input: |
   {⟦
     φ ↦ Φ.hone.distill-lambda,
     static ↦ "true",
     bridge-input ↦ "Ljava/lang/Long;",
+    returned ↦ "Ljava/lang/Long;",
     consumer ↦ "Ljava/util/function/Consumer;",
     target-method ↦ "distill_1",
     body ↦ ⟦

--- a/src/test/phino/507-distill-filter-frame-fallback.yml
+++ b/src/test/phino/507-distill-filter-frame-fallback.yml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The boxed-roundtrip shape, left to 507 (the fallback) by 506: a filter at the
+# head of the pipeline whose predicate takes an OBJECT, (Ljava/lang/Integer;)Z.
+# 232 still classifies an `(...)Z` target as a p-filter, so 304 leaves a
+# frame-item marker, but the survivor the dup keeps is the wrapper element
+# (java/lang/Integer) — NOT the distill's `returned`, which trailing
+# mapToLong/mapToDouble stages have driven to a primitive D. 506 declines this
+# marker because the predicate parameter (Ljava/lang/Integer;) is not a
+# primitive, so 507 resolves it from bridge-input (Ljava/lang/Integer; ->
+# java/lang/Integer). Deriving from `returned` here would wrongly declare
+# `double` over a one-slot Integer and fail JVM verification.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/506-distill-filter-frame.phr
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/507-distill-filter-frame-fallback.phr
+input: |
+  {⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ "true",
+    bridge-input ↦ "Ljava/lang/Integer;",
+    returned ↦ "D",
+    consumer ↦ "Ljava/util/function/DoubleConsumer;",
+    target-method ↦ "distill_1",
+    body ↦ ⟦
+      i1 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+      i2 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$0", i4 ↦ "(Ljava/lang/Integer;)Z", i5 ↦ Φ.false ⟧,
+      i3 ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L1" ⟧ ⟧,
+      i4 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      i5 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L1" ⟧,
+      i6 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.jeo.frame, type ↦ 4, 𝐵-e ⟧
+  - ⟦ φ ↦ Φ.jeo.seq.of1, item ↦ "java/lang/Integer" ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/maptolong-filter.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/maptolong-filter.yml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Reproduction of issue #713: a boxed-stream pipeline led by an UNBOXING map
+# (mapToLong(Long::longValue)) and followed by a filter — the `collection`
+# benchmark shape from objectionary/sabj25. The head mapToLong fuses in AHEAD
+# of the filter and moves the element permanently into the primitive domain:
+# the synthesized distill method still receives the wrapper
+# (distill_N(java.lang.Long, java.util.function.LongConsumer)), but the head
+# `lambda$hone$N:(Ljava/lang/Long;)J` has already unboxed it, the dup before
+# the (J)Z predicate is a two-slot dup2, and the survivor kept at the filter's
+# keep-label is a two-slot primitive `long`.
+#
+# Before the fix the keep-frame (506, derived from the distill's wrapper
+# bridge-input) declared a one-slot java/lang/Long while the stack held a
+# `long`, and 412 promoted the distill's `returned` to that wrapper so 422
+# skipped its Long.valueOf(J) re-box while 451 still appended the
+# Long.longValue() bridge unbox — a longValue applied to a primitive long.
+# The class failed JVM verification with "java.lang.VerifyError: Inconsistent
+# stackmap frames at branch target 12". The fix derives the keep-frame from
+# the distill's `returned` (kept primitive, J -> long) and keeps 412 off this
+# shape (its `accepted` is the wrapper, so 422 boxes the survivor exactly as
+# for a filterless distill), so frame, returned and tail agree again.
+#
+# {1..6} kept to multiples of 3 = {3, 6}, summed as long = 9. The mapToLong +
+# filter collapse to a single Stream.mapMultiToLong, so invokedynamic 2 -> 1.
+java: |
+  package maptolongfilter;
+  import java.util.List;
+  public class X {
+    public static void main(String[] a) {
+      List<Long> list = List.of(1L, 2L, 3L, 4L, 5L, 6L);
+      long sum = list.stream()
+        .mapToLong(Long::longValue)
+        .filter(n -> n % 3L == 0L)
+        .sum();
+      System.out.printf("The result is %d%n", sum);
+    }
+  }
+log:
+  - "BUILD SUCCESS"
+  - "The result is 9"
+before:
+  invokedynamic: 2
+after:
+  invokedynamic: 1


### PR DESCRIPTION
Fixes #713.

## Problem

A boxed-stream pipeline led by an unboxing map and containing a filter — e.g.
`list.stream().mapToLong(Long::longValue).filter(n -> n % 3L == 0L).sum()` —
optimized to a class that failed JVM verification:

```
java.lang.VerifyError: Inconsistent stackmap frames at branch target 12
  ... distill_N(Ljava/lang/Long;Ljava/util/function/LongConsumer;)V @8: ifne
  Stackmap stack: { 'java/lang/Long' }   actual stack: { long, long_2nd, ... }
```

When the head `mapToLong` fuses in **ahead** of the filter it permanently
unboxes the element, so the `dup` before the `(J)Z` predicate is a two-slot
`dup2` and the survivor kept at the filter's keep-label is a two-slot primitive
`long`. Two rules misread that survivor as the wrapper the synthesized method
receives:

* **506** derived the keep-frame from the distill's `bridge-input` (still the
  wrapper `Long`), declaring a one-slot `java/lang/Long` over a two-slot `long`.
* **412** promoted the distill's `returned` to that wrapper, so **422** skipped
  its `Long.valueOf(J)` re-box while **451** still appended a `Long.longValue()`
  bridge unbox — a `longValue` applied to a primitive `long`.

This is the mirror image of the closed #704 (there the keep-frame said `long`
while the stack held a `Long`), and reproduces on 0.27.2 which already contains
the #704 fix.

## Fix

* **412** now also requires `accepted` to be primitive before promoting
  `returned`. A fused head map leaves `accepted` a wrapper, so the #713 shape is
  left primitive and 422 boxes the survivor exactly as for a filterless distill
  — the `valueOf`/`longValue` pair then type-checks.
* **501 / 511** thread the distill's `returned` onto the `distill-lambda`.
* **506** becomes the specific rule for **primitive-predicate** filters
  (predicate signature `(<primitive>)Z` with a wrapper `bridge-input`): it
  derives the keep-frame from `returned`, which 412 keeps primitive for #713 and
  (still) promotes to the wrapper for the #704 boxed filter.
* **New 507** fallback derives the keep-frame from `bridge-input` for every
  other marker — including object-predicate filters whose survivor stays the
  wrapper even when trailing maps drive `returned` to a primitive
  (`boxed-roundtrip`).

The predicate parameter type is what cleanly separates the head-unboxing-map
shape (`(J)Z`, survivor primitive) from a `boxed-roundtrip` object-predicate
filter (`(Ljava/lang/Integer;)Z`, survivor stays the wrapper).

## Tests

* New end-to-end fixture `optimize/streams/maptolong-filter.yml` (the issue's
  reproduction; `invokedynamic` 2 → 1).
* New single-rule packs: `412-distill-filter-returned-kept-primitive`,
  `506-distill-filter-frame-unboxed`, `507-distill-filter-frame-fallback`;
  updated `506-distill-filter-frame`.

## Verification

Built phino `0.0.77` and ran the real phino + jeo roundtrip on the host:

* The #713 reproduction now runs (`The result is 9`) with no `VerifyError`.
* #704 (`long-filter-boxed`) still verifies (`The result is 18`).
* All 30 `optimize/streams/*.yml` fixtures pass the compile → optimize → run
  roundtrip with correct output and no verification errors.
* All 51 single-rule phino packs pass (`mvn -Pdeep test
  -Dtest=OptimizeMojoTest#appliesPhinoRulesAsSpecifiedInYamlPack`: 51 tests,
  0 failures).

https://claude.ai/code/session_01XT3mf7ksijA6xbNasyYQ2c

---
_Generated by [Claude Code](https://claude.ai/code/session_01XT3mf7ksijA6xbNasyYQ2c)_