### PR TITLE
#725: reproduce flatMap's null-skip and sequential() in the mapMulti adapter

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/455-flatMap-to-mapMulti.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/455-flatMap-to-mapMulti.phr
@@ -14,6 +14,8 @@
 # handle-6 target — whose target is a freshly synthesised BiConsumer `flatadapt`:
 #
 #   flatadapt(x, c):  invokestatic lambda$(x) -> Stream ; mapper applied to item
+#                     dup; ifnonnull L; pop; return    ; flatMap's null-skip
+#                     L: invokeinterface BaseStream.sequential() ; force sequential
 #                     invokeinterface Stream.forEach(c) ; drains it into c
 #
 # The original mapper body (lambda$…) is kept untouched — the rule only wires the
@@ -26,9 +28,11 @@
 #
 # Scope: reference Stream.flatMap only (mapper returns java/util/stream/Stream).
 # The primitive flatMapToInt/Long/Double variants carry different SAM and result
-# types and are left for a follow-up. Like the JDK's own mapMulti-via-flatMap
-# bridge, this assumes the mapper returns a non-null, non-resource stream — the
-# null-skip and auto-close of flatMap are not reproduced.
+# types and are left for a follow-up. The adapter reproduces flatMap's null-skip
+# (a null mapper result is dropped rather than dereferenced) and its
+# `result.sequential()` drain (a parallel sub-stream is forced sequential before
+# its elements reach the downstream Consumer); the auto-close of the returned
+# stream still needs try-finally synthesis and is tracked separately.
 name: flatMap-to-mapMulti
 pattern: |
   ⟦
@@ -125,6 +129,29 @@ result: |
           i4 ↦ 𝑒-target-signature,
           i5 ↦ 𝑒-target-is-interface
         ⟧,
+        dup-stream ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+        guard ↦ ⟦
+          φ ↦ Φ.jeo.opcode.ifnonnull,
+          i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label ⟧
+        ⟧,
+        drop-null ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+        ret-null ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+        keep ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label ⟧,
+        keep-frame ↦ ⟦
+          φ ↦ Φ.jeo.frame,
+          type ↦ 4,
+          nlocal ↦ 0,
+          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+          nstack ↦ 1,
+          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, item ↦ "java/util/stream/Stream" ⟧
+        ⟧,
+        force-seq ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          i2 ↦ "java/util/stream/BaseStream",
+          i3 ↦ "sequential",
+          i4 ↦ "()Ljava/util/stream/BaseStream;",
+          i5 ↦ Φ.true
+        ⟧,
         ld-downstream ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
         call-foreach ↦ ⟦
           φ ↦ Φ.jeo.opcode.invokeinterface,
@@ -143,6 +170,9 @@ result: |
 where:
   - meta: 𝜏-adapter-method
     function: random-tau
+  - meta: 𝑒-label
+    function: random-string
+    args: [ '"L%d"' ]
   - meta: 𝑒-adapter-name
     function: random-string
     args: [ '"flatadapt_%d"' ]

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/456-flatMapToInt-to-mapMultiToInt.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/456-flatMapToInt-to-mapMultiToInt.phr
@@ -15,6 +15,8 @@
 # BiConsumer `flatadapt`:
 #
 #   flatadapt(x, c):  invokestatic lambda$(x) -> IntStream ; mapper applied to item
+#                     dup; ifnonnull L; pop; return    ; flatMapToInt's null-skip
+#                     L: invokeinterface BaseStream.sequential() ; force sequential
 #                     invokeinterface IntStream.forEach(c) ; drains it into c
 #
 # The mapper body is kept untouched. IntStream.forEach takes precisely the
@@ -23,9 +25,9 @@
 # so the jeo roundtrip of these calls is proven.
 #
 # Scope: reference Stream.flatMapToInt only (mapper returns
-# java/util/stream/IntStream). Like 455, this assumes the mapper returns a
-# non-null, non-resource stream — the null-skip and auto-close of flatMapToInt are
-# not reproduced.
+# java/util/stream/IntStream). Like 455, the adapter reproduces flatMapToInt's
+# null-skip and its `result.sequential()` drain; the auto-close of the returned
+# stream still needs try-finally synthesis and is tracked separately.
 name: flatMapToInt-to-mapMultiToInt
 pattern: |
   ⟦
@@ -122,6 +124,29 @@ result: |
           i4 ↦ 𝑒-target-signature,
           i5 ↦ 𝑒-target-is-interface
         ⟧,
+        dup-stream ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+        guard ↦ ⟦
+          φ ↦ Φ.jeo.opcode.ifnonnull,
+          i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label ⟧
+        ⟧,
+        drop-null ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+        ret-null ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+        keep ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label ⟧,
+        keep-frame ↦ ⟦
+          φ ↦ Φ.jeo.frame,
+          type ↦ 4,
+          nlocal ↦ 0,
+          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+          nstack ↦ 1,
+          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, item ↦ "java/util/stream/IntStream" ⟧
+        ⟧,
+        force-seq ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          i2 ↦ "java/util/stream/BaseStream",
+          i3 ↦ "sequential",
+          i4 ↦ "()Ljava/util/stream/BaseStream;",
+          i5 ↦ Φ.true
+        ⟧,
         ld-downstream ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
         call-foreach ↦ ⟦
           φ ↦ Φ.jeo.opcode.invokeinterface,
@@ -140,6 +165,9 @@ result: |
 where:
   - meta: 𝜏-adapter-method
     function: random-tau
+  - meta: 𝑒-label
+    function: random-string
+    args: [ '"L%d"' ]
   - meta: 𝑒-adapter-name
     function: random-string
     args: [ '"flatadapt_%d"' ]

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/457-flatMapToLong-to-mapMultiToLong.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/457-flatMapToLong-to-mapMultiToLong.phr
@@ -15,6 +15,8 @@
 # target is a freshly synthesised BiConsumer `flatadapt`:
 #
 #   flatadapt(x, c):  invokestatic lambda$(x) -> LongStream ; mapper applied to item
+#                     dup; ifnonnull L; pop; return    ; flatMapToLong's null-skip
+#                     L: invokeinterface BaseStream.sequential() ; force sequential
 #                     invokeinterface LongStream.forEach(c) ; drains it into c
 #
 # The mapper body is kept untouched. LongStream.forEach takes precisely the
@@ -23,9 +25,9 @@
 # dispatches, so the jeo roundtrip of these calls is proven.
 #
 # Scope: reference Stream.flatMapToLong only (mapper returns
-# java/util/stream/LongStream). Like 455, this assumes the mapper returns a
-# non-null, non-resource stream — the null-skip and auto-close of flatMapToLong
-# are not reproduced.
+# java/util/stream/LongStream). Like 455, the adapter reproduces flatMapToLong's
+# null-skip and its `result.sequential()` drain; the auto-close of the returned
+# stream still needs try-finally synthesis and is tracked separately.
 name: flatMapToLong-to-mapMultiToLong
 pattern: |
   ⟦
@@ -122,6 +124,29 @@ result: |
           i4 ↦ 𝑒-target-signature,
           i5 ↦ 𝑒-target-is-interface
         ⟧,
+        dup-stream ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+        guard ↦ ⟦
+          φ ↦ Φ.jeo.opcode.ifnonnull,
+          i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label ⟧
+        ⟧,
+        drop-null ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+        ret-null ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+        keep ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label ⟧,
+        keep-frame ↦ ⟦
+          φ ↦ Φ.jeo.frame,
+          type ↦ 4,
+          nlocal ↦ 0,
+          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+          nstack ↦ 1,
+          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, item ↦ "java/util/stream/LongStream" ⟧
+        ⟧,
+        force-seq ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          i2 ↦ "java/util/stream/BaseStream",
+          i3 ↦ "sequential",
+          i4 ↦ "()Ljava/util/stream/BaseStream;",
+          i5 ↦ Φ.true
+        ⟧,
         ld-downstream ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
         call-foreach ↦ ⟦
           φ ↦ Φ.jeo.opcode.invokeinterface,
@@ -140,6 +165,9 @@ result: |
 where:
   - meta: 𝜏-adapter-method
     function: random-tau
+  - meta: 𝑒-label
+    function: random-string
+    args: [ '"L%d"' ]
   - meta: 𝑒-adapter-name
     function: random-string
     args: [ '"flatadapt_%d"' ]

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/458-flatMapToDouble-to-mapMultiToDouble.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/458-flatMapToDouble-to-mapMultiToDouble.phr
@@ -16,6 +16,8 @@
 # whose target is a freshly synthesised BiConsumer `flatadapt`:
 #
 #   flatadapt(x, c):  invokestatic lambda$(x) -> DoubleStream ; mapper applied to item
+#                     dup; ifnonnull L; pop; return    ; flatMapToDouble's null-skip
+#                     L: invokeinterface BaseStream.sequential() ; force sequential
 #                     invokeinterface DoubleStream.forEach(c) ; drains it into c
 #
 # The mapper body is kept untouched. DoubleStream.forEach takes precisely the
@@ -24,9 +26,10 @@
 # dispatches, so the jeo roundtrip of these calls is proven.
 #
 # Scope: reference Stream.flatMapToDouble only (mapper returns
-# java/util/stream/DoubleStream). Like 455, this assumes the mapper returns a
-# non-null, non-resource stream — the null-skip and auto-close of flatMapToDouble
-# are not reproduced.
+# java/util/stream/DoubleStream). Like 455, the adapter reproduces
+# flatMapToDouble's null-skip and its `result.sequential()` drain; the auto-close
+# of the returned stream still needs try-finally synthesis and is tracked
+# separately.
 name: flatMapToDouble-to-mapMultiToDouble
 pattern: |
   ⟦
@@ -123,6 +126,29 @@ result: |
           i4 ↦ 𝑒-target-signature,
           i5 ↦ 𝑒-target-is-interface
         ⟧,
+        dup-stream ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+        guard ↦ ⟦
+          φ ↦ Φ.jeo.opcode.ifnonnull,
+          i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label ⟧
+        ⟧,
+        drop-null ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+        ret-null ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+        keep ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label ⟧,
+        keep-frame ↦ ⟦
+          φ ↦ Φ.jeo.frame,
+          type ↦ 4,
+          nlocal ↦ 0,
+          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+          nstack ↦ 1,
+          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, item ↦ "java/util/stream/DoubleStream" ⟧
+        ⟧,
+        force-seq ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          i2 ↦ "java/util/stream/BaseStream",
+          i3 ↦ "sequential",
+          i4 ↦ "()Ljava/util/stream/BaseStream;",
+          i5 ↦ Φ.true
+        ⟧,
         ld-downstream ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
         call-foreach ↦ ⟦
           φ ↦ Φ.jeo.opcode.invokeinterface,
@@ -141,6 +167,9 @@ result: |
 where:
   - meta: 𝜏-adapter-method
     function: random-tau
+  - meta: 𝑒-label
+    function: random-string
+    args: [ '"L%d"' ]
   - meta: 𝑒-adapter-name
     function: random-string
     args: [ '"flatadapt_%d"' ]

--- a/src/test/phino/455-flatMap-to-mapMulti.yml
+++ b/src/test/phino/455-flatMap-to-mapMulti.yml
@@ -11,9 +11,11 @@
 # freshly synthesised BiConsumer `flatadapt`, and appends that adapter method to
 # the class. The adapter applies the original mapper to the item
 # (invokestatic lambda$main$0) and drains the returned stream into the downstream
-# Consumer (invokeinterface Stream.forEach). Matching all three — the surviving
-# mapMulti stream block, the invokestatic into the untouched mapper body, and the
-# forEach — proves the flatMap was rewired into a mapMulti rather than dropped.
+# Consumer (invokeinterface Stream.forEach). Matching all of them — the surviving
+# mapMulti stream block, the invokestatic into the untouched mapper body, the
+# ifnonnull null-skip guard, the BaseStream.sequential drain, and the forEach —
+# proves the flatMap was rewired into a mapMulti that also reproduces flatMap's
+# null-skip and sequential().
 rules:
   - src/main/resources/org/eolang/hone/rules/streams/4xx/455-flatMap-to-mapMulti.phr
 input: |
@@ -45,4 +47,7 @@ input: |
 expected:
   - ⟦ class ↦ "java/util/stream/Stream", method ↦ "mapMulti", signature ↦ "(Ljava/util/function/BiConsumer;)Ljava/util/stream/Stream;" ⟧
   - ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$0", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.ifnonnull, 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.frame, 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/stream/BaseStream", i3 ↦ "sequential", 𝐵-rest ⟧
   - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/stream/Stream", i3 ↦ "forEach", 𝐵-rest ⟧

--- a/src/test/phino/456-flatMapToInt-to-mapMultiToInt.yml
+++ b/src/test/phino/456-flatMapToInt-to-mapMultiToInt.yml
@@ -12,10 +12,11 @@
 # freshly synthesised BiConsumer `flatadapt`, and appends that adapter method to
 # the class. The adapter applies the original mapper to the item
 # (invokestatic lambda$main$0) and drains the returned IntStream into the
-# downstream IntConsumer (invokeinterface IntStream.forEach). Matching all three —
+# downstream IntConsumer (invokeinterface IntStream.forEach). Matching all of them —
 # the surviving mapMultiToInt stream block, the invokestatic into the untouched
-# mapper body, and the IntStream.forEach — proves the flatMapToInt was rewired
-# into a mapMultiToInt rather than dropped.
+# mapper body, the ifnonnull null-skip guard, the BaseStream.sequential drain, and
+# the IntStream.forEach — proves the flatMapToInt was rewired into a mapMultiToInt
+# that also reproduces flatMapToInt's null-skip and sequential().
 rules:
   - src/main/resources/org/eolang/hone/rules/streams/4xx/456-flatMapToInt-to-mapMultiToInt.phr
 input: |
@@ -47,4 +48,7 @@ input: |
 expected:
   - ⟦ class ↦ "java/util/stream/Stream", method ↦ "mapMultiToInt", signature ↦ "(Ljava/util/function/BiConsumer;)Ljava/util/stream/IntStream;" ⟧
   - ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$0", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.ifnonnull, 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.frame, 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/stream/BaseStream", i3 ↦ "sequential", 𝐵-rest ⟧
   - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/stream/IntStream", i3 ↦ "forEach", 𝐵-rest ⟧

--- a/src/test/phino/457-flatMapToLong-to-mapMultiToLong.yml
+++ b/src/test/phino/457-flatMapToLong-to-mapMultiToLong.yml
@@ -12,10 +12,11 @@
 # freshly synthesised BiConsumer `flatadapt`, and appends that adapter method to
 # the class. The adapter applies the original mapper to the item
 # (invokestatic lambda$main$0) and drains the returned LongStream into the
-# downstream LongConsumer (invokeinterface LongStream.forEach). Matching all
-# three — the surviving mapMultiToLong stream block, the invokestatic into the
-# untouched mapper body, and the LongStream.forEach — proves the flatMapToLong was
-# rewired into a mapMultiToLong rather than dropped.
+# downstream LongConsumer (invokeinterface LongStream.forEach). Matching all of
+# them — the surviving mapMultiToLong stream block, the invokestatic into the
+# untouched mapper body, the ifnonnull null-skip guard, the BaseStream.sequential
+# drain, and the LongStream.forEach — proves the flatMapToLong was rewired into a
+# mapMultiToLong that also reproduces flatMapToLong's null-skip and sequential().
 rules:
   - src/main/resources/org/eolang/hone/rules/streams/4xx/457-flatMapToLong-to-mapMultiToLong.phr
 input: |
@@ -47,4 +48,7 @@ input: |
 expected:
   - ⟦ class ↦ "java/util/stream/Stream", method ↦ "mapMultiToLong", signature ↦ "(Ljava/util/function/BiConsumer;)Ljava/util/stream/LongStream;" ⟧
   - ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$0", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.ifnonnull, 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.frame, 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/stream/BaseStream", i3 ↦ "sequential", 𝐵-rest ⟧
   - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/stream/LongStream", i3 ↦ "forEach", 𝐵-rest ⟧

--- a/src/test/phino/458-flatMapToDouble-to-mapMultiToDouble.yml
+++ b/src/test/phino/458-flatMapToDouble-to-mapMultiToDouble.yml
@@ -13,9 +13,11 @@
 # the class. The adapter applies the original mapper to the item
 # (invokestatic lambda$main$0) and drains the returned DoubleStream into the
 # downstream DoubleConsumer (invokeinterface DoubleStream.forEach). Matching all
-# three — the surviving mapMultiToDouble stream block, the invokestatic into the
-# untouched mapper body, and the DoubleStream.forEach — proves the flatMapToDouble
-# was rewired into a mapMultiToDouble rather than dropped.
+# of them — the surviving mapMultiToDouble stream block, the invokestatic into the
+# untouched mapper body, the ifnonnull null-skip guard, the BaseStream.sequential
+# drain, and the DoubleStream.forEach — proves the flatMapToDouble was rewired into
+# a mapMultiToDouble that also reproduces flatMapToDouble's null-skip and
+# sequential().
 rules:
   - src/main/resources/org/eolang/hone/rules/streams/4xx/458-flatMapToDouble-to-mapMultiToDouble.phr
 input: |
@@ -47,4 +49,7 @@ input: |
 expected:
   - ⟦ class ↦ "java/util/stream/Stream", method ↦ "mapMultiToDouble", signature ↦ "(Ljava/util/function/BiConsumer;)Ljava/util/stream/DoubleStream;" ⟧
   - ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$0", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.ifnonnull, 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.frame, 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/stream/BaseStream", i3 ↦ "sequential", 𝐵-rest ⟧
   - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/stream/DoubleStream", i3 ↦ "forEach", 𝐵-rest ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/flatmap-fusion.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/flatmap-fusion.yml
@@ -23,12 +23,15 @@
 # class reproduces it exactly (1535632236), which is the real proof — bytecode
 # that merely verifies but miswires the consumers would print a different number.
 #
-# Counts: invokeinterface drops from 7 to 6. The three fan-out call sites
+# Counts: invokeinterface stays at 7. The three fan-out call sites
 # (Stream.flatMap + two Stream.mapMulti) collapse to the single surviving
-# Stream.mapMulti, and the converted flatMap contributes one Stream.forEach in
-# its `flatadapt` body; the three Consumer.accept calls in the two mapMulti
-# bodies and the terminal reduce are untouched (1 mapMulti + 1 forEach + 3 accept
-# + 1 reduce = 6, down from 1 flatMap + 2 mapMulti + 3 accept + 1 reduce = 7).
+# Stream.mapMulti, and the converted flatMap contributes one Stream.forEach plus
+# one BaseStream.sequential (flatMap's sequential() drain) in its `flatadapt`
+# body; the three Consumer.accept calls in the two mapMulti bodies and the
+# terminal reduce are untouched (1 mapMulti + 1 forEach + 1 sequential + 3 accept
+# + 1 reduce = 7, the same total as 1 flatMap + 2 mapMulti + 3 accept + 1
+# reduce = 7 before — the collapsed call sites are offset by the adapter's
+# sequential drain).
 # invokedynamic stays at 4 (flatMap + two mapMulti + reduce lambdas before; one
 # surviving mapMulti call site + two relocated wrapper-builder indys + the reduce
 # lambda after) — like 461, the adapter relocates each fused-away call-site indy
@@ -67,4 +70,4 @@ before:
   invokeinterface: 7
 after:
   invokedynamic: 4
-  invokeinterface: 6
+  invokeinterface: 7

--- a/src/test/resources/org/eolang/hone/optimize/streams/flatmap-null-skip.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/flatmap-null-skip.yml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Regression for issue #725: the flatMap -> mapMulti adapter must reproduce
+# flatMap's null-skip. The JDK's ReferencePipeline.flatMap does, per element,
+# `try (Stream r = mapper.apply(u)) { if (r != null) r.sequential().forEach(...); }`
+# — when the mapper returns null that element is silently skipped. 455 lowers the
+# flatMap into a mapMulti whose `flatadapt` body applies the mapper and drains the
+# returned stream into the downstream Consumer; before #725 it called forEach
+# unconditionally, so a null mapper result threw NullPointerException instead of
+# being skipped. The fix wraps the drain in `dup; ifnonnull L; pop; return` so the
+# null case returns without touching the consumer, exactly like the JDK.
+#
+# The mapper here returns null for every odd element and a two-element Stream for
+# every even one, so half the elements feed a null into the adapter. The terminal
+# is an order- AND value-sensitive 31-fold (reduce) over the surviving 2, 20, 4,
+# 40, 6, 60, which the JDK evaluates to 75886572. The optimized class reproduces
+# it exactly — proof that the nulls are skipped rather than dereferenced. Without
+# the null guard the optimized run throws NPE and never prints the line.
+#
+# Counts: a lone flatMap (no adjacent mapMulti to fuse with) is converted to one
+# Stream.mapMulti and lowered back by 701, and its `flatadapt` body is appended:
+# one invokestatic into the untouched mapper, the null-skip guard
+# (dup; ifnonnull L; pop; return), one BaseStream.sequential invokeinterface, one
+# Stream.forEach invokeinterface, and the final return. So invokestatic rises by 1
+# (12 -> 13), invokeinterface by 2 (2 -> 4, the sequential + forEach), and return
+# by 2 (2 -> 4, the null-branch return plus the final return). invokedynamic stays
+# at 2: 455 relocates the Function call-site indy into the BiConsumer adapter's
+# indy rather than adding one, and the mapper lambda$ and reduce lambda bodies are
+# untouched.
+java: |
+  package flatmapnull;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      int n = Stream.of(1, 2, 3, 4, 5, 6)
+        .<Integer>flatMap(x -> x % 2 == 0 ? Stream.of(x, x * 10) : null)
+        .reduce(0, (p, q) -> p * 31 + q);
+      System.out.printf("The result is %d\n", n);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 75886572"
+before:
+  invokedynamic: 2
+  invokeinterface: 2
+  invokestatic: 12
+  return: 2
+after:
+  invokedynamic: 2
+  invokeinterface: 4
+  invokestatic: 13
+  return: 4

--- a/src/test/resources/org/eolang/hone/optimize/streams/flatmaptox.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/flatmaptox.yml
@@ -23,13 +23,14 @@
 #
 # Counts: each of the three flatMapToX call sites stays a single invokeinterface
 # on Stream (now mapMultiToX rather than flatMapToX), and each converted call adds
-# its `flatadapt` body — one invokestatic into the untouched mapper, one
-# XStream.forEach invokeinterface, and one return. So invokestatic rises by 3
-# (23 -> 26), invokeinterface by 3 (6 -> 9, the three forEach calls), and return
-# by 3 (2 -> 5, the three adapter returns). invokedynamic stays at 6: 456/457/458
-# relocate each Function call-site indy into the BiConsumer adapter's indy rather
-# than adding one, and the three mapper lambda$ bodies plus the three reduce
-# lambdas are untouched.
+# its `flatadapt` body — one invokestatic into the untouched mapper, the null-skip
+# guard (dup; ifnonnull L; pop; return), one BaseStream.sequential invokeinterface,
+# one XStream.forEach invokeinterface, and the final return. So invokestatic rises
+# by 3 (23 -> 26), invokeinterface by 6 (6 -> 12, three sequential + three forEach
+# calls), and return by 6 (2 -> 8, the three null-branch returns plus the three
+# final returns). invokedynamic stays at 6: 456/457/458 relocate each Function
+# call-site indy into the BiConsumer adapter's indy rather than adding one, and the
+# three mapper lambda$ bodies plus the three reduce lambdas are untouched.
 java: |
   package flatmaptox;
   import java.util.stream.Stream;
@@ -62,6 +63,6 @@ before:
   return: 2
 after:
   invokedynamic: 6
-  invokeinterface: 9
+  invokeinterface: 12
   invokestatic: 26
-  return: 5
+  return: 8


### PR DESCRIPTION
Fixes #725.

## Problem

The `flatadapt` BiConsumer synthesised by `455-flatMap-to-mapMulti.phr` and its primitive siblings `456`/`457`/`458` lowered a `flatMap` into, per element:

```
aload0; invokestatic lambda$(x)→Stream; aload1; invokeinterface Stream.forEach(Consumer); return
```

The JDK's `ReferencePipeline.flatMap` instead does `if (result != null) result.sequential().forEach(downstream)`. The fused adapter reproduced neither contract, so:

1. **null-skip** — when the mapper returned `null` the adapter called `forEach` on it and threw `NullPointerException` instead of silently skipping the element.
2. **sequential()** — a parallel sub-stream returned by the mapper raced straight into a downstream `Consumer` that may not be thread-safe, instead of being forced sequential first.

## Fix

In each `flatadapt` body:

- Wrap the drain in a null guard — `dup; ifnonnull L; pop; return` (the same branch/label/`dup`/`pop` synthesis used by `308-skip-to-distill.phr`).
- Insert `invokeinterface java/util/stream/BaseStream.sequential ()Ljava/util/stream/BaseStream;` before the `forEach`.
- Emit an explicit `Φ.jeo.frame` (F_SAME1) at the keep-label. jeo's assembler does not compute stackmap frames, so a synthesized branch target needs the frame written out (as `506-distill-filter-frame.phr` does) — without it the reassembled class fails verification with *"Expecting a stackmap frame at branch target"*.

`max-stack` stays 2. The third gap noted in #725 — auto-close of the returned stream — needs try-finally synthesis and is left for a separate issue.

## Tests

- Updated the four `src/test/phino/*.yml` unit packs to assert the `ifnonnull` guard, the `Φ.jeo.frame`, and the `BaseStream.sequential` drain.
- Updated the pinned opcode counts in `flatmaptox.yml` (`invokeinterface` 9→12, `return` 5→8) and `flatmap-fusion.yml` (`invokeinterface` 6→7) for the added `sequential`/branch opcodes.
- Added `flatmap-null-skip.yml`, an end-to-end regression whose mapper returns `null` for odd elements: it throws `NullPointerException` (never printing its result line) without the guard, and reproduces the JDK's `75886572` with it.

## Validation

All four phino packs rewrite and match. The full disassemble → phino-rewrite → jeo-assemble pipeline was run on each fixture: every optimized class **verifies, runs, and prints the JDK-identical result**, with opcode counts matching the updated expectations exactly.

https://claude.ai/code/session_01CSz8mMdns1g4KLMCKtfAec

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSz8mMdns1g4KLMCKtfAec)_