### PR TITLE
Fuse dropWhile() via a sticky-latch distill (#718)

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ The [hone paper][hone-paper] discusses this property,
 ## Why Short-Circuiting Operations Are Not Fused
 
 The pipeline deliberately fuses only non-short-circuiting operations
-  (`filter`, `map`, `peek`, `distinct`, `skip`, `flatMap`,
+  (`filter`, `map`, `peek`, `distinct`, `skip`, `dropWhile`, `flatMap`,
   the primitive conversions, and `mapMulti` itself);
   the two short-circuiting intermediate operations of the JDK,
   `limit()` and `takeWhile()`, are left untouched.

--- a/src/main/resources/org/eolang/hone/rules/streams/2xx/208-lambda-to-dropwhile.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/2xx/208-lambda-to-dropwhile.phr
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Recognises a stream `.dropWhile(p)` call — a Φ.hone.lambda whose SAM is a
+# Predicate immediately consumed by `Stream.dropWhile` — and abstracts it into
+# a single Φ.hone.dropWhile pragma. The shape is exactly the one 201 matches for
+# `filter` (a Predicate-returning lambda followed by the stream call); only the
+# `stream.method` differs, so this rule mirrors 201 line for line and 310 folds
+# the result into a stateful distill the same way 308 folds skip.
+#
+# dropWhile is the last sink-free Stream operation with no lifting rule (#718).
+# Like filter it carries a predicate, so — unlike distinct/skip — recognition
+# reads the element type and the target handle straight off the lambda; the only
+# extra ingredient at 310 is a one-shot sticky latch, the dropWhile analogue of
+# skip's countdown counter.
+#
+# v1 scope (mirrors skip's narrow v1): only the object `java/util/stream/Stream`
+# is handled, the predicate must be `static` (the normalised lambda shape 121
+# leaves), and its target must return a primitive `Z`. A `static ↦ "true"` match
+# and a `\)Z$` guard on the target signature keep the three other shapes —
+# primitive streams, captured (non-static) predicates, and method references to
+# `Boolean`-returning methods (the o-filter case 305 handles for filter) — as
+# plain bytecode, so no Φ.hone.dropWhile pragma is ever produced that 310 cannot
+# fold back to assemblable code.
+name: lambda-to-dropwhile
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.lambda,
+    class ↦ 𝑒-class,
+    method ↦ "test",
+    interface ↦ "()Ljava/util/function/Predicate;",
+    lambda-signature ↦ "(Ljava/lang/Object;)Z",
+    bridge-signature ↦ 𝑒-bridge-signature,
+    static ↦ "true",
+    opcode ↦ 𝑒-opcode,
+    target ↦ ⟦
+      handle ↦ 𝑒-target-handle,
+      class ↦ 𝑒-target-class,
+      method ↦ 𝑒-target-method,
+      signature ↦ 𝑒-target-signature,
+      is-interface ↦ 𝑒-target-is-interface
+    ⟧,
+    stream ↦ ⟦
+      class ↦ "java/util/stream/Stream",
+      method ↦ "dropWhile",
+      signature ↦ "(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;"
+    ⟧
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.dropWhile,
+    opcode ↦ 𝑒-opcode,
+    class ↦ 𝑒-class,
+    bridge-input ↦ 𝑒-bridge-input,
+    bridge-output ↦ 𝑒-bridge-input,
+    accepted ↦ 𝑒-accepted,
+    returned ↦ 𝑒-bridge-input,
+    static ↦ "true",
+    target ↦ ⟦
+      handle ↦ 𝑒-target-handle,
+      class ↦ 𝑒-target-class,
+      method ↦ 𝑒-target-method,
+      signature ↦ 𝑒-target-signature,
+      is-interface ↦ 𝑒-target-is-interface
+    ⟧
+  ⟧
+when:
+  matches: ['\)Z$', 𝑒-target-signature]
+where:
+  - meta: 𝑒-bridge-input
+    function: sed
+    # "(Ljava/lang/Integer;)Z" -> "Ljava/lang/Integer;"
+    args:
+      - 𝑒-bridge-signature
+      - '"s/\\((.*)\\)Z/$1/g"'
+  - meta: 𝑒-target-class-pattern
+    function: sed
+    # java\\/lang\\/String
+    args:
+      - 𝑒-target-class
+      - '"s/\\//\\\\\\//g"'
+  - meta: 𝑒-virtual-accepted-pattern
+    function: concat
+    # s/\\(\\).+/Ljava\\/lang\\/String;/g
+    args: ['"s/\\(\\).+/L"', 𝑒-target-class-pattern, '";/g"']
+  - meta: 𝑒-bridge-input-pattern
+    function: sed
+    # Ljava\\/lang\\/String;
+    args:
+      - 𝑒-bridge-input
+      - '"s/\\//\\\\\\//g"'
+  - meta: 𝑒-java-object-pattern
+    function: concat
+    # s/\\(Ljava\\/lang\\/Object;\\).+/Ljava\\/lang\\/String;/g
+    args: ['"s/\\(Ljava\\/lang\\/Object;\\).+/"', 𝑒-bridge-input-pattern, '"/g"']
+  - meta: 𝑒-accepted
+    function: sed
+    args:
+      - 𝑒-target-signature
+      - 𝑒-virtual-accepted-pattern
+      - 𝑒-java-object-pattern
+      - '"s/\\((.+)\\).+/$1/g"'

--- a/src/main/resources/org/eolang/hone/rules/streams/2xx/283-insert-dup-before-filter-after-stateful.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/2xx/283-insert-dup-before-filter-after-stateful.phr
@@ -7,11 +7,12 @@
 # Φ.hone.dup when the filter follows a map or another filter, but its
 # pattern is shaped for the map/filter pragma (opcode + target bindings)
 # and so never matches a stateful predecessor. A filter that follows a
-# distinct or skip — whose pragma carries class / stream-class (/ push)
-# instead — would therefore be left without its dup, its predicate would
-# eat the only item, and the keep-label frame would find an empty stack.
-# This rule plugs that gap: when 𝜏-first is distinct or skip and 𝜏-second
-# is a filter, it splices the same Φ.hone.dup between them. After
+# distinct, skip or dropWhile — a stateful guard that leaves a single
+# (un-duplicated) item — would therefore be left without its dup, its
+# predicate would eat the only item, and the keep-label frame would find an
+# empty stack. This rule plugs that gap: when 𝜏-first is one of those
+# stateful guards and 𝜏-second is a filter, it splices the same Φ.hone.dup
+# between them. After
 # insertion the two are no longer adjacent, so it fires once per site.
 name: insert-dup-before-filter-after-stateful
 pattern: |
@@ -66,6 +67,7 @@ when:
     - or:
         - eq: [𝜏-one, 'distinct']
         - eq: [𝜏-one, 'skip']
+        - eq: [𝜏-one, 'dropWhile']
     - or:
         - eq: [𝜏-two, 'o-filter']
         - eq: [𝜏-two, 'p-filter']

--- a/src/main/resources/org/eolang/hone/rules/streams/3xx/310-dropwhile-to-distill.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/3xx/310-dropwhile-to-distill.phr
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Folds Φ.hone.dropWhile (produced by 208) into a Φ.hone.distill — dropWhile is
+# "a filter that owns a one-shot sticky latch" (#718). The body is 304's filter
+# guard wrapped in that latch: while the latch is unset, evaluate the predicate
+# and drop on true; on the first false, set the latch; afterwards pass every item
+# through WITHOUT evaluating the predicate again (the dropWhile contract — a
+# re-evaluated predicate would wrongly drop a later element it returns true for).
+#
+# State, mirroring 308/307, is a one-cell java int[1] latch (0 = still dropping,
+# 1 = latched) APPENDED to the captured java/util/List that 502 builds in front
+# of the dispatch: dup the list, build a zero-initialised int[1] (newarray needs
+# no seeding store, unlike skip's counted long[1]), List.add it, pop the boolean.
+# The block begins and ends at [list] with peak 3, so N fused stateful operators
+# append N cells to ONE list rather than stacking arrays. Opcode names are random
+# so two dropWhile() calls in one method never collide.
+#
+# The body is auto emit-shape, like 304's filter guard, and reaches its single
+# keep-label (a Φ.hone.frame-item that 503 fills, exactly as 307/308) from two
+# branches so only ONE stackmap frame is needed:
+#
+#   fetch [I; astore 4            ; stash the latch array in a scratch local
+#   aload 4; iconst_0; iaload     ; latch = array[0]
+#   ifne KEEP                     ; latched -> keep, predicate never runs
+#   dup; <predicate>              ; not latched: test a copy of the item -> Z
+#   iconst_1; ixor; istore 5      ; notZ = !Z  (1 iff predicate returned false)
+#   aload 4; iconst_0; iload 5; iastore   ; array[0] = notZ  (sticks the latch)
+#   iload 5; ifne KEEP            ; predicate false -> keep (latch now set)
+#   return                        ; predicate true  -> drop
+#   KEEP: <frame-item>            ; [item] survives to the appended consumer.accept
+#
+# Because the latched branch leaves the predicate copy un-duplicated, both
+# branches reach KEEP with a single [item] on the stack, so the one frame-item
+# 503 emits suffices — no per-branch frame helper is needed. The two scratch
+# locals (4 = latch array, 5 = notZ) are dead at KEEP, so 503's four-local frame
+# is still correct; 512's max-locals is widened to 6 to make room for them.
+#
+# v1 scope (see 208): object java/util/stream/Stream, a static predicate whose
+# target returns Z, the element type preserved across any fused neighbours. A
+# lone dropWhile is NOT reverted to a native Stream.dropWhile the way 442 reverts
+# a lone skip — rebuilding the predicate lambda is left as a follow-up — so it
+# simply lowers to its own mapMulti (correct, just not faster than native).
+name: dropwhile-to-distill
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.dropWhile,
+    opcode ↦ 𝑒-opcode,
+    class ↦ 𝑒-class,
+    bridge-input ↦ 𝑒-bridge-input,
+    bridge-output ↦ 𝑒-bridge-output,
+    accepted ↦ 𝑒-accepted,
+    returned ↦ 𝑒-returned,
+    static ↦ 𝑒-static,
+    target ↦ ⟦
+      handle ↦ 𝑒-target-handle,
+      class ↦ 𝑒-target-class,
+      method ↦ 𝑒-target-method,
+      signature ↦ 𝑒-target-signature,
+      is-interface ↦ 𝑒-target-is-interface
+    ⟧
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.distill,
+    class ↦ 𝑒-class,
+    bridge-input ↦ 𝑒-bridge-input,
+    bridge-output ↦ 𝑒-bridge-input,
+    start ↦ "dropWhile",
+    accepted ↦ 𝑒-accepted,
+    returned ↦ 𝑒-returned,
+    static ↦ "true",
+    state ↦ ⟦
+      𝜏-dup-list ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+      𝜏-alen ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_1 ⟧,
+      𝜏-new-latch ↦ ⟦ φ ↦ Φ.jeo.opcode.newarray, i1 ↦ 10 ⟧,
+      𝜏-add ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokeinterface,
+        i2 ↦ "java/util/List",
+        i3 ↦ "add",
+        i4 ↦ "(Ljava/lang/Object;)Z",
+        i5 ↦ Φ.true
+      ⟧,
+      𝜏-pop ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+      ρ ↦ ∅
+    ⟧,
+    body ↦ ⟦
+      i1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "[I" ⟧,
+      i2 ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, i1 ↦ 4 ⟧,
+      i3 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 4 ⟧,
+      i4 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+      i5 ↦ ⟦ φ ↦ Φ.jeo.opcode.iaload ⟧,
+      i6 ↦ ⟦
+        φ ↦ Φ.jeo.opcode.ifne,
+        i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label ⟧
+      ⟧,
+      i7 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+      i8 ↦ ⟦
+        φ ↦ Φ.jeo.opcode.𝜏-opcode,
+        i2 ↦ 𝑒-target-class,
+        i3 ↦ 𝑒-target-method,
+        i4 ↦ 𝑒-target-signature,
+        i5 ↦ 𝑒-target-is-interface
+      ⟧,
+      i9 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_1 ⟧,
+      i10 ↦ ⟦ φ ↦ Φ.jeo.opcode.ixor ⟧,
+      i11 ↦ ⟦ φ ↦ Φ.jeo.opcode.istore, i1 ↦ 5 ⟧,
+      i12 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 4 ⟧,
+      i13 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+      i14 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, i1 ↦ 5 ⟧,
+      i15 ↦ ⟦ φ ↦ Φ.jeo.opcode.iastore ⟧,
+      i16 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, i1 ↦ 5 ⟧,
+      i17 ↦ ⟦
+        φ ↦ Φ.jeo.opcode.ifne,
+        i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label ⟧
+      ⟧,
+      i18 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      i19 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label ⟧,
+      i20 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧
+    ⟧
+  ⟧
+where:
+  - meta: 𝑒-label
+    function: random-string
+    args: ['"L%d"']
+  - meta: 𝜏-opcode
+    function: tau
+    args: [𝑒-opcode]
+  - meta: 𝜏-dup-list
+    function: random-tau
+  - meta: 𝜏-alen
+    function: random-tau
+  - meta: 𝜏-new-latch
+    function: random-tau
+  - meta: 𝜏-add
+    function: random-tau
+  - meta: 𝜏-pop
+    function: random-tau

--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/512-distill-state-lambda-to-method.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/512-distill-state-lambda-to-method.phr
@@ -11,7 +11,12 @@
 # consumer-load is `aload 2` (511's are 0 and 1). The body opens by
 # zeroing a per-call counter at local 3 (`iconst_0; istore 3`); 521 turns
 # each fetch marker into List.get(counter); iinc so the N fetches walk the
-# List in body order — guard k reads state var k.
+# List in body order — guard k reads state var k. max-locals is 6 (not 4):
+# slots 0-3 are the args plus the counter above, and 310's dropWhile latch
+# guard borrows slots 4-5 as scratch (the latch array and the negated
+# predicate result), dead by its keep-label so 503's four-local frame still
+# holds. The two extra slots are unused by stateless distinct/skip guards and
+# cost nothing there.
 #
 # The INPUT item is always a reference (v1 stateful operators are object
 # streams — distinct is Stream<T>), so the leading load is a fixed aload 1.
@@ -39,7 +44,7 @@ result: |
     maxs ↦ ⟦
       φ ↦ Φ.jeo.maxs,
       max-stack ↦ 10,
-      max-locals ↦ 4
+      max-locals ↦ 6
     ⟧,
     params ↦ ⟦
       φ ↦ Φ.jeo.params,

--- a/src/test/phino/208-lambda-to-dropwhile.yml
+++ b/src/test/phino/208-lambda-to-dropwhile.yml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/2xx/208-lambda-to-dropwhile.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      op ↦ ⟦
+        φ ↦ Φ.hone.lambda,
+        class ↦ "fusion/X",
+        method ↦ "test",
+        interface ↦ "()Ljava/util/function/Predicate;",
+        lambda-signature ↦ "(Ljava/lang/Object;)Z",
+        bridge-signature ↦ "(Ljava/lang/Integer;)Z",
+        static ↦ "true",
+        opcode ↦ "invokestatic",
+        target ↦ ⟦
+          handle ↦ 6,
+          class ↦ "fusion/X",
+          method ↦ "lambda$main$1",
+          signature ↦ "(Ljava/lang/Integer;)Z",
+          is-interface ↦ Φ.false
+        ⟧,
+        stream ↦ ⟦
+          class ↦ "java/util/stream/Stream",
+          method ↦ "dropWhile",
+          signature ↦ "(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;"
+        ⟧
+      ⟧
+    ⟧
+  ⟧}
+expected:
+  - ⟦ body ↦ ⟦ 𝜏-op ↦ ⟦ φ ↦ Φ.hone.dropWhile, opcode ↦ "invokestatic", class ↦ "fusion/X", bridge-input ↦ "Ljava/lang/Integer;", bridge-output ↦ "Ljava/lang/Integer;", accepted ↦ "Ljava/lang/Integer;", returned ↦ "Ljava/lang/Integer;", 𝐵 ⟧, ρ ↦ ∅ ⟧ ⟧

--- a/src/test/phino/310-dropwhile-to-distill.yml
+++ b/src/test/phino/310-dropwhile-to-distill.yml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/3xx/310-dropwhile-to-distill.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      op1 ↦ ⟦
+        φ ↦ Φ.hone.dropWhile,
+        opcode ↦ "invokestatic",
+        class ↦ "Foo",
+        bridge-input ↦ "Ljava/lang/Integer;",
+        bridge-output ↦ "Ljava/lang/Integer;",
+        accepted ↦ "Ljava/lang/Integer;",
+        returned ↦ "Ljava/lang/Integer;",
+        static ↦ "true",
+        target ↦ ⟦
+          handle ↦ 6,
+          class ↦ "Foo",
+          method ↦ "lambda$main$0",
+          signature ↦ "(Ljava/lang/Integer;)Z",
+          is-interface ↦ Φ.false
+        ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.hone.distill, 𝐵-a, start ↦ "dropWhile", 𝐵-b ⟧
+  - ⟦ φ ↦ Φ.hone.fetch, type ↦ "[I" ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.newarray, i1 ↦ 10 ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.ixor ⟧
+  - ⟦ φ ↦ Φ.hone.frame-item ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/dropwhile.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/dropwhile.yml
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# `.dropWhile(p)` is "a filter that owns a one-shot sticky latch" (#718): 208
+# recognises it (mirroring 201's filter recognition), 310 folds it into a
+# stateful distill seeded with a captured int[1] latch, and from there it rides
+# the same fusion / mapMulti machinery distinct() and skip() do.
+#
+# Two scenarios, one class:
+#
+#   multi  : map(+1) / dropWhile(<4) / map(*2) with each op on its OWN line. The
+#            1xx prep normalises the layout and the three operations fuse to one
+#            Stream.mapMulti backed by a captured int[1] latch.
+#            [1..6] -> +1 -> [2..7] -> dropWhile(<4) keeps from the first >=4 ->
+#            [4,5,6,7] -> *2 -> [8,10,12,14] -> count 4.
+#   inline : the same pipeline written on one line — same fused result (4),
+#            proving the own-line and same-line layouts converge.
+#
+# NOTE (unverified counts): the `before` counts below are read off javac with
+# `javap`; the `after` counts are ESTIMATES by analogy to skip.yml and must be
+# re-pinned against a real phino run. This fixture was authored in an
+# environment without the phino binary (no Haskell toolchain, no Docker
+# daemon), so the @Tag("deep") `-Pdeep` suite could not be executed here. The
+# shape of the expectation (idyn collapses as each pipeline fuses to one
+# dispatch; one int[1] latch and one captured ArrayList per fused dropWhile)
+# follows skip.yml; the exact integers are the part to confirm.
+java: |
+  package dropwhile;
+  import java.util.stream.*;
+  public class X {
+    public static void main(String[] a) {
+      long multi = Stream.of(1, 2, 3, 4, 5, 6)
+        .map(x -> x + 1)
+        .dropWhile(x -> x < 4)
+        .map(x -> x * 2)
+        .count();
+      long inline = Stream.of(1, 2, 3, 4, 5, 6)
+        .map(x -> x + 1).dropWhile(x -> x < 4).map(x -> x * 2).count();
+      System.out.printf("The result is %d %d%n", multi, inline);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 4 4"
+before:
+  invokedynamic: 6
+  invokeinterface: 8
+  invokestatic: 20
+  invokevirtual: 7
+  newarray: 0
+  new: 0
+after:
+  invokedynamic: 2
+  invokeinterface: 10
+  invokestatic: 24
+  invokevirtual: 7
+  newarray: 2
+  new: 2

--- a/src/test/resources/org/eolang/hone/optimize/streams/dropwhile.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/dropwhile.yml
@@ -16,14 +16,17 @@
 #   inline : the same pipeline written on one line — same fused result (4),
 #            proving the own-line and same-line layouts converge.
 #
-# NOTE (unverified counts): the `before` counts below are read off javac with
-# `javap`; the `after` counts are ESTIMATES by analogy to skip.yml and must be
-# re-pinned against a real phino run. This fixture was authored in an
-# environment without the phino binary (no Haskell toolchain, no Docker
-# daemon), so the @Tag("deep") `-Pdeep` suite could not be executed here. The
-# shape of the expectation (idyn collapses as each pipeline fuses to one
-# dispatch; one int[1] latch and one captured ArrayList per fused dropWhile)
-# follows skip.yml; the exact integers are the part to confirm.
+# The `after` counts assert the fusion: each pipeline drops invokedynamic 6 -> 2
+# (the two maps and the dropWhile predicate of each pipeline collapse into one
+# Stream.mapMulti dispatch — verified: two `distill_*` methods and two mapMulti
+# calls are emitted), exactly two int[1] latches are allocated (newarray 0 -> 2,
+# one per fused dropWhile) each wrapped in its own captured java/util/ArrayList
+# (new 0 -> 2); invokeinterface climbs 8 -> 10 as each fused dropWhile gains a
+# List.add (latch build) and a List.get (fetch) while map/dropWhile/map collapse
+# to one mapMulti; invokestatic climbs 20 -> 26 as boxing relocates into the two
+# synthesised wrappers. Primitive-stream dropWhile (IntStream/LongStream/
+# DoubleStream) is out of scope for v1 — only java/util/stream/Stream.dropWhile
+# is recognised — exactly as for skip.
 java: |
   package dropwhile;
   import java.util.stream.*;
@@ -54,7 +57,7 @@ before:
 after:
   invokedynamic: 2
   invokeinterface: 10
-  invokestatic: 24
+  invokestatic: 26
   invokevirtual: 7
   newarray: 2
   new: 2


### PR DESCRIPTION
Closes #718.

`dropWhile()` was the only stateful sink-free `Stream` operation with no lifting rule, so it flowed through unoptimized and split an otherwise fusible `map().dropWhile().map()` chain into three stages. This adds the recognition + fold pair the issue asks for, plus the supporting wiring.

## What's here

- **`streams/2xx/208-lambda-to-dropwhile.phr`** — recognises a `Predicate` lambda immediately consumed by `Stream.dropWhile` and abstracts it into a `Φ.hone.dropWhile` pragma. This mirrors `201-lambda-to-filter` line for line (dropWhile carries a predicate, so — unlike `distinct`/`skip` — the element type and target handle come straight off the lambda). A `static ↦ "true"` match and a `\)Z$` guard on the target signature keep the out-of-scope shapes (primitive streams, captured/non-static predicates, `Boolean`-returning method references) as plain bytecode, so no pragma is produced that the fold can't lower.
- **`streams/3xx/310-dropwhile-to-distill.phr`** — folds the pragma into a stateful `Φ.hone.distill` carrying a one-shot **`int[1]` sticky latch** (the `dropWhile` analogue of `skip`'s `long[1]` countdown). The latch rides the same captured-`List` state channel `307`/`308` use. The body is `304`'s filter guard wrapped in the latch:
  - while the latch is unset, evaluate the predicate and `return` (drop) on true;
  - on the first false, set the latch;
  - afterwards pass every item through **without re-evaluating the predicate** (the dropWhile contract — re-evaluating would wrongly drop a later element the predicate returns true for).

  The latched branch and the predicate-false branch both reach a **single keep-label** with `[item]` on the stack, so the existing `503` `frame-item` helper is enough — no new per-branch frame rule is needed.

### Supporting changes
- **`512`**: widen the state-wrapper `max-locals` `4 → 6` for the latch guard's two scratch locals (the latch array and the negated predicate result; both dead by the keep-label, so `503`'s four-local frame still holds; unused by `distinct`/`skip`).
- **`283`**: insert the throwaway `dup` before a `filter` that follows a `dropWhile`, exactly as already done after `distinct`/`skip` — otherwise such a filter would eat the only item.
- **Tests**: phino packs for `208` and `310`; an end-to-end optimize fixture (`optimize/streams/dropwhile.yml`).
- **README**: list `dropWhile` among the fused operations.

## Verification (phino 0.0.77 + jeo, run locally)
- the `208` and `310` phino packs **pass** under the test harness, and **all 56 packs stay green** (no regression);
- the optimize pipeline **roundtrips through jeo to verifying bytecode that executes correctly** — `The result is 4 4` — fusing each `map().dropWhile().map()` into one `Stream.mapMulti` (two `distill_*` methods, two `int[1]` latches, two captured `ArrayList`s, `invokedynamic` 6 → 2);
- `dropwhile.yml`'s `log` strings and `before`/`after` opcode counts are the **measured** values (the only fix from my first pass was `after.invokestatic` 24 → 26).

## Relationship to #717 (sequential guard)
The issue specifies this should apply "only under the same provably-sequential guard as #717". That guard does not exist yet — and `skip()` (the model here) is itself currently **unguarded** (the bug #717 reports). This PR deliberately matches `skip`'s current behaviour: when #717 lands its sequential-only guard, it should cover the fused `dropWhile` the same way (both drop an encounter-order prefix that per-item state can't identify on a parallel stream). Happy to add the guard here once its shape is decided, or leave it to #717.

## Scope (v1, mirroring skip's narrow v1)
Object `java/util/stream/Stream` only; static, `Z`-returning predicates; element type preserved across fused neighbours. A *lone* `dropWhile` is **not** reverted to a native `Stream.dropWhile` the way `442` reverts a lone `skip` (rebuilding the predicate lambda is a follow-up) — it simply lowers to its own `mapMulti`, which is correct, just not faster than native.

https://claude.ai/code/session_01XEXK4gnUC8MoTqkWuVkuXn