### PR TITLE
#717: guard skip() against parallel-stream miscompilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,9 +336,9 @@ On a parallel stream several `ForkJoin` workers drive that `BiConsumer`
 This is the same race class that `distinct` had (see [#715][715]),
   but for `skip` thread-safety alone cannot fix it:
   `Stream.skip(n)` on an ordered stream must drop the first `n` elements
-  in *encounter* order,
+  in _encounter_ order,
   while any per-item counter — even an atomic one —
-  drops the first `n` in *arrival* order,
+  drops the first `n` in _arrival_ order,
   a non-deterministic subset.
 The fix (see [#717][717]) is therefore a guard, not a stronger counter:
   rules `213`–`215` taint a `skip()` that shares its method

--- a/README.md
+++ b/README.md
@@ -324,6 +324,35 @@ Instead, `limit` and `takeWhile` act as barriers:
   fuse into their own `mapMulti` calls independently,
   while the native short-circuiting call stays in place.
 
+## Why `skip` Is Not Fused on Parallel Streams
+
+`skip` is fused only when the pipeline provably stays sequential.
+The fused `skip` carries its countdown as a single `long[]` cell,
+  decremented once per element by the one `BiConsumer`
+  that backs the fused `Stream.mapMulti` dispatch.
+On a parallel stream several `ForkJoin` workers drive that `BiConsumer`
+  at once, so the read-decrement-write of the counter races
+  and the wrong number of elements is dropped.
+This is the same race class that `distinct` had (see [#715][715]),
+  but for `skip` thread-safety alone cannot fix it:
+  `Stream.skip(n)` on an ordered stream must drop the first `n` elements
+  in *encounter* order,
+  while any per-item counter — even an atomic one —
+  drops the first `n` in *arrival* order,
+  a non-deterministic subset.
+The fix (see [#717][717]) is therefore a guard, not a stronger counter:
+  rules `213`–`215` taint a `skip()` that shares its method
+  with a `parallel()` or `parallelStream()` call,
+  and the recognition rule `220` then leaves it
+  as a native `Stream.skip(n)` —
+  correct on sequential and parallel streams alike —
+  acting as a fusion barrier just like `limit`.
+The guard is a same-method analysis:
+  a stream handed in as a parameter and made parallel by the caller
+  is invisible to it,
+  so this remains a `v1` best-effort guard
+  rather than a whole-program proof of sequentiality.
+
 ## How to Use in Gradle
 
 You can use this plugin with [Gradle] too, but it requires
@@ -449,3 +478,5 @@ that we use, are defined in the `pom.xml` file.
 [𝜑-calculus]: https://arxiv.org/abs/2111.13384
 [XMIR]: https://news.eolang.org/2022-11-25-xmir-guide.html
 [hone-paper]: https://github.com/objectionary/hone-paper
+[715]: https://github.com/objectionary/hone-maven-plugin/issues/715
+[717]: https://github.com/objectionary/hone-maven-plugin/issues/717

--- a/src/main/resources/org/eolang/hone/rules/streams/2xx/213-guard-skip-after-parallel-stream.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/2xx/213-guard-skip-after-parallel-stream.phr
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Parallel-safety guard for skip() (#717). The fused skip() that 220 → 308 →
+# 502 produce carries the countdown state — a one-cell long[] decremented per
+# item — captured into the SINGLE BiConsumer that backs the fused
+# Stream.mapMulti dispatch. On a parallel stream several ForkJoin workers
+# invoke that BiConsumer concurrently, so the counter is read-decremented-
+# written from many threads at once: updates are lost and the wrong number of
+# elements is dropped. Worse than the #715 distinct() race, thread-safety
+# alone cannot save it: Stream.skip(n) on an ordered stream must drop the
+# first n elements in ENCOUNTER order, while any per-item counter — even an
+# atomic one — drops n elements in ARRIVAL order, a non-deterministic subset.
+# So a fused skip() is simply unsound on a parallel pipeline.
+#
+# The sound fix is a guard, not a stronger counter: do NOT lift a skip() that
+# shares its method with a parallel/parallelStream call. This rule taints such
+# a skip with a `parallel-unsafe` marker; 220's recognition pattern is closed
+# on the four-operand opcode jeo emits (ρ ↦ ∅), so the extra operand stops it
+# folding the skip into a distill. The skip therefore stays a plain native
+# Stream.skip(n) — correct on sequential AND parallel streams — and acts as a
+# fusion barrier (exactly like limit/takeWhile), with the neighbouring
+# map/filter/distinct chains fusing independently around it. jeo ignores the
+# extra operand on assemble (same trick 442 uses with its `reverted` marker).
+#
+# This rule covers a `parallelStream()` source (always upstream of the skip):
+# `coll.parallelStream()…skip(n)…`. 214 covers an explicit `.parallel()`
+# placed before the skip and 215 the rarer `.parallel()` placed after it.
+# `.parallel()`/`.sequential()` toggle a flag on the WHOLE pipeline, so the
+# guard is deliberately conservative — any such call anywhere in the method
+# keeps skip native. (Limitation: a stream handed in as a parameter and made
+# parallel by the caller is invisible here; this guard, like skip recognition
+# itself, is a same-method, v1 analysis.)
+name: guard-skip-after-parallel-stream
+pattern: |
+  ⟦
+    𝐵-head,
+    𝜏-source ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      𝜏so ↦ 𝑒-source-owner,
+      𝜏sn ↦ "parallelStream",
+      𝐵-source-rest
+    ⟧,
+    𝐵-mid,
+    𝜏-skip ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      𝜏k1 ↦ "java/util/stream/Stream",
+      𝜏k2 ↦ "skip",
+      𝜏k3 ↦ "(J)Ljava/util/stream/Stream;",
+      𝜏k4 ↦ Φ.true,
+      ρ ↦ ∅
+    ⟧,
+    𝐵-tail
+  ⟧
+result: |
+  ⟦
+    𝐵-head,
+    𝜏-source ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      𝜏so ↦ 𝑒-source-owner,
+      𝜏sn ↦ "parallelStream",
+      𝐵-source-rest
+    ⟧,
+    𝐵-mid,
+    𝜏-skip ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      𝜏k1 ↦ "java/util/stream/Stream",
+      𝜏k2 ↦ "skip",
+      𝜏k3 ↦ "(J)Ljava/util/stream/Stream;",
+      𝜏k4 ↦ Φ.true,
+      parallel-unsafe ↦ Φ.true
+    ⟧,
+    𝐵-tail
+  ⟧

--- a/src/main/resources/org/eolang/hone/rules/streams/2xx/214-guard-skip-after-parallel.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/2xx/214-guard-skip-after-parallel.phr
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Parallel-safety guard for skip() (#717), the `.parallel()`-before-skip case.
+# See 213 for the full rationale: a fused skip() is unsound on a parallel
+# stream (lost-update race AND arrival-order vs encounter-order drop), so a
+# skip() sharing its method with a `.parallel()` call is tainted with a
+# `parallel-unsafe` marker that stops 220 folding it, leaving a native
+# Stream.skip(n) that is correct on both sequential and parallel pipelines.
+#
+# This rule matches the common chain order `…parallel()…skip(n)…`. The
+# `.parallel()` opcode is pinned by its name AND its distinctive no-arg
+# `()Ljava/util/stream/BaseStream;` descriptor (parallel() is declared on
+# BaseStream), so a user method that merely happens to be named "parallel"
+# cannot trip the guard. 215 handles the mirror order `…skip(n)…parallel()…`.
+name: guard-skip-after-parallel
+pattern: |
+  ⟦
+    𝐵-head,
+    𝜏-parallel ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      𝜏po ↦ 𝑒-parallel-owner,
+      𝜏pn ↦ "parallel",
+      𝜏pd ↦ "()Ljava/util/stream/BaseStream;",
+      𝐵-parallel-rest
+    ⟧,
+    𝐵-mid,
+    𝜏-skip ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      𝜏k1 ↦ "java/util/stream/Stream",
+      𝜏k2 ↦ "skip",
+      𝜏k3 ↦ "(J)Ljava/util/stream/Stream;",
+      𝜏k4 ↦ Φ.true,
+      ρ ↦ ∅
+    ⟧,
+    𝐵-tail
+  ⟧
+result: |
+  ⟦
+    𝐵-head,
+    𝜏-parallel ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      𝜏po ↦ 𝑒-parallel-owner,
+      𝜏pn ↦ "parallel",
+      𝜏pd ↦ "()Ljava/util/stream/BaseStream;",
+      𝐵-parallel-rest
+    ⟧,
+    𝐵-mid,
+    𝜏-skip ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      𝜏k1 ↦ "java/util/stream/Stream",
+      𝜏k2 ↦ "skip",
+      𝜏k3 ↦ "(J)Ljava/util/stream/Stream;",
+      𝜏k4 ↦ Φ.true,
+      parallel-unsafe ↦ Φ.true
+    ⟧,
+    𝐵-tail
+  ⟧

--- a/src/main/resources/org/eolang/hone/rules/streams/2xx/215-guard-skip-before-parallel.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/2xx/215-guard-skip-before-parallel.phr
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Parallel-safety guard for skip() (#717), the `.parallel()`-AFTER-skip case.
+# See 213 for the full rationale. `.parallel()` toggles a flag on the whole
+# pipeline regardless of where it sits in the chain, so `stream.skip(n)
+# .parallel()…` runs the skip in parallel mode and is just as unsound as the
+# `…parallel().skip(n)…` order 214 catches. This rule taints the skip with a
+# `parallel-unsafe` marker so 220 leaves it as a native Stream.skip(n).
+#
+# Mirror of 214 with the two anchors swapped: the skip comes first, the
+# `.parallel()` call (pinned by name and its `()Ljava/util/stream/BaseStream;`
+# descriptor) comes later in the same body.
+name: guard-skip-before-parallel
+pattern: |
+  ⟦
+    𝐵-head,
+    𝜏-skip ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      𝜏k1 ↦ "java/util/stream/Stream",
+      𝜏k2 ↦ "skip",
+      𝜏k3 ↦ "(J)Ljava/util/stream/Stream;",
+      𝜏k4 ↦ Φ.true,
+      ρ ↦ ∅
+    ⟧,
+    𝐵-mid,
+    𝜏-parallel ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      𝜏po ↦ 𝑒-parallel-owner,
+      𝜏pn ↦ "parallel",
+      𝜏pd ↦ "()Ljava/util/stream/BaseStream;",
+      𝐵-parallel-rest
+    ⟧,
+    𝐵-tail
+  ⟧
+result: |
+  ⟦
+    𝐵-head,
+    𝜏-skip ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      𝜏k1 ↦ "java/util/stream/Stream",
+      𝜏k2 ↦ "skip",
+      𝜏k3 ↦ "(J)Ljava/util/stream/Stream;",
+      𝜏k4 ↦ Φ.true,
+      parallel-unsafe ↦ Φ.true
+    ⟧,
+    𝐵-mid,
+    𝜏-parallel ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      𝜏po ↦ 𝑒-parallel-owner,
+      𝜏pn ↦ "parallel",
+      𝜏pd ↦ "()Ljava/util/stream/BaseStream;",
+      𝐵-parallel-rest
+    ⟧,
+    𝐵-tail
+  ⟧

--- a/src/main/resources/org/eolang/hone/rules/streams/2xx/220-recognize-skip.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/2xx/220-recognize-skip.phr
@@ -26,6 +26,13 @@
 # v1 assumes the count is a compile-time constant (a single opcode pushes the
 # whole value). A computed argument would miscapture only the last opcode of
 # its expression; such streams are left unoptimised.
+#
+# A skip() that shares its method with a parallel/parallelStream call has
+# already been tainted with a `parallel-unsafe` marker by 213/214/215 (#717):
+# the pattern below is closed on the four-operand opcode (ρ ↦ ∅), so the extra
+# operand makes it skip such a skip, which stays a native Stream.skip(n). A
+# fused skip is unsound on a parallel stream — the captured countdown races and
+# drops elements in arrival rather than encounter order — so it must not lift.
 name: recognize-skip
 pattern: |
   ⟦

--- a/src/test/phino/213-guard-skip-after-parallel-stream.yml
+++ b/src/test/phino/213-guard-skip-after-parallel-stream.yml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A skip() downstream of a parallelStream() source (#717) is tainted with a
+# `parallel-unsafe` marker so 220 leaves it as a native Stream.skip(n) instead
+# of folding it into an order-unsound fused distill.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/2xx/213-guard-skip-after-parallel-stream.phr
+input: |
+  {⟦
+    j$X ↦ ⟦
+      φ ↦ Φ.jeo.class,
+      name ↦ "Foo",
+      j$main ↦ ⟦
+        φ ↦ Φ.jeo.method,
+        name ↦ "main",
+        body ↦ ⟦
+          op0 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/List", v1 ↦ "parallelStream", v2 ↦ "()Ljava/util/stream/Stream;", v3 ↦ Φ.true ⟧,
+          op1 ↦ ⟦ φ ↦ Φ.jeo.opcode.ldc, v4 ↦ ⟦ φ ↦ Φ.jeo.long, n0 ↦ 2 ⟧ ⟧,
+          op2 ↦ ⟦
+            φ ↦ Φ.jeo.opcode.invokeinterface,
+            v9 ↦ "java/util/stream/Stream",
+            v10 ↦ "skip",
+            v11 ↦ "(J)Ljava/util/stream/Stream;",
+            v12 ↦ Φ.true
+          ⟧
+        ⟧
+      ⟧
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, 𝐵-a, v10 ↦ "skip", 𝐵-b, parallel-unsafe ↦ Φ.true, 𝐵-c ⟧

--- a/src/test/phino/214-guard-skip-after-parallel.yml
+++ b/src/test/phino/214-guard-skip-after-parallel.yml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A skip() downstream of an explicit .parallel() call (#717) is tainted with a
+# `parallel-unsafe` marker so 220 leaves it native. The .parallel() opcode is
+# matched by name AND its ()Ljava/util/stream/BaseStream; descriptor.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/2xx/214-guard-skip-after-parallel.phr
+input: |
+  {⟦
+    j$X ↦ ⟦
+      φ ↦ Φ.jeo.class,
+      name ↦ "Foo",
+      j$main ↦ ⟦
+        φ ↦ Φ.jeo.method,
+        name ↦ "main",
+        body ↦ ⟦
+          op0 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "parallel", v2 ↦ "()Ljava/util/stream/BaseStream;", v3 ↦ Φ.true ⟧,
+          op1 ↦ ⟦ φ ↦ Φ.jeo.opcode.ldc, v4 ↦ ⟦ φ ↦ Φ.jeo.long, n0 ↦ 2 ⟧ ⟧,
+          op2 ↦ ⟦
+            φ ↦ Φ.jeo.opcode.invokeinterface,
+            v9 ↦ "java/util/stream/Stream",
+            v10 ↦ "skip",
+            v11 ↦ "(J)Ljava/util/stream/Stream;",
+            v12 ↦ Φ.true
+          ⟧
+        ⟧
+      ⟧
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, 𝐵-a, v10 ↦ "skip", 𝐵-b, parallel-unsafe ↦ Φ.true, 𝐵-c ⟧

--- a/src/test/phino/215-guard-skip-before-parallel.yml
+++ b/src/test/phino/215-guard-skip-before-parallel.yml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A skip() UPSTREAM of a later .parallel() call (#717) is just as unsound —
+# .parallel() toggles the whole pipeline — so it too is tainted with the
+# `parallel-unsafe` marker that keeps 220 from folding it.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/2xx/215-guard-skip-before-parallel.phr
+input: |
+  {⟦
+    j$X ↦ ⟦
+      φ ↦ Φ.jeo.class,
+      name ↦ "Foo",
+      j$main ↦ ⟦
+        φ ↦ Φ.jeo.method,
+        name ↦ "main",
+        body ↦ ⟦
+          op0 ↦ ⟦ φ ↦ Φ.jeo.opcode.ldc, v4 ↦ ⟦ φ ↦ Φ.jeo.long, n0 ↦ 2 ⟧ ⟧,
+          op1 ↦ ⟦
+            φ ↦ Φ.jeo.opcode.invokeinterface,
+            v9 ↦ "java/util/stream/Stream",
+            v10 ↦ "skip",
+            v11 ↦ "(J)Ljava/util/stream/Stream;",
+            v12 ↦ Φ.true
+          ⟧,
+          op2 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "parallel", v2 ↦ "()Ljava/util/stream/BaseStream;", v3 ↦ Φ.true ⟧
+        ⟧
+      ⟧
+    ⟧
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, 𝐵-a, v10 ↦ "skip", 𝐵-b, parallel-unsafe ↦ Φ.true, 𝐵-c ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/parallel-skip.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/parallel-skip.yml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Regression for #717: a skip() on a PARALLEL stream must stay correct. The
+# pipeline below builds an ordered Stream<Long> from a List, maps, skips the
+# first 500,000 elements in encounter order, maps again and sums. Because a
+# fused skip() carries its countdown as a single captured long[] cell decreased
+# per item by the ONE BiConsumer that backs the fused Stream.mapMulti dispatch,
+# a parallel source drives it from several ForkJoin workers at once: the
+# read-decrement-write races (lost updates), and — fatally — a per-item counter
+# drops the first n elements in ARRIVAL order, not the encounter order
+# Stream.skip(n) promises on an ordered stream. Both defects make the dropped
+# subset, and therefore the sum, wrong and non-deterministic.
+#
+# Unlike #715's distinct() (whose contract is order-free, so a thread-safe set
+# repairs it), skip() cannot be made sound by a stronger counter, so the 213/
+# 214/215 guards keep it as a native Stream.skip(n) whenever a
+# parallel/parallelStream call shares its method. Native skip drops the first n
+# in encounter order on a parallel stream too, so the dedup-free dropped subset
+# is [500001..1000000], mapped *2, summing deterministically to
+# 2 * (500001 + ... + 1000000) = 750000500000.
+#
+# `before`/`after` opcode counts are intentionally omitted (as in
+# parallel-distinct.yml): this pack guards the RUNTIME result of the optimised
+# parallel pipeline, not a particular opcode shape.
+java: |
+  package skip;
+  import java.util.List;
+  import java.util.stream.Collectors;
+  import java.util.stream.LongStream;
+  public class X {
+    public static void main(String[] a) {
+      final List<Long> list = LongStream.range(0, 1_000_000L)
+        .boxed()
+        .collect(Collectors.toList());
+      final long n = list.parallelStream()
+        .map(x -> x + 1L)
+        .skip(500_000L)
+        .map(x -> x * 2L)
+        .mapToLong(Long::longValue)
+        .sum();
+      System.out.printf("The result is %d%n", n);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 750000500000"


### PR DESCRIPTION
Fixes #717.

## Problem

A fused `skip()` is unsound on a parallel stream. The `220 → 308 → 502` path lowers `skip()` into a single `Stream.mapMulti` dispatch whose countdown state is a one-cell `long[]` captured into the **one** `BiConsumer` that backs the fused dispatch. On a parallel stream several `ForkJoin` workers decrement that cell concurrently (lost updates), and — fatally — a per-item counter drops the first `n` elements in **arrival** order while `Stream.skip(n)` on an ordered stream must drop them in **encounter** order.

Unlike the #715 `distinct()` race, thread-safety alone cannot repair this: `skip()`'s contract is order-dependent, so no counter (atomic or not) reproduces it on a parallel pipeline.

## Fix

A guard, not a stronger counter (as suggested in the issue). Three new rules taint a `skip()` that shares its method with a `parallel()`/`parallelStream()` call by appending a `parallel-unsafe` operand to its `invokeinterface`. Rule `220`'s recognition pattern is closed (`ρ ↦ ∅`), so the extra operand stops it folding the skip into a distill; the skip stays a native `Stream.skip(n)` — correct on sequential and parallel streams alike — and acts as a fusion barrier like `limit`/`takeWhile`. jeo ignores the extra operand on assemble (the same trick `442` uses with `reverted`).

- **213** — `parallelStream()` source upstream of the skip.
- **214** — explicit `.parallel()` upstream of the skip.
- **215** — `.parallel()` downstream of the skip (it toggles the whole pipeline).
- **220** — comment noting the guard and why a fused skip must not lift.

## Tests

- Single-rule packs `213`/`214`/`215` under `src/test/phino/`.
- `parallel-skip.yml` e2e regression (mirroring `parallel-distinct.yml`) asserting the deterministic sum `750000500000` for `list.parallelStream().map(+1).skip(500_000).map(*2).mapToLong(...).sum()`. On `master` the fused skip makes this wrong/non-deterministic.

## Known limitation

The guard is a **same-method** analysis: a stream handed in as a parameter and made parallel by the caller is invisible to it, so this is a `v1` best-effort guard rather than a whole-program proof of sequentiality. Documented in `README.md` ("Why `skip` Is Not Fused on Parallel Streams").

⚠️ I could not run the `deep` (phino-backed) suite locally — phino is not installed in this environment and there is no Docker fallback — so the `.phr` rules are validated by construction (mirroring existing rules `219`/`220`/`442`/`711`) and rely on CI's `-Pdeep` run.

https://claude.ai/code/session_01JGesjGXwyQdJsLk36VRpLJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGesjGXwyQdJsLk36VRpLJ)_