### PR TITLE
#719: guard stateful skip lifting against parallel pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,26 @@ Instead, `limit` and `takeWhile` act as barriers:
   fuse into their own `mapMulti` calls independently,
   while the native short-circuiting call stays in place.
 
+## Why `skip` Is Only Fused on Sequential Pipelines
+
+`skip(n)` is fused (it lowers to a countdown counter inside the
+  `mapMulti` body, see `308-skip-to-distill`), but only when the pipeline
+  provably stays sequential.
+The fused counter is correct only if arrival order equals encounter order:
+  on a parallel stream several `ForkJoin` workers drive the one captured
+  counter concurrently, so it both races and counts in arrival order rather
+  than encounter order, dropping the wrong elements
+  (this is the order-dependent analogue of the parallel `distinct` race
+  fixed in #715, except that no thread-safe data structure can recover
+  encounter order once it is lost).
+The JDK's native `Stream.skip(n)` honours the ordered/parallel contract,
+  so when a method contains a `parallel()` or `parallelStream()` call the
+  rules `222-parallel-reverts-skip` and `223-parallel-reverts-skip-after`
+  revert the recognised `skip` back to the native call before `308` can fold
+  it (#719, #717).
+The same revert-on-parallel guard applies verbatim to a future `dropWhile`
+  lifting, which is order-dependent for the same reason.
+
 ## How to Use in Gradle
 
 You can use this plugin with [Gradle] too, but it requires

--- a/src/main/resources/org/eolang/hone/rules/streams/2xx/222-parallel-reverts-skip.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/2xx/222-parallel-reverts-skip.phr
@@ -83,9 +83,7 @@ when:
     - or:
         - eq: [𝜏-op, 'invokeinterface']
         - eq: [𝜏-op, 'invokevirtual']
-    - or:
-        - eq: [𝑒-pmethod, 'parallel']
-        - eq: [𝑒-pmethod, 'parallelStream']
+    - matches: ['^(parallel|parallelStream)$', 𝑒-pmethod]
 where:
   - meta: 𝜏-push-back
     function: random-tau

--- a/src/main/resources/org/eolang/hone/rules/streams/2xx/222-parallel-reverts-skip.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/2xx/222-parallel-reverts-skip.phr
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Guards the stateful skip lifting against parallel pipelines (#719, #717).
+#
+# `220-recognize-skip` lifts every `.skip(n)` into a Φ.hone.skip pragma, which
+# `308` then folds into a stateful distill that fuses (`401`) into one
+# `Stream.mapMulti` driven by a captured `long[1]` countdown counter. That
+# rewrite is sound only when arrival order equals encounter order — i.e. when
+# the stream provably stays sequential. On a parallel stream several ForkJoin
+# workers drive the fused BiConsumer concurrently, so the shared counter both
+# races and counts in ARRIVAL order rather than ENCOUNTER order: the wrong
+# elements are dropped and the result is non-deterministic. The native
+# `Stream.skip(n)` the JVM already has honours the parallel/ordered contract,
+# so on a parallel pipeline the skip must stay native and unfused.
+#
+# phino patterns cannot test a binding group for the ABSENCE of a parallel
+# call, so instead of stamping a "sequential" marker and gating `220`/`308` on
+# it, this rule takes the dual, positive route used by `442`: once `220` has
+# produced a Φ.hone.skip, if the SAME method body also contains a
+# `parallel()` / `parallelStream()` invoke, the skip pragma is reverted back to
+# a plain `invokeinterface java/util/stream/Stream.skip:(J)…` before `308`
+# (3xx) ever folds it. The recovered count rides in the pragma's `push`. The
+# reverted opcode carries `reverted ↦ Φ.true`, the same fifth-operand guard
+# `442` uses, so `220` (closed on the four-operand opcode jeo emits) cannot
+# re-recognise it and the 220 → 222 cycle cannot spin.
+#
+# Detection is intentionally over-broad: any `parallel`/`parallelStream` call
+# anywhere in the method reverts every Φ.hone.skip in it, even one on an
+# unrelated, locally-consumed stream. Over-reverting only forfeits the skip
+# optimisation on that method (the native call stays correct), so erring this
+# way keeps the pass sound. This rule covers a parallel call that appears
+# BEFORE the skip in the body (`source.parallel().…skip(n)`,
+# `coll.parallelStream().…skip(n)`); its sibling `223` covers the call after
+# the skip (`source.skip(n).parallel()`). Binding groups are order-preserving,
+# so both layouts need their own rule.
+#
+# When a future `dropWhile` lifting lands, the same revert-on-parallel guard
+# applies to its pragma verbatim.
+name: parallel-reverts-skip
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-parallel ↦ ⟦
+      φ ↦ Φ.jeo.opcode.𝜏-op,
+      𝜏-pclass ↦ 𝑒-pclass,
+      𝜏-pmethod ↦ 𝑒-pmethod,
+      𝐵-parallel-rest
+    ⟧,
+    𝐵-between,
+    𝜏-skip ↦ ⟦
+      φ ↦ Φ.hone.skip,
+      class ↦ 𝑒-class,
+      stream-class ↦ 𝑒-stream-class,
+      push ↦ 𝑒-push
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-parallel ↦ ⟦
+      φ ↦ Φ.jeo.opcode.𝜏-op,
+      𝜏-pclass ↦ 𝑒-pclass,
+      𝜏-pmethod ↦ 𝑒-pmethod,
+      𝐵-parallel-rest
+    ⟧,
+    𝐵-between,
+    𝜏-push-back ↦ 𝑒-push,
+    𝜏-skip-call ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      i2 ↦ 𝑒-stream-class,
+      i3 ↦ "skip",
+      i4 ↦ "(J)Ljava/util/stream/Stream;",
+      i5 ↦ Φ.true,
+      reverted ↦ Φ.true
+    ⟧,
+    𝐵-after
+  ⟧
+when:
+  and:
+    - or:
+        - eq: [𝜏-op, 'invokeinterface']
+        - eq: [𝜏-op, 'invokevirtual']
+    - or:
+        - eq: [𝑒-pmethod, 'parallel']
+        - eq: [𝑒-pmethod, 'parallelStream']
+where:
+  - meta: 𝜏-push-back
+    function: random-tau
+  - meta: 𝜏-skip-call
+    function: random-tau

--- a/src/main/resources/org/eolang/hone/rules/streams/2xx/223-parallel-reverts-skip-after.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/2xx/223-parallel-reverts-skip-after.phr
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Positional sibling of `222`. `222` reverts a Φ.hone.skip back to a native
+# `Stream.skip` when a `parallel()` / `parallelStream()` call sits BEFORE it in
+# the method body; this rule covers the mirror layout where the parallel call
+# comes AFTER the skip, e.g. `source.skip(n).parallel().…`. phino binding
+# groups are order-preserving (the same property `281` relies on to stay
+# idempotent), so a single pattern cannot match the call on either side of the
+# skip — the two orderings need two rules. Everything else — the soundness
+# rationale, the recovered count from the pragma's `push`, and the
+# `reverted ↦ Φ.true` guard that stops `220` re-recognising the result — is
+# exactly as documented in `222`.
+name: parallel-reverts-skip-after
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-skip ↦ ⟦
+      φ ↦ Φ.hone.skip,
+      class ↦ 𝑒-class,
+      stream-class ↦ 𝑒-stream-class,
+      push ↦ 𝑒-push
+    ⟧,
+    𝐵-between,
+    𝜏-parallel ↦ ⟦
+      φ ↦ Φ.jeo.opcode.𝜏-op,
+      𝜏-pclass ↦ 𝑒-pclass,
+      𝜏-pmethod ↦ 𝑒-pmethod,
+      𝐵-parallel-rest
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-push-back ↦ 𝑒-push,
+    𝜏-skip-call ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      i2 ↦ 𝑒-stream-class,
+      i3 ↦ "skip",
+      i4 ↦ "(J)Ljava/util/stream/Stream;",
+      i5 ↦ Φ.true,
+      reverted ↦ Φ.true
+    ⟧,
+    𝐵-between,
+    𝜏-parallel ↦ ⟦
+      φ ↦ Φ.jeo.opcode.𝜏-op,
+      𝜏-pclass ↦ 𝑒-pclass,
+      𝜏-pmethod ↦ 𝑒-pmethod,
+      𝐵-parallel-rest
+    ⟧,
+    𝐵-after
+  ⟧
+when:
+  and:
+    - or:
+        - eq: [𝜏-op, 'invokeinterface']
+        - eq: [𝜏-op, 'invokevirtual']
+    - or:
+        - eq: [𝑒-pmethod, 'parallel']
+        - eq: [𝑒-pmethod, 'parallelStream']
+where:
+  - meta: 𝜏-push-back
+    function: random-tau
+  - meta: 𝜏-skip-call
+    function: random-tau

--- a/src/main/resources/org/eolang/hone/rules/streams/2xx/223-parallel-reverts-skip-after.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/2xx/223-parallel-reverts-skip-after.phr
@@ -57,9 +57,7 @@ when:
     - or:
         - eq: [𝜏-op, 'invokeinterface']
         - eq: [𝜏-op, 'invokevirtual']
-    - or:
-        - eq: [𝑒-pmethod, 'parallel']
-        - eq: [𝑒-pmethod, 'parallelStream']
+    - matches: ['^(parallel|parallelStream)$', 𝑒-pmethod]
 where:
   - meta: 𝜏-push-back
     function: random-tau

--- a/src/test/phino/222-parallel-reverts-skip.yml
+++ b/src/test/phino/222-parallel-reverts-skip.yml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A Φ.hone.skip in a method that also calls `.parallel()` BEFORE it must be
+# put back to a native `Stream.skip` (carrying the `reverted` guard) so 308
+# never folds it into a parallel-unsound countdown distill (#719, #717).
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/2xx/222-parallel-reverts-skip.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      op0 ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokeinterface,
+        v0 ↦ "java/util/stream/Stream",
+        v1 ↦ "parallel",
+        v2 ↦ "()Ljava/util/stream/Stream;",
+        v3 ↦ Φ.true
+      ⟧,
+      op1 ↦ ⟦
+        φ ↦ Φ.hone.skip,
+        class ↦ "Foo",
+        stream-class ↦ "java/util/stream/Stream",
+        push ↦ ⟦ φ ↦ Φ.jeo.opcode.ldc, v0 ↦ ⟦ φ ↦ Φ.jeo.long, n0 ↦ 2 ⟧ ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, 𝐵-h, i3 ↦ "skip", 𝐵-t ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, 𝐵-h, reverted ↦ Φ.true, 𝐵-t ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, 𝐵-h, v1 ↦ "parallel", 𝐵-t ⟧

--- a/src/test/phino/223-parallel-reverts-skip-after.yml
+++ b/src/test/phino/223-parallel-reverts-skip-after.yml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Mirror of 222 for the layout where `.parallel()` is called AFTER the skip
+# (`source.skip(n).parallel()`): the skip is still reverted to a native
+# `Stream.skip` so it is never folded into a parallel-unsound distill.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/2xx/223-parallel-reverts-skip-after.phr
+input: |
+  {⟦
+    body ↦ ⟦
+      op0 ↦ ⟦
+        φ ↦ Φ.hone.skip,
+        class ↦ "Foo",
+        stream-class ↦ "java/util/stream/Stream",
+        push ↦ ⟦ φ ↦ Φ.jeo.opcode.ldc, v0 ↦ ⟦ φ ↦ Φ.jeo.long, n0 ↦ 2 ⟧ ⟧
+      ⟧,
+      op1 ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokeinterface,
+        v0 ↦ "java/util/stream/Stream",
+        v1 ↦ "parallel",
+        v2 ↦ "()Ljava/util/stream/Stream;",
+        v3 ↦ Φ.true
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, 𝐵-h, i3 ↦ "skip", 𝐵-t ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, 𝐵-h, reverted ↦ Φ.true, 𝐵-t ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, 𝐵-h, v1 ↦ "parallel", 𝐵-t ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/parallel-skip.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/parallel-skip.yml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Regression for #719 (and #717): a `.skip(n)` on a PARALLEL stream must stay
+# correct. Lifted and fused (220 → 308 → 401 → 502) a skip becomes a single
+# Stream.mapMulti whose countdown counter is a captured long[1]. On a parallel
+# stream several ForkJoin workers drive that one BiConsumer concurrently, so
+# the counter both races and counts in ARRIVAL order rather than ENCOUNTER
+# order — the wrong elements are dropped and the sum comes out wrong and
+# non-deterministic. The guard (222 / 223) detects the `.parallel()` call in
+# the method and reverts the skip to a native Stream.skip before 308 can fold
+# it, so the JVM's own ordered-parallel skip runs and the result is exact.
+#
+# The pipeline maps the ordered range 1..1_000_000 through an identity map (a
+# stateless neighbour that would otherwise fuse the skip), skips the first 10
+# in encounter order, and sums the rest: 500000500000 - (1+..+10) =
+# 500000499945. With the buggy fused skip this sum was wrong and varied run to
+# run; with the native skip it is deterministically 500000499945.
+#
+# `before`/`after` opcode counts are intentionally omitted (as in
+# parallel-distinct): this pack guards the RUNTIME result of the optimised,
+# parallel pipeline, not a particular opcode shape.
+java: |
+  package skipparallel;
+  import java.util.stream.LongStream;
+  public class X {
+    public static void main(String[] a) {
+      long n = LongStream.rangeClosed(1, 1_000_000L)
+        .boxed()
+        .parallel()
+        .map(x -> x)
+        .skip(10L)
+        .mapToLong(Long::longValue)
+        .sum();
+      System.out.printf("The result is %d%n", n);
+    }
+  }
+log:
+  - "BUILD SUCCESS"
+  - "The result is 500000499945"


### PR DESCRIPTION
Fixes #719.

## Problem

`220-recognize-skip` → `308-skip-to-distill` lift every `.skip(n)` into a stateful countdown distill that fuses into one `Stream.mapMulti`. That rewrite is sound only when **arrival order equals encounter order**, i.e. when the pipeline provably stays sequential. On a parallel stream several `ForkJoin` workers drive the single captured `long[1]` counter concurrently, so it both races and counts in *arrival* order rather than *encounter* order — the wrong elements are dropped and the result is non-deterministic (#717). This is the order-dependent analogue of the parallel `distinct` race fixed in #715, except no thread-safe data structure can recover encounter order once it's lost.

## Approach (note the deviation from the issue text)

The issue proposes stamping a positive "provably-sequential" marker and gating `220`/`308` on it. While implementing I hit a structural limitation: **phino patterns cannot test a binding group for the *absence* of a `parallel()` call**, and an optimistically-stamped marker that's retracted later races with its own cleanup rule in phino's fixed-point evaluation.

So this PR takes the **dual, positive route already proven by `442-unfused-skip-to-invokeinterface`**: once `220` has produced a `Φ.hone.skip`, if the same method body *also* contains a `parallel()`/`parallelStream()` call, the skip pragma is reverted back to a native `invokeinterface Stream.skip:(J)…` **before `308` (3xx) ever folds it**. The native `Stream.skip(n)` honours the ordered/parallel contract, so the result stays correct; only the fusion optimization is forfeited on that method. The reverted opcode carries `reverted ↦ Φ.true` (the same fifth-operand guard `442` uses) so `220` cannot re-recognise it and the cycle cannot spin.

Because binding groups are order-preserving, the two layouts need two rules:
- **`222-parallel-reverts-skip`** — parallel call *before* the skip (`source.parallel()…skip(n)`, `coll.parallelStream()…skip(n)`)
- **`223-parallel-reverts-skip-after`** — parallel call *after* the skip (`source.skip(n).parallel()`)

Detection is intentionally over-broad (any parallel call in the method reverts every skip in it); over-reverting only forfeits an optimization and stays sound. The same guard extends verbatim to a future `dropWhile` lifting (#718).

`308` needs no change: the skip is already reverted before it runs, so it never sees a parallel-method skip. I kept the change to recognition/revert rather than adding a `when` to `308` to minimise risk.

## Changes

- `streams/2xx/222-parallel-reverts-skip.phr`, `streams/2xx/223-parallel-reverts-skip-after.phr`
- single-rule packs `src/test/phino/222-*.yml`, `223-*.yml`
- end-to-end fixture `optimize/streams/parallel-skip.yml` (runtime-only assertions, like `parallel-distinct.yml`): a 1,000,000-element ordered parallel range with an identity `map` neighbour, `skip(10)`, summed — correct = `500000499945`; the buggy fused skip gave a wrong, varying sum.
- README section "Why `skip` Is Only Fused on Sequential Pipelines".

## Validation

Validated locally against the prebuilt **phino 0.0.77** binary (the same one CI installs):
- both single-rule packs (`222`/`223`) rewrite as expected and every `expected` pattern matches;
- the rules are **inert without a `parallel()` call** (a sequential `skip` keeps its `Φ.hone.skip` pragma untouched, so `skip.yml` is unaffected);
- the **full 92-rule `streams/*` set terminates** on a parallel-skip input, leaving the skip as a native `Stream.skip` with no re-recognition loop.

The end-to-end JVM roundtrip + runtime-result assertion still depends on the `@Tag("deep")` CI jobs (`deep` / `codecov`), which run the real jeo+phino pipeline.

https://claude.ai/code/session_016Wqrw3TdkSDfiVbkTYNJqG