### PR TITLE
#726: close the mapper stream in the flatMap→mapMulti adapter

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/455-flatMap-to-mapMulti.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/455-flatMap-to-mapMulti.phr
@@ -5,18 +5,30 @@
 # Converts a user-written Stream.flatMap into an equivalent Stream.mapMulti so
 # that it can be fused with adjacent mapMultis by 461. A flatMap takes a
 # Function<T, Stream<R>> and flattens the returned streams; the same fan-out is
-# expressed by mapMulti((x, c) -> mapper(x).forEach(c)), where c is the
-# downstream Consumer. 111 lifts the flatMap invokedynamic into a Φ.hone.lambda
-# carrying stream.method = "flatMap" and a handle-6 target to a non-capturing
-# lambda$ body of signature (L<elem>;)Ljava/util/stream/Stream;. This rule
-# rewrites that pragma into the very shape 111 produces for a user mapMulti — a
-# Φ.hone.lambda with interface BiConsumer, stream.method = "mapMulti", and a
-# handle-6 target — whose target is a freshly synthesised BiConsumer `flatadapt`:
+# expressed by mapMulti((x, c) -> { try (var r = mapper(x)) { if (r != null)
+# r.sequential().forEach(c); } }), where c is the downstream Consumer. 111 lifts
+# the flatMap invokedynamic into a Φ.hone.lambda carrying stream.method =
+# "flatMap" and a handle-6 target to a non-capturing lambda$ body of signature
+# (L<elem>;)Ljava/util/stream/Stream;. This rule rewrites that pragma into the
+# very shape 111 produces for a user mapMulti — a Φ.hone.lambda with interface
+# BiConsumer, stream.method = "mapMulti", and a handle-6 target — whose target is
+# a freshly synthesised BiConsumer `flatadapt`:
 #
 #   flatadapt(x, c):  invokestatic lambda$(x) -> Stream ; mapper applied to item
-#                     dup; ifnonnull L; pop; return    ; flatMap's null-skip
-#                     L: invokeinterface BaseStream.sequential() ; force sequential
-#                     invokeinterface Stream.forEach(c) ; drains it into c
+#                     astore r                          ; keep result in a local
+#                  L_try:                               ; try-with-resources start
+#                     aload r; ifnull L_end             ; flatMap's null-skip
+#                     aload r; sequential; checkcast Stream
+#                     aload c; invokeinterface Stream.forEach(c) ; drains into c
+#                  L_end:                               ; try region end
+#                     aload r; ifnull L_done; aload r; close(); goto L_done
+#                  L_h1: astore t                       ; drain threw: catch it,
+#                     aload r; ifnull L_rethrow         ; close the stream and
+#                     aload r; close(); goto L_rethrow  ; rethrow (addSuppressed
+#                  L_h2: astore u; aload t; aload u     ; if close() also throws)
+#                     invokevirtual Throwable.addSuppressed
+#                  L_rethrow: aload t; athrow
+#                  L_done: return
 #
 # The original mapper body (lambda$…) is kept untouched — the rule only wires the
 # adapter around it, so it is agnostic to what the mapper does. Because the
@@ -26,13 +38,20 @@
 # a win, since mapMulti pushes straight into the downstream Consumer instead of
 # allocating an intermediate Stream per element.
 #
+# The adapter reproduces flatMap's full per-element contract: the null-skip (a
+# null mapper result is dropped rather than dereferenced), the
+# `result.sequential()` drain (a parallel sub-stream is forced sequential before
+# its elements reach the downstream Consumer), and — wrapping the whole drain in a
+# synthesised try-with-resources, with its own exception-table entries, finally
+# close() and addSuppressed dance — the auto-close of the returned stream that
+# the JDK's ReferencePipeline.flatMap performs. That auto-close is what releases
+# the file handle or connection behind I/O-backed streams (Files.lines,
+# BufferedReader.lines, Files.walk, JDBC), so the fused pipeline no longer leaks a
+# descriptor per element (#726).
+#
 # Scope: reference Stream.flatMap only (mapper returns java/util/stream/Stream).
 # The primitive flatMapToInt/Long/Double variants carry different SAM and result
-# types and are left for a follow-up. The adapter reproduces flatMap's null-skip
-# (a null mapper result is dropped rather than dereferenced) and its
-# `result.sequential()` drain (a parallel sub-stream is forced sequential before
-# its elements reach the downstream Consumer); the auto-close of the returned
-# stream still needs try-finally synthesis and is tracked separately.
+# types and are handled by the sibling rules 456/457/458.
 name: flatMap-to-mapMulti
 pattern: |
   ⟦
@@ -113,7 +132,7 @@ result: |
       access ↦ 4106,
       descriptor ↦ 𝑒-adapter-signature,
       signature ↦ "",
-      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, max-stack ↦ 2, max-locals ↦ 2 ⟧,
+      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, max-stack ↦ 2, max-locals ↦ 5 ⟧,
       params ↦ ⟦
         φ ↦ Φ.jeo.params,
         i1 ↦ ⟦ φ ↦ Φ.jeo.param, index ↦ 0, access ↦ 0, type ↦ 𝑒-flatmap-input ⟧,
@@ -121,47 +140,141 @@ result: |
       ⟧,
       body ↦ ⟦
         φ ↦ Φ.jeo.seq.of,
-        ld-item ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 0 ⟧,
+        ld-item ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 0 ⟧,
         call-mapper ↦ ⟦
           φ ↦ Φ.jeo.opcode.invokestatic,
-          i2 ↦ 𝑒-target-class,
-          i3 ↦ 𝑒-target-method,
-          i4 ↦ 𝑒-target-signature,
-          i5 ↦ 𝑒-target-is-interface
+          v0 ↦ 𝑒-target-class,
+          v1 ↦ 𝑒-target-method,
+          v2 ↦ 𝑒-target-signature,
+          v3 ↦ 𝑒-target-is-interface
         ⟧,
-        dup-stream ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+        store-stream ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, v0 ↦ 2 ⟧,
+        try-start ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-try ⟧,
+        ld-check ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 2 ⟧,
         guard ↦ ⟦
-          φ ↦ Φ.jeo.opcode.ifnonnull,
-          i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label ⟧
+          φ ↦ Φ.jeo.opcode.ifnull,
+          l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-end ⟧
         ⟧,
-        drop-null ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
-        ret-null ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
-        keep ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label ⟧,
-        keep-frame ↦ ⟦
-          φ ↦ Φ.jeo.frame,
-          type ↦ 4,
-          nlocal ↦ 0,
-          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
-          nstack ↦ 1,
-          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, item ↦ "java/util/stream/Stream" ⟧
-        ⟧,
+        ld-stream ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 2 ⟧,
         force-seq ↦ ⟦
           φ ↦ Φ.jeo.opcode.invokeinterface,
-          i2 ↦ "java/util/stream/BaseStream",
-          i3 ↦ "sequential",
-          i4 ↦ "()Ljava/util/stream/BaseStream;",
-          i5 ↦ Φ.true
+          v0 ↦ "java/util/stream/BaseStream",
+          v1 ↦ "sequential",
+          v2 ↦ "()Ljava/util/stream/BaseStream;",
+          v3 ↦ Φ.true
         ⟧,
-        ld-downstream ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
+        cast ↦ ⟦ φ ↦ Φ.jeo.opcode.checkcast, v0 ↦ "java/util/stream/Stream" ⟧,
+        ld-downstream ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 1 ⟧,
         call-foreach ↦ ⟦
           φ ↦ Φ.jeo.opcode.invokeinterface,
-          i2 ↦ "java/util/stream/Stream",
-          i3 ↦ "forEach",
-          i4 ↦ "(Ljava/util/function/Consumer;)V",
-          i5 ↦ Φ.true
+          v0 ↦ "java/util/stream/Stream",
+          v1 ↦ "forEach",
+          v2 ↦ "(Ljava/util/function/Consumer;)V",
+          v3 ↦ Φ.true
+        ⟧,
+        try-end ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-end ⟧,
+        frame-drained ↦ ⟦
+          φ ↦ Φ.jeo.frame,
+          type ↦ 0,
+          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of3, x0 ↦ 𝑒-frame-input, x1 ↦ "java/util/function/Consumer", x2 ↦ "java/util/stream/Stream" ⟧,
+          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
+        ⟧,
+        ld-close ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 2 ⟧,
+        guard-close ↦ ⟦
+          φ ↦ Φ.jeo.opcode.ifnull,
+          l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-done ⟧
+        ⟧,
+        ld-close-stream ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 2 ⟧,
+        call-close ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          v0 ↦ "java/util/stream/Stream",
+          v1 ↦ "close",
+          v2 ↦ "()V",
+          v3 ↦ Φ.true
+        ⟧,
+        goto-done ↦ ⟦
+          φ ↦ Φ.jeo.opcode.goto,
+          l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-done ⟧
+        ⟧,
+        handler ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-handler ⟧,
+        frame-handler ↦ ⟦
+          φ ↦ Φ.jeo.frame,
+          type ↦ 0,
+          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of3, x0 ↦ 𝑒-frame-input, x1 ↦ "java/util/function/Consumer", x2 ↦ "java/util/stream/Stream" ⟧,
+          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, x0 ↦ "java/lang/Throwable" ⟧
+        ⟧,
+        store-primary ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, v0 ↦ 3 ⟧,
+        ld-check2 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 2 ⟧,
+        guard-handler ↦ ⟦
+          φ ↦ Φ.jeo.opcode.ifnull,
+          l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-rethrow ⟧
+        ⟧,
+        close2-start ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-close2 ⟧,
+        ld-close2 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 2 ⟧,
+        call-close2 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          v0 ↦ "java/util/stream/Stream",
+          v1 ↦ "close",
+          v2 ↦ "()V",
+          v3 ↦ Φ.true
+        ⟧,
+        close2-end ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-close2end ⟧,
+        goto-rethrow ↦ ⟦
+          φ ↦ Φ.jeo.opcode.goto,
+          l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-rethrow ⟧
+        ⟧,
+        handler2 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-handler2 ⟧,
+        frame-handler2 ↦ ⟦
+          φ ↦ Φ.jeo.frame,
+          type ↦ 0,
+          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of4, x0 ↦ 𝑒-frame-input, x1 ↦ "java/util/function/Consumer", x2 ↦ "java/util/stream/Stream", x3 ↦ "java/lang/Throwable" ⟧,
+          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, x0 ↦ "java/lang/Throwable" ⟧
+        ⟧,
+        store-suppressed ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, v0 ↦ 4 ⟧,
+        ld-primary ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 3 ⟧,
+        ld-suppressed ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 4 ⟧,
+        call-addsup ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokevirtual,
+          v0 ↦ "java/lang/Throwable",
+          v1 ↦ "addSuppressed",
+          v2 ↦ "(Ljava/lang/Throwable;)V",
+          v3 ↦ Φ.false
+        ⟧,
+        rethrow-label ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-rethrow ⟧,
+        frame-rethrow ↦ ⟦
+          φ ↦ Φ.jeo.frame,
+          type ↦ 0,
+          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of4, x0 ↦ 𝑒-frame-input, x1 ↦ "java/util/function/Consumer", x2 ↦ "java/util/stream/Stream", x3 ↦ "java/lang/Throwable" ⟧,
+          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
+        ⟧,
+        ld-primary2 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 3 ⟧,
+        do-throw ↦ ⟦ φ ↦ Φ.jeo.opcode.athrow ⟧,
+        done-label ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-done ⟧,
+        frame-done ↦ ⟦
+          φ ↦ Φ.jeo.frame,
+          type ↦ 0,
+          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of2, x0 ↦ 𝑒-frame-input, x1 ↦ "java/util/function/Consumer" ⟧,
+          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
         ⟧,
         ret ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
         ρ ↦ ∅
+      ⟧,
+      trycatchblocks ↦ ⟦
+        φ ↦ Φ.jeo.seq.of2,
+        t0 ↦ ⟦
+          φ ↦ Φ.jeo.trycatch,
+          l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-try ⟧,
+          l1 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-end ⟧,
+          l2 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-handler ⟧,
+          v3 ↦ "java/lang/Throwable"
+        ⟧,
+        t1 ↦ ⟦
+          φ ↦ Φ.jeo.trycatch,
+          l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-close2 ⟧,
+          l1 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-close2end ⟧,
+          l2 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-handler2 ⟧,
+          v3 ↦ "java/lang/Throwable"
+        ⟧
       ⟧,
       name ↦ 𝑒-adapter-name
     ⟧,
@@ -170,7 +283,28 @@ result: |
 where:
   - meta: 𝜏-adapter-method
     function: random-tau
-  - meta: 𝑒-label
+  - meta: 𝑒-l-try
+    function: random-string
+    args: [ '"L%d"' ]
+  - meta: 𝑒-l-end
+    function: random-string
+    args: [ '"L%d"' ]
+  - meta: 𝑒-l-handler
+    function: random-string
+    args: [ '"L%d"' ]
+  - meta: 𝑒-l-close2
+    function: random-string
+    args: [ '"L%d"' ]
+  - meta: 𝑒-l-close2end
+    function: random-string
+    args: [ '"L%d"' ]
+  - meta: 𝑒-l-handler2
+    function: random-string
+    args: [ '"L%d"' ]
+  - meta: 𝑒-l-rethrow
+    function: random-string
+    args: [ '"L%d"' ]
+  - meta: 𝑒-l-done
     function: random-string
     args: [ '"L%d"' ]
   - meta: 𝑒-adapter-name
@@ -181,6 +315,11 @@ where:
     args:
       - 𝑒-target-signature
       - '"s/^[(](L[^;]*;).*/$1/"'
+  - meta: 𝑒-frame-input
+    function: sed
+    args:
+      - 𝑒-flatmap-input
+      - '"s/^L(.*);$/$1/"'
   - meta: 𝑒-adapter-signature
     function: concat
     args: [ '"("', 𝑒-flatmap-input, '"Ljava/util/function/Consumer;)V"' ]

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/456-flatMapToInt-to-mapMultiToInt.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/456-flatMapToInt-to-mapMultiToInt.phr
@@ -3,31 +3,30 @@
 ---
 # yamllint disable rule:line-length
 # The IntStream sibling of 455-flatMap-to-mapMulti. Converts a user-written
-# Stream.flatMapToInt into an equivalent Stream.mapMultiToInt. flatMapToInt takes
-# a Function<T, IntStream> and flattens the returned IntStreams; the same fan-out
-# is expressed by mapMultiToInt((x, c) -> mapper(x).forEach(c)), where c is the
-# downstream IntConsumer. 111 lifts the flatMapToInt invokedynamic into a
-# Φ.hone.lambda carrying stream.method = "flatMapToInt" and a handle-6 target to a
-# non-capturing lambda$ body of signature (L<elem>;)Ljava/util/stream/IntStream;.
-# This rule rewrites that pragma into the shape 111 produces for a user
-# mapMultiToInt — a Φ.hone.lambda with interface BiConsumer, stream.method =
-# "mapMultiToInt", and a handle-6 target — whose target is a freshly synthesised
-# BiConsumer `flatadapt`:
+# Stream.flatMapToInt into an equivalent Stream.mapMultiToInt. flatMapToInt takes a
+# Function<T, IntStream> and flattens the returned IntStreams; the same fan-out
+# is expressed by mapMultiToInt((x, c) -> { try (var r = mapper(x)) { if (r != null)
+# r.sequential().forEach(c); } }), where c is the downstream IntConsumer. 111 lifts
+# the flatMapToInt invokedynamic into a Φ.hone.lambda carrying stream.method =
+# "flatMapToInt" and a handle-6 target to a non-capturing lambda$ body of signature
+# (L<elem>;)Ljava/util/stream/IntStream;. This rule rewrites that pragma into the
+# shape 111 produces for a user mapMultiToInt — a Φ.hone.lambda with interface
+# BiConsumer, stream.method = "mapMultiToInt", and a handle-6 target — whose target is a
+# freshly synthesised BiConsumer `flatadapt` that applies the original mapper to the
+# item, then drains the returned IntStream into the downstream IntConsumer inside a
+# synthesised try-with-resources. IntStream.forEach takes precisely the IntConsumer
+# that mapMultiToInt hands down, so the same adapter shape 455 synthesises works
+# unchanged here. 501/502 already emit mapMultiToInt dispatches, so the jeo roundtrip of
+# these calls is proven.
 #
-#   flatadapt(x, c):  invokestatic lambda$(x) -> IntStream ; mapper applied to item
-#                     dup; ifnonnull L; pop; return    ; flatMapToInt's null-skip
-#                     L: invokeinterface BaseStream.sequential() ; force sequential
-#                     invokeinterface IntStream.forEach(c) ; drains it into c
-#
-# The mapper body is kept untouched. IntStream.forEach takes precisely the
-# IntConsumer that mapMultiToInt hands down, so the same adapter shape 455
-# synthesises works unchanged here. 501/502 already emit mapMultiToInt dispatches,
-# so the jeo roundtrip of these calls is proven.
+# The mapper body is kept untouched. Like 455, the adapter reproduces flatMapToInt's
+# null-skip, its `result.sequential()` drain, and — wrapping the drain in a
+# try-with-resources with its own exception-table entries, finally close() and
+# addSuppressed dance — the auto-close of the returned stream that the JDK performs,
+# so an I/O-backed sub-stream no longer leaks a descriptor per element (#726).
 #
 # Scope: reference Stream.flatMapToInt only (mapper returns
-# java/util/stream/IntStream). Like 455, the adapter reproduces flatMapToInt's
-# null-skip and its `result.sequential()` drain; the auto-close of the returned
-# stream still needs try-finally synthesis and is tracked separately.
+# java/util/stream/IntStream).
 name: flatMapToInt-to-mapMultiToInt
 pattern: |
   ⟦
@@ -108,7 +107,7 @@ result: |
       access ↦ 4106,
       descriptor ↦ 𝑒-adapter-signature,
       signature ↦ "",
-      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, max-stack ↦ 2, max-locals ↦ 2 ⟧,
+      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, max-stack ↦ 2, max-locals ↦ 5 ⟧,
       params ↦ ⟦
         φ ↦ Φ.jeo.params,
         i1 ↦ ⟦ φ ↦ Φ.jeo.param, index ↦ 0, access ↦ 0, type ↦ 𝑒-flatmap-input ⟧,
@@ -116,47 +115,141 @@ result: |
       ⟧,
       body ↦ ⟦
         φ ↦ Φ.jeo.seq.of,
-        ld-item ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 0 ⟧,
+        ld-item ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 0 ⟧,
         call-mapper ↦ ⟦
           φ ↦ Φ.jeo.opcode.invokestatic,
-          i2 ↦ 𝑒-target-class,
-          i3 ↦ 𝑒-target-method,
-          i4 ↦ 𝑒-target-signature,
-          i5 ↦ 𝑒-target-is-interface
+          v0 ↦ 𝑒-target-class,
+          v1 ↦ 𝑒-target-method,
+          v2 ↦ 𝑒-target-signature,
+          v3 ↦ 𝑒-target-is-interface
         ⟧,
-        dup-stream ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+        store-stream ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, v0 ↦ 2 ⟧,
+        try-start ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-try ⟧,
+        ld-check ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 2 ⟧,
         guard ↦ ⟦
-          φ ↦ Φ.jeo.opcode.ifnonnull,
-          i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label ⟧
+          φ ↦ Φ.jeo.opcode.ifnull,
+          l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-end ⟧
         ⟧,
-        drop-null ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
-        ret-null ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
-        keep ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label ⟧,
-        keep-frame ↦ ⟦
-          φ ↦ Φ.jeo.frame,
-          type ↦ 4,
-          nlocal ↦ 0,
-          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
-          nstack ↦ 1,
-          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, item ↦ "java/util/stream/IntStream" ⟧
-        ⟧,
+        ld-stream ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 2 ⟧,
         force-seq ↦ ⟦
           φ ↦ Φ.jeo.opcode.invokeinterface,
-          i2 ↦ "java/util/stream/BaseStream",
-          i3 ↦ "sequential",
-          i4 ↦ "()Ljava/util/stream/BaseStream;",
-          i5 ↦ Φ.true
+          v0 ↦ "java/util/stream/BaseStream",
+          v1 ↦ "sequential",
+          v2 ↦ "()Ljava/util/stream/BaseStream;",
+          v3 ↦ Φ.true
         ⟧,
-        ld-downstream ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
+        cast ↦ ⟦ φ ↦ Φ.jeo.opcode.checkcast, v0 ↦ "java/util/stream/IntStream" ⟧,
+        ld-downstream ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 1 ⟧,
         call-foreach ↦ ⟦
           φ ↦ Φ.jeo.opcode.invokeinterface,
-          i2 ↦ "java/util/stream/IntStream",
-          i3 ↦ "forEach",
-          i4 ↦ "(Ljava/util/function/IntConsumer;)V",
-          i5 ↦ Φ.true
+          v0 ↦ "java/util/stream/IntStream",
+          v1 ↦ "forEach",
+          v2 ↦ "(Ljava/util/function/IntConsumer;)V",
+          v3 ↦ Φ.true
+        ⟧,
+        try-end ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-end ⟧,
+        frame-drained ↦ ⟦
+          φ ↦ Φ.jeo.frame,
+          type ↦ 0,
+          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of3, x0 ↦ 𝑒-frame-input, x1 ↦ "java/util/function/IntConsumer", x2 ↦ "java/util/stream/IntStream" ⟧,
+          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
+        ⟧,
+        ld-close ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 2 ⟧,
+        guard-close ↦ ⟦
+          φ ↦ Φ.jeo.opcode.ifnull,
+          l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-done ⟧
+        ⟧,
+        ld-close-stream ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 2 ⟧,
+        call-close ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          v0 ↦ "java/util/stream/IntStream",
+          v1 ↦ "close",
+          v2 ↦ "()V",
+          v3 ↦ Φ.true
+        ⟧,
+        goto-done ↦ ⟦
+          φ ↦ Φ.jeo.opcode.goto,
+          l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-done ⟧
+        ⟧,
+        handler ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-handler ⟧,
+        frame-handler ↦ ⟦
+          φ ↦ Φ.jeo.frame,
+          type ↦ 0,
+          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of3, x0 ↦ 𝑒-frame-input, x1 ↦ "java/util/function/IntConsumer", x2 ↦ "java/util/stream/IntStream" ⟧,
+          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, x0 ↦ "java/lang/Throwable" ⟧
+        ⟧,
+        store-primary ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, v0 ↦ 3 ⟧,
+        ld-check2 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 2 ⟧,
+        guard-handler ↦ ⟦
+          φ ↦ Φ.jeo.opcode.ifnull,
+          l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-rethrow ⟧
+        ⟧,
+        close2-start ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-close2 ⟧,
+        ld-close2 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 2 ⟧,
+        call-close2 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          v0 ↦ "java/util/stream/IntStream",
+          v1 ↦ "close",
+          v2 ↦ "()V",
+          v3 ↦ Φ.true
+        ⟧,
+        close2-end ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-close2end ⟧,
+        goto-rethrow ↦ ⟦
+          φ ↦ Φ.jeo.opcode.goto,
+          l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-rethrow ⟧
+        ⟧,
+        handler2 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-handler2 ⟧,
+        frame-handler2 ↦ ⟦
+          φ ↦ Φ.jeo.frame,
+          type ↦ 0,
+          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of4, x0 ↦ 𝑒-frame-input, x1 ↦ "java/util/function/IntConsumer", x2 ↦ "java/util/stream/IntStream", x3 ↦ "java/lang/Throwable" ⟧,
+          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, x0 ↦ "java/lang/Throwable" ⟧
+        ⟧,
+        store-suppressed ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, v0 ↦ 4 ⟧,
+        ld-primary ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 3 ⟧,
+        ld-suppressed ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 4 ⟧,
+        call-addsup ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokevirtual,
+          v0 ↦ "java/lang/Throwable",
+          v1 ↦ "addSuppressed",
+          v2 ↦ "(Ljava/lang/Throwable;)V",
+          v3 ↦ Φ.false
+        ⟧,
+        rethrow-label ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-rethrow ⟧,
+        frame-rethrow ↦ ⟦
+          φ ↦ Φ.jeo.frame,
+          type ↦ 0,
+          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of4, x0 ↦ 𝑒-frame-input, x1 ↦ "java/util/function/IntConsumer", x2 ↦ "java/util/stream/IntStream", x3 ↦ "java/lang/Throwable" ⟧,
+          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
+        ⟧,
+        ld-primary2 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 3 ⟧,
+        do-throw ↦ ⟦ φ ↦ Φ.jeo.opcode.athrow ⟧,
+        done-label ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-done ⟧,
+        frame-done ↦ ⟦
+          φ ↦ Φ.jeo.frame,
+          type ↦ 0,
+          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of2, x0 ↦ 𝑒-frame-input, x1 ↦ "java/util/function/IntConsumer" ⟧,
+          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
         ⟧,
         ret ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
         ρ ↦ ∅
+      ⟧,
+      trycatchblocks ↦ ⟦
+        φ ↦ Φ.jeo.seq.of2,
+        t0 ↦ ⟦
+          φ ↦ Φ.jeo.trycatch,
+          l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-try ⟧,
+          l1 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-end ⟧,
+          l2 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-handler ⟧,
+          v3 ↦ "java/lang/Throwable"
+        ⟧,
+        t1 ↦ ⟦
+          φ ↦ Φ.jeo.trycatch,
+          l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-close2 ⟧,
+          l1 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-close2end ⟧,
+          l2 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-handler2 ⟧,
+          v3 ↦ "java/lang/Throwable"
+        ⟧
       ⟧,
       name ↦ 𝑒-adapter-name
     ⟧,
@@ -165,7 +258,28 @@ result: |
 where:
   - meta: 𝜏-adapter-method
     function: random-tau
-  - meta: 𝑒-label
+  - meta: 𝑒-l-try
+    function: random-string
+    args: [ '"L%d"' ]
+  - meta: 𝑒-l-end
+    function: random-string
+    args: [ '"L%d"' ]
+  - meta: 𝑒-l-handler
+    function: random-string
+    args: [ '"L%d"' ]
+  - meta: 𝑒-l-close2
+    function: random-string
+    args: [ '"L%d"' ]
+  - meta: 𝑒-l-close2end
+    function: random-string
+    args: [ '"L%d"' ]
+  - meta: 𝑒-l-handler2
+    function: random-string
+    args: [ '"L%d"' ]
+  - meta: 𝑒-l-rethrow
+    function: random-string
+    args: [ '"L%d"' ]
+  - meta: 𝑒-l-done
     function: random-string
     args: [ '"L%d"' ]
   - meta: 𝑒-adapter-name
@@ -176,6 +290,11 @@ where:
     args:
       - 𝑒-target-signature
       - '"s/^[(](L[^;]*;).*/$1/"'
+  - meta: 𝑒-frame-input
+    function: sed
+    args:
+      - 𝑒-flatmap-input
+      - '"s/^L(.*);$/$1/"'
   - meta: 𝑒-adapter-signature
     function: concat
     args: [ '"("', 𝑒-flatmap-input, '"Ljava/util/function/IntConsumer;)V"' ]

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/457-flatMapToLong-to-mapMultiToLong.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/457-flatMapToLong-to-mapMultiToLong.phr
@@ -3,31 +3,30 @@
 ---
 # yamllint disable rule:line-length
 # The LongStream sibling of 455-flatMap-to-mapMulti. Converts a user-written
-# Stream.flatMapToLong into an equivalent Stream.mapMultiToLong. flatMapToLong
-# takes a Function<T, LongStream> and flattens the returned LongStreams; the same
-# fan-out is expressed by mapMultiToLong((x, c) -> mapper(x).forEach(c)), where c
-# is the downstream LongConsumer. 111 lifts the flatMapToLong invokedynamic into a
-# Φ.hone.lambda carrying stream.method = "flatMapToLong" and a handle-6 target to
-# a non-capturing lambda$ body of signature
+# Stream.flatMapToLong into an equivalent Stream.mapMultiToLong. flatMapToLong takes a
+# Function<T, LongStream> and flattens the returned LongStreams; the same fan-out
+# is expressed by mapMultiToLong((x, c) -> { try (var r = mapper(x)) { if (r != null)
+# r.sequential().forEach(c); } }), where c is the downstream LongConsumer. 111 lifts
+# the flatMapToLong invokedynamic into a Φ.hone.lambda carrying stream.method =
+# "flatMapToLong" and a handle-6 target to a non-capturing lambda$ body of signature
 # (L<elem>;)Ljava/util/stream/LongStream;. This rule rewrites that pragma into the
 # shape 111 produces for a user mapMultiToLong — a Φ.hone.lambda with interface
-# BiConsumer, stream.method = "mapMultiToLong", and a handle-6 target — whose
-# target is a freshly synthesised BiConsumer `flatadapt`:
+# BiConsumer, stream.method = "mapMultiToLong", and a handle-6 target — whose target is a
+# freshly synthesised BiConsumer `flatadapt` that applies the original mapper to the
+# item, then drains the returned LongStream into the downstream LongConsumer inside a
+# synthesised try-with-resources. LongStream.forEach takes precisely the LongConsumer
+# that mapMultiToLong hands down, so the same adapter shape 455 synthesises works
+# unchanged here. 501/502 already emit mapMultiToLong dispatches, so the jeo roundtrip of
+# these calls is proven.
 #
-#   flatadapt(x, c):  invokestatic lambda$(x) -> LongStream ; mapper applied to item
-#                     dup; ifnonnull L; pop; return    ; flatMapToLong's null-skip
-#                     L: invokeinterface BaseStream.sequential() ; force sequential
-#                     invokeinterface LongStream.forEach(c) ; drains it into c
-#
-# The mapper body is kept untouched. LongStream.forEach takes precisely the
-# LongConsumer that mapMultiToLong hands down, so the same adapter shape 455
-# synthesises works unchanged here. 501/502 already emit mapMultiToLong
-# dispatches, so the jeo roundtrip of these calls is proven.
+# The mapper body is kept untouched. Like 455, the adapter reproduces flatMapToLong's
+# null-skip, its `result.sequential()` drain, and — wrapping the drain in a
+# try-with-resources with its own exception-table entries, finally close() and
+# addSuppressed dance — the auto-close of the returned stream that the JDK performs,
+# so an I/O-backed sub-stream no longer leaks a descriptor per element (#726).
 #
 # Scope: reference Stream.flatMapToLong only (mapper returns
-# java/util/stream/LongStream). Like 455, the adapter reproduces flatMapToLong's
-# null-skip and its `result.sequential()` drain; the auto-close of the returned
-# stream still needs try-finally synthesis and is tracked separately.
+# java/util/stream/LongStream).
 name: flatMapToLong-to-mapMultiToLong
 pattern: |
   ⟦
@@ -108,7 +107,7 @@ result: |
       access ↦ 4106,
       descriptor ↦ 𝑒-adapter-signature,
       signature ↦ "",
-      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, max-stack ↦ 2, max-locals ↦ 2 ⟧,
+      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, max-stack ↦ 2, max-locals ↦ 5 ⟧,
       params ↦ ⟦
         φ ↦ Φ.jeo.params,
         i1 ↦ ⟦ φ ↦ Φ.jeo.param, index ↦ 0, access ↦ 0, type ↦ 𝑒-flatmap-input ⟧,
@@ -116,47 +115,141 @@ result: |
       ⟧,
       body ↦ ⟦
         φ ↦ Φ.jeo.seq.of,
-        ld-item ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 0 ⟧,
+        ld-item ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 0 ⟧,
         call-mapper ↦ ⟦
           φ ↦ Φ.jeo.opcode.invokestatic,
-          i2 ↦ 𝑒-target-class,
-          i3 ↦ 𝑒-target-method,
-          i4 ↦ 𝑒-target-signature,
-          i5 ↦ 𝑒-target-is-interface
+          v0 ↦ 𝑒-target-class,
+          v1 ↦ 𝑒-target-method,
+          v2 ↦ 𝑒-target-signature,
+          v3 ↦ 𝑒-target-is-interface
         ⟧,
-        dup-stream ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+        store-stream ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, v0 ↦ 2 ⟧,
+        try-start ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-try ⟧,
+        ld-check ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 2 ⟧,
         guard ↦ ⟦
-          φ ↦ Φ.jeo.opcode.ifnonnull,
-          i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label ⟧
+          φ ↦ Φ.jeo.opcode.ifnull,
+          l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-end ⟧
         ⟧,
-        drop-null ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
-        ret-null ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
-        keep ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label ⟧,
-        keep-frame ↦ ⟦
-          φ ↦ Φ.jeo.frame,
-          type ↦ 4,
-          nlocal ↦ 0,
-          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
-          nstack ↦ 1,
-          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, item ↦ "java/util/stream/LongStream" ⟧
-        ⟧,
+        ld-stream ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 2 ⟧,
         force-seq ↦ ⟦
           φ ↦ Φ.jeo.opcode.invokeinterface,
-          i2 ↦ "java/util/stream/BaseStream",
-          i3 ↦ "sequential",
-          i4 ↦ "()Ljava/util/stream/BaseStream;",
-          i5 ↦ Φ.true
+          v0 ↦ "java/util/stream/BaseStream",
+          v1 ↦ "sequential",
+          v2 ↦ "()Ljava/util/stream/BaseStream;",
+          v3 ↦ Φ.true
         ⟧,
-        ld-downstream ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
+        cast ↦ ⟦ φ ↦ Φ.jeo.opcode.checkcast, v0 ↦ "java/util/stream/LongStream" ⟧,
+        ld-downstream ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 1 ⟧,
         call-foreach ↦ ⟦
           φ ↦ Φ.jeo.opcode.invokeinterface,
-          i2 ↦ "java/util/stream/LongStream",
-          i3 ↦ "forEach",
-          i4 ↦ "(Ljava/util/function/LongConsumer;)V",
-          i5 ↦ Φ.true
+          v0 ↦ "java/util/stream/LongStream",
+          v1 ↦ "forEach",
+          v2 ↦ "(Ljava/util/function/LongConsumer;)V",
+          v3 ↦ Φ.true
+        ⟧,
+        try-end ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-end ⟧,
+        frame-drained ↦ ⟦
+          φ ↦ Φ.jeo.frame,
+          type ↦ 0,
+          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of3, x0 ↦ 𝑒-frame-input, x1 ↦ "java/util/function/LongConsumer", x2 ↦ "java/util/stream/LongStream" ⟧,
+          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
+        ⟧,
+        ld-close ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 2 ⟧,
+        guard-close ↦ ⟦
+          φ ↦ Φ.jeo.opcode.ifnull,
+          l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-done ⟧
+        ⟧,
+        ld-close-stream ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 2 ⟧,
+        call-close ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          v0 ↦ "java/util/stream/LongStream",
+          v1 ↦ "close",
+          v2 ↦ "()V",
+          v3 ↦ Φ.true
+        ⟧,
+        goto-done ↦ ⟦
+          φ ↦ Φ.jeo.opcode.goto,
+          l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-done ⟧
+        ⟧,
+        handler ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-handler ⟧,
+        frame-handler ↦ ⟦
+          φ ↦ Φ.jeo.frame,
+          type ↦ 0,
+          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of3, x0 ↦ 𝑒-frame-input, x1 ↦ "java/util/function/LongConsumer", x2 ↦ "java/util/stream/LongStream" ⟧,
+          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, x0 ↦ "java/lang/Throwable" ⟧
+        ⟧,
+        store-primary ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, v0 ↦ 3 ⟧,
+        ld-check2 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 2 ⟧,
+        guard-handler ↦ ⟦
+          φ ↦ Φ.jeo.opcode.ifnull,
+          l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-rethrow ⟧
+        ⟧,
+        close2-start ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-close2 ⟧,
+        ld-close2 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 2 ⟧,
+        call-close2 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          v0 ↦ "java/util/stream/LongStream",
+          v1 ↦ "close",
+          v2 ↦ "()V",
+          v3 ↦ Φ.true
+        ⟧,
+        close2-end ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-close2end ⟧,
+        goto-rethrow ↦ ⟦
+          φ ↦ Φ.jeo.opcode.goto,
+          l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-rethrow ⟧
+        ⟧,
+        handler2 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-handler2 ⟧,
+        frame-handler2 ↦ ⟦
+          φ ↦ Φ.jeo.frame,
+          type ↦ 0,
+          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of4, x0 ↦ 𝑒-frame-input, x1 ↦ "java/util/function/LongConsumer", x2 ↦ "java/util/stream/LongStream", x3 ↦ "java/lang/Throwable" ⟧,
+          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, x0 ↦ "java/lang/Throwable" ⟧
+        ⟧,
+        store-suppressed ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, v0 ↦ 4 ⟧,
+        ld-primary ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 3 ⟧,
+        ld-suppressed ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 4 ⟧,
+        call-addsup ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokevirtual,
+          v0 ↦ "java/lang/Throwable",
+          v1 ↦ "addSuppressed",
+          v2 ↦ "(Ljava/lang/Throwable;)V",
+          v3 ↦ Φ.false
+        ⟧,
+        rethrow-label ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-rethrow ⟧,
+        frame-rethrow ↦ ⟦
+          φ ↦ Φ.jeo.frame,
+          type ↦ 0,
+          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of4, x0 ↦ 𝑒-frame-input, x1 ↦ "java/util/function/LongConsumer", x2 ↦ "java/util/stream/LongStream", x3 ↦ "java/lang/Throwable" ⟧,
+          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
+        ⟧,
+        ld-primary2 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 3 ⟧,
+        do-throw ↦ ⟦ φ ↦ Φ.jeo.opcode.athrow ⟧,
+        done-label ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-done ⟧,
+        frame-done ↦ ⟦
+          φ ↦ Φ.jeo.frame,
+          type ↦ 0,
+          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of2, x0 ↦ 𝑒-frame-input, x1 ↦ "java/util/function/LongConsumer" ⟧,
+          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
         ⟧,
         ret ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
         ρ ↦ ∅
+      ⟧,
+      trycatchblocks ↦ ⟦
+        φ ↦ Φ.jeo.seq.of2,
+        t0 ↦ ⟦
+          φ ↦ Φ.jeo.trycatch,
+          l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-try ⟧,
+          l1 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-end ⟧,
+          l2 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-handler ⟧,
+          v3 ↦ "java/lang/Throwable"
+        ⟧,
+        t1 ↦ ⟦
+          φ ↦ Φ.jeo.trycatch,
+          l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-close2 ⟧,
+          l1 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-close2end ⟧,
+          l2 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-handler2 ⟧,
+          v3 ↦ "java/lang/Throwable"
+        ⟧
       ⟧,
       name ↦ 𝑒-adapter-name
     ⟧,
@@ -165,7 +258,28 @@ result: |
 where:
   - meta: 𝜏-adapter-method
     function: random-tau
-  - meta: 𝑒-label
+  - meta: 𝑒-l-try
+    function: random-string
+    args: [ '"L%d"' ]
+  - meta: 𝑒-l-end
+    function: random-string
+    args: [ '"L%d"' ]
+  - meta: 𝑒-l-handler
+    function: random-string
+    args: [ '"L%d"' ]
+  - meta: 𝑒-l-close2
+    function: random-string
+    args: [ '"L%d"' ]
+  - meta: 𝑒-l-close2end
+    function: random-string
+    args: [ '"L%d"' ]
+  - meta: 𝑒-l-handler2
+    function: random-string
+    args: [ '"L%d"' ]
+  - meta: 𝑒-l-rethrow
+    function: random-string
+    args: [ '"L%d"' ]
+  - meta: 𝑒-l-done
     function: random-string
     args: [ '"L%d"' ]
   - meta: 𝑒-adapter-name
@@ -176,6 +290,11 @@ where:
     args:
       - 𝑒-target-signature
       - '"s/^[(](L[^;]*;).*/$1/"'
+  - meta: 𝑒-frame-input
+    function: sed
+    args:
+      - 𝑒-flatmap-input
+      - '"s/^L(.*);$/$1/"'
   - meta: 𝑒-adapter-signature
     function: concat
     args: [ '"("', 𝑒-flatmap-input, '"Ljava/util/function/LongConsumer;)V"' ]

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/458-flatMapToDouble-to-mapMultiToDouble.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/458-flatMapToDouble-to-mapMultiToDouble.phr
@@ -3,33 +3,30 @@
 ---
 # yamllint disable rule:line-length
 # The DoubleStream sibling of 455-flatMap-to-mapMulti. Converts a user-written
-# Stream.flatMapToDouble into an equivalent Stream.mapMultiToDouble.
-# flatMapToDouble takes a Function<T, DoubleStream> and flattens the returned
-# DoubleStreams; the same fan-out is expressed by
-# mapMultiToDouble((x, c) -> mapper(x).forEach(c)), where c is the downstream
-# DoubleConsumer. 111 lifts the flatMapToDouble invokedynamic into a Φ.hone.lambda
-# carrying stream.method = "flatMapToDouble" and a handle-6 target to a
-# non-capturing lambda$ body of signature
-# (L<elem>;)Ljava/util/stream/DoubleStream;. This rule rewrites that pragma into
-# the shape 111 produces for a user mapMultiToDouble — a Φ.hone.lambda with
-# interface BiConsumer, stream.method = "mapMultiToDouble", and a handle-6 target —
-# whose target is a freshly synthesised BiConsumer `flatadapt`:
+# Stream.flatMapToDouble into an equivalent Stream.mapMultiToDouble. flatMapToDouble takes a
+# Function<T, DoubleStream> and flattens the returned DoubleStreams; the same fan-out
+# is expressed by mapMultiToDouble((x, c) -> { try (var r = mapper(x)) { if (r != null)
+# r.sequential().forEach(c); } }), where c is the downstream DoubleConsumer. 111 lifts
+# the flatMapToDouble invokedynamic into a Φ.hone.lambda carrying stream.method =
+# "flatMapToDouble" and a handle-6 target to a non-capturing lambda$ body of signature
+# (L<elem>;)Ljava/util/stream/DoubleStream;. This rule rewrites that pragma into the
+# shape 111 produces for a user mapMultiToDouble — a Φ.hone.lambda with interface
+# BiConsumer, stream.method = "mapMultiToDouble", and a handle-6 target — whose target is a
+# freshly synthesised BiConsumer `flatadapt` that applies the original mapper to the
+# item, then drains the returned DoubleStream into the downstream DoubleConsumer inside a
+# synthesised try-with-resources. DoubleStream.forEach takes precisely the DoubleConsumer
+# that mapMultiToDouble hands down, so the same adapter shape 455 synthesises works
+# unchanged here. 501/502 already emit mapMultiToDouble dispatches, so the jeo roundtrip of
+# these calls is proven.
 #
-#   flatadapt(x, c):  invokestatic lambda$(x) -> DoubleStream ; mapper applied to item
-#                     dup; ifnonnull L; pop; return    ; flatMapToDouble's null-skip
-#                     L: invokeinterface BaseStream.sequential() ; force sequential
-#                     invokeinterface DoubleStream.forEach(c) ; drains it into c
-#
-# The mapper body is kept untouched. DoubleStream.forEach takes precisely the
-# DoubleConsumer that mapMultiToDouble hands down, so the same adapter shape 455
-# synthesises works unchanged here. 501/502 already emit mapMultiToDouble
-# dispatches, so the jeo roundtrip of these calls is proven.
+# The mapper body is kept untouched. Like 455, the adapter reproduces flatMapToDouble's
+# null-skip, its `result.sequential()` drain, and — wrapping the drain in a
+# try-with-resources with its own exception-table entries, finally close() and
+# addSuppressed dance — the auto-close of the returned stream that the JDK performs,
+# so an I/O-backed sub-stream no longer leaks a descriptor per element (#726).
 #
 # Scope: reference Stream.flatMapToDouble only (mapper returns
-# java/util/stream/DoubleStream). Like 455, the adapter reproduces
-# flatMapToDouble's null-skip and its `result.sequential()` drain; the auto-close
-# of the returned stream still needs try-finally synthesis and is tracked
-# separately.
+# java/util/stream/DoubleStream).
 name: flatMapToDouble-to-mapMultiToDouble
 pattern: |
   ⟦
@@ -110,7 +107,7 @@ result: |
       access ↦ 4106,
       descriptor ↦ 𝑒-adapter-signature,
       signature ↦ "",
-      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, max-stack ↦ 2, max-locals ↦ 2 ⟧,
+      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, max-stack ↦ 2, max-locals ↦ 5 ⟧,
       params ↦ ⟦
         φ ↦ Φ.jeo.params,
         i1 ↦ ⟦ φ ↦ Φ.jeo.param, index ↦ 0, access ↦ 0, type ↦ 𝑒-flatmap-input ⟧,
@@ -118,47 +115,141 @@ result: |
       ⟧,
       body ↦ ⟦
         φ ↦ Φ.jeo.seq.of,
-        ld-item ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 0 ⟧,
+        ld-item ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 0 ⟧,
         call-mapper ↦ ⟦
           φ ↦ Φ.jeo.opcode.invokestatic,
-          i2 ↦ 𝑒-target-class,
-          i3 ↦ 𝑒-target-method,
-          i4 ↦ 𝑒-target-signature,
-          i5 ↦ 𝑒-target-is-interface
+          v0 ↦ 𝑒-target-class,
+          v1 ↦ 𝑒-target-method,
+          v2 ↦ 𝑒-target-signature,
+          v3 ↦ 𝑒-target-is-interface
         ⟧,
-        dup-stream ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+        store-stream ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, v0 ↦ 2 ⟧,
+        try-start ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-try ⟧,
+        ld-check ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 2 ⟧,
         guard ↦ ⟦
-          φ ↦ Φ.jeo.opcode.ifnonnull,
-          i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label ⟧
+          φ ↦ Φ.jeo.opcode.ifnull,
+          l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-end ⟧
         ⟧,
-        drop-null ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
-        ret-null ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
-        keep ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-label ⟧,
-        keep-frame ↦ ⟦
-          φ ↦ Φ.jeo.frame,
-          type ↦ 4,
-          nlocal ↦ 0,
-          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
-          nstack ↦ 1,
-          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, item ↦ "java/util/stream/DoubleStream" ⟧
-        ⟧,
+        ld-stream ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 2 ⟧,
         force-seq ↦ ⟦
           φ ↦ Φ.jeo.opcode.invokeinterface,
-          i2 ↦ "java/util/stream/BaseStream",
-          i3 ↦ "sequential",
-          i4 ↦ "()Ljava/util/stream/BaseStream;",
-          i5 ↦ Φ.true
+          v0 ↦ "java/util/stream/BaseStream",
+          v1 ↦ "sequential",
+          v2 ↦ "()Ljava/util/stream/BaseStream;",
+          v3 ↦ Φ.true
         ⟧,
-        ld-downstream ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
+        cast ↦ ⟦ φ ↦ Φ.jeo.opcode.checkcast, v0 ↦ "java/util/stream/DoubleStream" ⟧,
+        ld-downstream ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 1 ⟧,
         call-foreach ↦ ⟦
           φ ↦ Φ.jeo.opcode.invokeinterface,
-          i2 ↦ "java/util/stream/DoubleStream",
-          i3 ↦ "forEach",
-          i4 ↦ "(Ljava/util/function/DoubleConsumer;)V",
-          i5 ↦ Φ.true
+          v0 ↦ "java/util/stream/DoubleStream",
+          v1 ↦ "forEach",
+          v2 ↦ "(Ljava/util/function/DoubleConsumer;)V",
+          v3 ↦ Φ.true
+        ⟧,
+        try-end ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-end ⟧,
+        frame-drained ↦ ⟦
+          φ ↦ Φ.jeo.frame,
+          type ↦ 0,
+          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of3, x0 ↦ 𝑒-frame-input, x1 ↦ "java/util/function/DoubleConsumer", x2 ↦ "java/util/stream/DoubleStream" ⟧,
+          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
+        ⟧,
+        ld-close ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 2 ⟧,
+        guard-close ↦ ⟦
+          φ ↦ Φ.jeo.opcode.ifnull,
+          l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-done ⟧
+        ⟧,
+        ld-close-stream ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 2 ⟧,
+        call-close ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          v0 ↦ "java/util/stream/DoubleStream",
+          v1 ↦ "close",
+          v2 ↦ "()V",
+          v3 ↦ Φ.true
+        ⟧,
+        goto-done ↦ ⟦
+          φ ↦ Φ.jeo.opcode.goto,
+          l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-done ⟧
+        ⟧,
+        handler ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-handler ⟧,
+        frame-handler ↦ ⟦
+          φ ↦ Φ.jeo.frame,
+          type ↦ 0,
+          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of3, x0 ↦ 𝑒-frame-input, x1 ↦ "java/util/function/DoubleConsumer", x2 ↦ "java/util/stream/DoubleStream" ⟧,
+          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, x0 ↦ "java/lang/Throwable" ⟧
+        ⟧,
+        store-primary ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, v0 ↦ 3 ⟧,
+        ld-check2 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 2 ⟧,
+        guard-handler ↦ ⟦
+          φ ↦ Φ.jeo.opcode.ifnull,
+          l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-rethrow ⟧
+        ⟧,
+        close2-start ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-close2 ⟧,
+        ld-close2 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 2 ⟧,
+        call-close2 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          v0 ↦ "java/util/stream/DoubleStream",
+          v1 ↦ "close",
+          v2 ↦ "()V",
+          v3 ↦ Φ.true
+        ⟧,
+        close2-end ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-close2end ⟧,
+        goto-rethrow ↦ ⟦
+          φ ↦ Φ.jeo.opcode.goto,
+          l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-rethrow ⟧
+        ⟧,
+        handler2 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-handler2 ⟧,
+        frame-handler2 ↦ ⟦
+          φ ↦ Φ.jeo.frame,
+          type ↦ 0,
+          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of4, x0 ↦ 𝑒-frame-input, x1 ↦ "java/util/function/DoubleConsumer", x2 ↦ "java/util/stream/DoubleStream", x3 ↦ "java/lang/Throwable" ⟧,
+          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, x0 ↦ "java/lang/Throwable" ⟧
+        ⟧,
+        store-suppressed ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, v0 ↦ 4 ⟧,
+        ld-primary ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 3 ⟧,
+        ld-suppressed ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 4 ⟧,
+        call-addsup ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokevirtual,
+          v0 ↦ "java/lang/Throwable",
+          v1 ↦ "addSuppressed",
+          v2 ↦ "(Ljava/lang/Throwable;)V",
+          v3 ↦ Φ.false
+        ⟧,
+        rethrow-label ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-rethrow ⟧,
+        frame-rethrow ↦ ⟦
+          φ ↦ Φ.jeo.frame,
+          type ↦ 0,
+          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of4, x0 ↦ 𝑒-frame-input, x1 ↦ "java/util/function/DoubleConsumer", x2 ↦ "java/util/stream/DoubleStream", x3 ↦ "java/lang/Throwable" ⟧,
+          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
+        ⟧,
+        ld-primary2 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 3 ⟧,
+        do-throw ↦ ⟦ φ ↦ Φ.jeo.opcode.athrow ⟧,
+        done-label ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-done ⟧,
+        frame-done ↦ ⟦
+          φ ↦ Φ.jeo.frame,
+          type ↦ 0,
+          locals ↦ ⟦ φ ↦ Φ.jeo.seq.of2, x0 ↦ 𝑒-frame-input, x1 ↦ "java/util/function/DoubleConsumer" ⟧,
+          stack ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
         ⟧,
         ret ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
         ρ ↦ ∅
+      ⟧,
+      trycatchblocks ↦ ⟦
+        φ ↦ Φ.jeo.seq.of2,
+        t0 ↦ ⟦
+          φ ↦ Φ.jeo.trycatch,
+          l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-try ⟧,
+          l1 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-end ⟧,
+          l2 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-handler ⟧,
+          v3 ↦ "java/lang/Throwable"
+        ⟧,
+        t1 ↦ ⟦
+          φ ↦ Φ.jeo.trycatch,
+          l0 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-close2 ⟧,
+          l1 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-close2end ⟧,
+          l2 ↦ ⟦ φ ↦ Φ.jeo.label, v0 ↦ 𝑒-l-handler2 ⟧,
+          v3 ↦ "java/lang/Throwable"
+        ⟧
       ⟧,
       name ↦ 𝑒-adapter-name
     ⟧,
@@ -167,7 +258,28 @@ result: |
 where:
   - meta: 𝜏-adapter-method
     function: random-tau
-  - meta: 𝑒-label
+  - meta: 𝑒-l-try
+    function: random-string
+    args: [ '"L%d"' ]
+  - meta: 𝑒-l-end
+    function: random-string
+    args: [ '"L%d"' ]
+  - meta: 𝑒-l-handler
+    function: random-string
+    args: [ '"L%d"' ]
+  - meta: 𝑒-l-close2
+    function: random-string
+    args: [ '"L%d"' ]
+  - meta: 𝑒-l-close2end
+    function: random-string
+    args: [ '"L%d"' ]
+  - meta: 𝑒-l-handler2
+    function: random-string
+    args: [ '"L%d"' ]
+  - meta: 𝑒-l-rethrow
+    function: random-string
+    args: [ '"L%d"' ]
+  - meta: 𝑒-l-done
     function: random-string
     args: [ '"L%d"' ]
   - meta: 𝑒-adapter-name
@@ -178,6 +290,11 @@ where:
     args:
       - 𝑒-target-signature
       - '"s/^[(](L[^;]*;).*/$1/"'
+  - meta: 𝑒-frame-input
+    function: sed
+    args:
+      - 𝑒-flatmap-input
+      - '"s/^L(.*);$/$1/"'
   - meta: 𝑒-adapter-signature
     function: concat
     args: [ '"("', 𝑒-flatmap-input, '"Ljava/util/function/DoubleConsumer;)V"' ]

--- a/src/test/phino/455-flatMap-to-mapMulti.yml
+++ b/src/test/phino/455-flatMap-to-mapMulti.yml
@@ -11,11 +11,13 @@
 # freshly synthesised BiConsumer `flatadapt`, and appends that adapter method to
 # the class. The adapter applies the original mapper to the item
 # (invokestatic lambda$main$0) and drains the returned stream into the downstream
-# Consumer (invokeinterface Stream.forEach). Matching all of them — the surviving
-# mapMulti stream block, the invokestatic into the untouched mapper body, the
-# ifnonnull null-skip guard, the BaseStream.sequential drain, and the forEach —
-# proves the flatMap was rewired into a mapMulti that also reproduces flatMap's
-# null-skip and sequential().
+# Consumer (invokeinterface Stream.forEach) inside a synthesised
+# try-with-resources that also closes the stream. Matching all of them — the
+# surviving mapMulti stream block, the invokestatic into the untouched mapper
+# body, the ifnull null-skip guard, the BaseStream.sequential drain, the forEach,
+# the Stream.close, the Throwable.addSuppressed dance, the athrow rethrow and a
+# trycatch entry — proves the flatMap was rewired into a mapMulti that reproduces
+# flatMap's null-skip, sequential() and the auto-close of the returned stream.
 rules:
   - src/main/resources/org/eolang/hone/rules/streams/4xx/455-flatMap-to-mapMulti.phr
 input: |
@@ -46,8 +48,11 @@ input: |
   ⟧}
 expected:
   - ⟦ class ↦ "java/util/stream/Stream", method ↦ "mapMulti", signature ↦ "(Ljava/util/function/BiConsumer;)Ljava/util/stream/Stream;" ⟧
-  - ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$0", 𝐵-rest ⟧
-  - ⟦ φ ↦ Φ.jeo.opcode.ifnonnull, 𝐵-rest ⟧
-  - ⟦ φ ↦ Φ.jeo.frame, 𝐵-rest ⟧
-  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/stream/BaseStream", i3 ↦ "sequential", 𝐵-rest ⟧
-  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/stream/Stream", i3 ↦ "forEach", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokestatic, v0 ↦ "Foo", v1 ↦ "lambda$main$0", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.ifnull, 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/BaseStream", v1 ↦ "sequential", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "forEach", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "close", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, v0 ↦ "java/lang/Throwable", v1 ↦ "addSuppressed", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.athrow ⟧
+  - ⟦ φ ↦ Φ.jeo.trycatch, 𝐵-rest ⟧

--- a/src/test/phino/456-flatMapToInt-to-mapMultiToInt.yml
+++ b/src/test/phino/456-flatMapToInt-to-mapMultiToInt.yml
@@ -12,11 +12,14 @@
 # freshly synthesised BiConsumer `flatadapt`, and appends that adapter method to
 # the class. The adapter applies the original mapper to the item
 # (invokestatic lambda$main$0) and drains the returned IntStream into the
-# downstream IntConsumer (invokeinterface IntStream.forEach). Matching all of them —
-# the surviving mapMultiToInt stream block, the invokestatic into the untouched
-# mapper body, the ifnonnull null-skip guard, the BaseStream.sequential drain, and
-# the IntStream.forEach — proves the flatMapToInt was rewired into a mapMultiToInt
-# that also reproduces flatMapToInt's null-skip and sequential().
+# downstream IntConsumer (invokeinterface IntStream.forEach) inside a synthesised
+# try-with-resources that also closes the stream. Matching all of them — the
+# surviving mapMultiToInt stream block, the invokestatic into the untouched mapper
+# body, the ifnull null-skip guard, the BaseStream.sequential drain, the
+# IntStream.forEach, the IntStream.close, the Throwable.addSuppressed dance, the
+# athrow rethrow and a trycatch entry — proves the flatMapToInt was rewired into a
+# mapMultiToInt that reproduces flatMapToInt's null-skip, sequential() and the
+# auto-close of the returned stream.
 rules:
   - src/main/resources/org/eolang/hone/rules/streams/4xx/456-flatMapToInt-to-mapMultiToInt.phr
 input: |
@@ -47,8 +50,11 @@ input: |
   ⟧}
 expected:
   - ⟦ class ↦ "java/util/stream/Stream", method ↦ "mapMultiToInt", signature ↦ "(Ljava/util/function/BiConsumer;)Ljava/util/stream/IntStream;" ⟧
-  - ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$0", 𝐵-rest ⟧
-  - ⟦ φ ↦ Φ.jeo.opcode.ifnonnull, 𝐵-rest ⟧
-  - ⟦ φ ↦ Φ.jeo.frame, 𝐵-rest ⟧
-  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/stream/BaseStream", i3 ↦ "sequential", 𝐵-rest ⟧
-  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/stream/IntStream", i3 ↦ "forEach", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokestatic, v0 ↦ "Foo", v1 ↦ "lambda$main$0", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.ifnull, 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/BaseStream", v1 ↦ "sequential", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/IntStream", v1 ↦ "forEach", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/IntStream", v1 ↦ "close", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, v0 ↦ "java/lang/Throwable", v1 ↦ "addSuppressed", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.athrow ⟧
+  - ⟦ φ ↦ Φ.jeo.trycatch, 𝐵-rest ⟧

--- a/src/test/phino/457-flatMapToLong-to-mapMultiToLong.yml
+++ b/src/test/phino/457-flatMapToLong-to-mapMultiToLong.yml
@@ -12,11 +12,14 @@
 # freshly synthesised BiConsumer `flatadapt`, and appends that adapter method to
 # the class. The adapter applies the original mapper to the item
 # (invokestatic lambda$main$0) and drains the returned LongStream into the
-# downstream LongConsumer (invokeinterface LongStream.forEach). Matching all of
-# them — the surviving mapMultiToLong stream block, the invokestatic into the
-# untouched mapper body, the ifnonnull null-skip guard, the BaseStream.sequential
-# drain, and the LongStream.forEach — proves the flatMapToLong was rewired into a
-# mapMultiToLong that also reproduces flatMapToLong's null-skip and sequential().
+# downstream LongConsumer (invokeinterface LongStream.forEach) inside a synthesised
+# try-with-resources that also closes the stream. Matching all of them — the
+# surviving mapMultiToLong stream block, the invokestatic into the untouched mapper
+# body, the ifnull null-skip guard, the BaseStream.sequential drain, the
+# LongStream.forEach, the LongStream.close, the Throwable.addSuppressed dance, the
+# athrow rethrow and a trycatch entry — proves the flatMapToLong was rewired into a
+# mapMultiToLong that reproduces flatMapToLong's null-skip, sequential() and the
+# auto-close of the returned stream.
 rules:
   - src/main/resources/org/eolang/hone/rules/streams/4xx/457-flatMapToLong-to-mapMultiToLong.phr
 input: |
@@ -47,8 +50,11 @@ input: |
   ⟧}
 expected:
   - ⟦ class ↦ "java/util/stream/Stream", method ↦ "mapMultiToLong", signature ↦ "(Ljava/util/function/BiConsumer;)Ljava/util/stream/LongStream;" ⟧
-  - ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$0", 𝐵-rest ⟧
-  - ⟦ φ ↦ Φ.jeo.opcode.ifnonnull, 𝐵-rest ⟧
-  - ⟦ φ ↦ Φ.jeo.frame, 𝐵-rest ⟧
-  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/stream/BaseStream", i3 ↦ "sequential", 𝐵-rest ⟧
-  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/stream/LongStream", i3 ↦ "forEach", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokestatic, v0 ↦ "Foo", v1 ↦ "lambda$main$0", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.ifnull, 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/BaseStream", v1 ↦ "sequential", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/LongStream", v1 ↦ "forEach", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/LongStream", v1 ↦ "close", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, v0 ↦ "java/lang/Throwable", v1 ↦ "addSuppressed", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.athrow ⟧
+  - ⟦ φ ↦ Φ.jeo.trycatch, 𝐵-rest ⟧

--- a/src/test/phino/458-flatMapToDouble-to-mapMultiToDouble.yml
+++ b/src/test/phino/458-flatMapToDouble-to-mapMultiToDouble.yml
@@ -12,12 +12,14 @@
 # a freshly synthesised BiConsumer `flatadapt`, and appends that adapter method to
 # the class. The adapter applies the original mapper to the item
 # (invokestatic lambda$main$0) and drains the returned DoubleStream into the
-# downstream DoubleConsumer (invokeinterface DoubleStream.forEach). Matching all
-# of them — the surviving mapMultiToDouble stream block, the invokestatic into the
-# untouched mapper body, the ifnonnull null-skip guard, the BaseStream.sequential
-# drain, and the DoubleStream.forEach — proves the flatMapToDouble was rewired into
-# a mapMultiToDouble that also reproduces flatMapToDouble's null-skip and
-# sequential().
+# downstream DoubleConsumer (invokeinterface DoubleStream.forEach) inside a synthesised
+# try-with-resources that also closes the stream. Matching all of them — the
+# surviving mapMultiToDouble stream block, the invokestatic into the untouched mapper
+# body, the ifnull null-skip guard, the BaseStream.sequential drain, the
+# DoubleStream.forEach, the DoubleStream.close, the Throwable.addSuppressed dance, the
+# athrow rethrow and a trycatch entry — proves the flatMapToDouble was rewired into
+# a mapMultiToDouble that reproduces flatMapToDouble's null-skip, sequential() and the
+# auto-close of the returned stream.
 rules:
   - src/main/resources/org/eolang/hone/rules/streams/4xx/458-flatMapToDouble-to-mapMultiToDouble.phr
 input: |
@@ -48,8 +50,11 @@ input: |
   ⟧}
 expected:
   - ⟦ class ↦ "java/util/stream/Stream", method ↦ "mapMultiToDouble", signature ↦ "(Ljava/util/function/BiConsumer;)Ljava/util/stream/DoubleStream;" ⟧
-  - ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$0", 𝐵-rest ⟧
-  - ⟦ φ ↦ Φ.jeo.opcode.ifnonnull, 𝐵-rest ⟧
-  - ⟦ φ ↦ Φ.jeo.frame, 𝐵-rest ⟧
-  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/stream/BaseStream", i3 ↦ "sequential", 𝐵-rest ⟧
-  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/stream/DoubleStream", i3 ↦ "forEach", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokestatic, v0 ↦ "Foo", v1 ↦ "lambda$main$0", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.ifnull, 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/BaseStream", v1 ↦ "sequential", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/DoubleStream", v1 ↦ "forEach", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/DoubleStream", v1 ↦ "close", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, v0 ↦ "java/lang/Throwable", v1 ↦ "addSuppressed", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.athrow ⟧
+  - ⟦ φ ↦ Φ.jeo.trycatch, 𝐵-rest ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/flatmap-close.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/flatmap-close.yml
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Regression for issue #726: the flatMap -> mapMulti adapter must close the stream
+# the mapper returns. The JDK's ReferencePipeline.flatMap drains every element
+# inside `try (Stream r = mapper.apply(u)) { if (r != null) r.sequential().forEach(...); }`
+# — the try-with-resources closes r after its elements are consumed, which is what
+# releases the file handle or connection behind an I/O-backed sub-stream
+# (Files.lines, BufferedReader.lines, Files.walk, JDBC). Before #726 the `flatadapt`
+# body 455 synthesised drained the sub-stream with a bare forEach and returned
+# without ever calling close(), so the fused pipeline leaked one resource per
+# element — a regression the original flatMap does not have. The fix wraps the
+# drain in a synthesised try-with-resources (its own exception-table entries, a
+# finally that calls BaseStream.close(), and the addSuppressed/athrow dance), so
+# close() runs once per returned stream, on the normal and the exceptional path.
+#
+# Each of the three source elements maps to a fresh two-element Stream carrying an
+# onClose handler that bumps a counter; the terminal is an order- AND
+# value-sensitive 31-fold (reduce) over 1, 10, 2, 20, 3, 30, which the JDK
+# evaluates to 37943286. The optimized class reproduces that value AND reports
+# `closed 3` — proof that every sub-stream was both fully drained and closed.
+# Before the fix the optimized run prints `closed 0`: the elements still flow but
+# the streams are never closed.
+#
+# Counts: a lone flatMap (no adjacent mapMulti to fuse with) is converted to one
+# Stream.mapMulti and lowered back by 701, and its `flatadapt` body is appended:
+# one invokestatic into the untouched mapper (10 -> 11), and on the drain path one
+# BaseStream.sequential, one Stream.forEach and — new for #726 — two Stream.close
+# invokeinterface calls (the normal-close and the handler-close), so invokeinterface
+# rises by 4 (3 -> 7). The body returns once (4 -> 5; the null-skip now branches to
+# the close path rather than returning early). invokedynamic stays at 3: 455
+# relocates the Function call-site indy into the BiConsumer adapter's indy, and the
+# mapper lambda$ (with its onClose Runnable) and the reduce lambda are untouched.
+java: |
+  package flatmapclose;
+  import java.util.stream.Stream;
+  import java.util.concurrent.atomic.AtomicInteger;
+  public class X {
+    private static final AtomicInteger CLOSED = new AtomicInteger();
+    public static void main(String[] a) {
+      int n = Stream.of(1, 2, 3)
+        .flatMap(x -> Stream.of(x, x * 10).onClose(() -> CLOSED.incrementAndGet()))
+        .reduce(0, (p, q) -> p * 31 + q);
+      System.out.printf("The result is %d closed %d\n", n, CLOSED.get());
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 37943286 closed 3"
+before:
+  invokedynamic: 3
+  invokeinterface: 3
+  invokestatic: 10
+  return: 4
+after:
+  invokedynamic: 3
+  invokeinterface: 7
+  invokestatic: 11
+  return: 5

--- a/src/test/resources/org/eolang/hone/optimize/streams/flatmap-fusion.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/flatmap-fusion.yml
@@ -23,15 +23,17 @@
 # class reproduces it exactly (1535632236), which is the real proof — bytecode
 # that merely verifies but miswires the consumers would print a different number.
 #
-# Counts: invokeinterface stays at 7. The three fan-out call sites
+# Counts: invokeinterface rises to 9. The three fan-out call sites
 # (Stream.flatMap + two Stream.mapMulti) collapse to the single surviving
-# Stream.mapMulti, and the converted flatMap contributes one Stream.forEach plus
-# one BaseStream.sequential (flatMap's sequential() drain) in its `flatadapt`
-# body; the three Consumer.accept calls in the two mapMulti bodies and the
-# terminal reduce are untouched (1 mapMulti + 1 forEach + 1 sequential + 3 accept
-# + 1 reduce = 7, the same total as 1 flatMap + 2 mapMulti + 3 accept + 1
-# reduce = 7 before — the collapsed call sites are offset by the adapter's
-# sequential drain).
+# Stream.mapMulti, and the converted flatMap contributes one Stream.forEach, one
+# BaseStream.sequential (flatMap's sequential() drain) and — new for #726 — two
+# Stream.close calls (the normal-close and the handler-close of the synthesised
+# try-with-resources, which survive the fusion into the mapMulti chain) in its
+# `flatadapt` body; the three Consumer.accept calls in the two mapMulti bodies and
+# the terminal reduce are untouched (1 mapMulti + 1 forEach + 1 sequential + 2
+# close + 3 accept + 1 reduce = 9, two more than the 1 flatMap + 2 mapMulti + 3
+# accept + 1 reduce = 7 before — the collapsed call sites are offset by the
+# adapter's sequential drain, and the two closes are the net addition).
 # invokedynamic stays at 4 (flatMap + two mapMulti + reduce lambdas before; one
 # surviving mapMulti call site + two relocated wrapper-builder indys + the reduce
 # lambda after) — like 461, the adapter relocates each fused-away call-site indy
@@ -70,4 +72,4 @@ before:
   invokeinterface: 7
 after:
   invokedynamic: 4
-  invokeinterface: 7
+  invokeinterface: 9

--- a/src/test/resources/org/eolang/hone/optimize/streams/flatmap-null-skip.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/flatmap-null-skip.yml
@@ -8,8 +8,9 @@
 # flatMap into a mapMulti whose `flatadapt` body applies the mapper and drains the
 # returned stream into the downstream Consumer; before #725 it called forEach
 # unconditionally, so a null mapper result threw NullPointerException instead of
-# being skipped. The fix wraps the drain in `dup; ifnonnull L; pop; return` so the
-# null case returns without touching the consumer, exactly like the JDK.
+# being skipped. The fix stores the mapper result in a local and guards the drain
+# with `aload r; ifnull L_end`, so the null case skips straight to the close path
+# without touching the consumer, exactly like the JDK.
 #
 # The mapper here returns null for every odd element and a two-element Stream for
 # every even one, so half the elements feed a null into the adapter. The terminal
@@ -20,13 +21,15 @@
 #
 # Counts: a lone flatMap (no adjacent mapMulti to fuse with) is converted to one
 # Stream.mapMulti and lowered back by 701, and its `flatadapt` body is appended:
-# one invokestatic into the untouched mapper, the null-skip guard
-# (dup; ifnonnull L; pop; return), one BaseStream.sequential invokeinterface, one
-# Stream.forEach invokeinterface, and the final return. So invokestatic rises by 1
-# (12 -> 13), invokeinterface by 2 (2 -> 4, the sequential + forEach), and return
-# by 2 (2 -> 4, the null-branch return plus the final return). invokedynamic stays
-# at 2: 455 relocates the Function call-site indy into the BiConsumer adapter's
-# indy rather than adding one, and the mapper lambda$ and reduce lambda bodies are
+# one invokestatic into the untouched mapper, the null-skip guard (aload; ifnull),
+# one BaseStream.sequential invokeinterface, one Stream.forEach invokeinterface,
+# and — new for #726 — two Stream.close invokeinterface calls (the normal-close and
+# the handler-close of the synthesised try-with-resources). So invokestatic rises
+# by 1 (12 -> 13), invokeinterface by 4 (2 -> 6, the sequential + forEach + two
+# closes), and return rises by 1 (2 -> 3, the single final return; the null branch
+# now jumps to the close path rather than returning early). invokedynamic stays at
+# 2: 455 relocates the Function call-site indy into the BiConsumer adapter's indy
+# rather than adding one, and the mapper lambda$ and reduce lambda bodies are
 # untouched.
 java: |
   package flatmapnull;
@@ -51,6 +54,6 @@ before:
   return: 2
 after:
   invokedynamic: 2
-  invokeinterface: 4
+  invokeinterface: 6
   invokestatic: 13
-  return: 4
+  return: 3

--- a/src/test/resources/org/eolang/hone/optimize/streams/flatmaptox.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/flatmaptox.yml
@@ -24,13 +24,15 @@
 # Counts: each of the three flatMapToX call sites stays a single invokeinterface
 # on Stream (now mapMultiToX rather than flatMapToX), and each converted call adds
 # its `flatadapt` body — one invokestatic into the untouched mapper, the null-skip
-# guard (dup; ifnonnull L; pop; return), one BaseStream.sequential invokeinterface,
-# one XStream.forEach invokeinterface, and the final return. So invokestatic rises
-# by 3 (23 -> 26), invokeinterface by 6 (6 -> 12, three sequential + three forEach
-# calls), and return by 6 (2 -> 8, the three null-branch returns plus the three
-# final returns). invokedynamic stays at 6: 456/457/458 relocate each Function
-# call-site indy into the BiConsumer adapter's indy rather than adding one, and the
-# three mapper lambda$ bodies plus the three reduce lambdas are untouched.
+# guard (aload; ifnull), one BaseStream.sequential invokeinterface, one
+# XStream.forEach invokeinterface, two XStream.close invokeinterface calls (the
+# normal-close and the handler-close of the synthesised try-with-resources), and
+# the final return. So invokestatic rises by 3 (23 -> 26), invokeinterface by 12
+# (6 -> 18, three sequential + three forEach + six close calls), and return by 3
+# (2 -> 5, the three final returns; each null branch now jumps to the close path
+# rather than returning early). invokedynamic stays at 6: 456/457/458 relocate each
+# Function call-site indy into the BiConsumer adapter's indy rather than adding one,
+# and the three mapper lambda$ bodies plus the three reduce lambdas are untouched.
 java: |
   package flatmaptox;
   import java.util.stream.Stream;
@@ -63,6 +65,6 @@ before:
   return: 2
 after:
   invokedynamic: 6
-  invokeinterface: 12
+  invokeinterface: 18
   invokestatic: 26
-  return: 8
+  return: 5


### PR DESCRIPTION
Fixes #726.

## Problem

The `flatadapt` adapter synthesised by `455-flatMap-to-mapMulti.phr` (and its primitive siblings `456`/`457`/`458`) drained the mapper's result with a bare `invokeinterface Stream.forEach(Consumer)` and returned — it never called `close()`. The JDK's `ReferencePipeline.flatMap` drains every element inside `try (Stream r = mapper.apply(u)) { if (r != null) r.sequential().forEach(...); }`, so it closes every stream the mapper returns. Streams backed by I/O (`Files.lines`, `BufferedReader.lines`, `Files.walk`, JDBC) release a file handle or connection on `close()`, so the fused pipeline leaked one resource per element — a regression the original `flatMap` does not have.

## Fix

The adapter now wraps the drain in a synthesised try-with-resources, faithfully reproducing javac's desugaring:

```
flatadapt(x, c):
  r = mapper(x); astore r
  try:  aload r; ifnull L_end; r.sequential(); checkcast; forEach(c)
  L_end: aload r; ifnull L_done; r.close(); goto L_done
  handler1: astore t; aload r; ifnull L_rethrow
            close2: r.close(); goto L_rethrow
            handler2: astore u; t.addSuppressed(u)
            L_rethrow: aload t; athrow
  L_done: return
```

This is the first rule to synthesise an **exception table** and explicit **stack-map frames** (all `F_FULL`, so they are self-contained). The null-skip and `sequential()` drain added in #725 are preserved.

## Validation

Because the issue calls for proving the jeo roundtrip survives (not phino in isolation), every change was driven end-to-end through `jeo:disassemble → phino rewrite (all stream rules) → phino → jeo:assemble → java -Xverify:all`:

- New regression fixture **`flatmap-close.yml`**: the optimized class reproduces the reduce value **and** prints `closed 3` (one close per source element). Before the fix the same run prints `closed 0`.
- All four single-rule packs (`455`–`458`) match `phino match` for the new `ifnull`/`checkcast`/`forEach`/`close`/`addSuppressed`/`athrow`/`trycatch` shape.
- Opcode counts updated for `flatmap-null-skip`, `flatmaptox` and `flatmap-fusion`; the two `close()` calls survive fusion into the mapMulti chain.
- Every optimized class passes `-Xverify:all` and prints the expected value-/order-sensitive result.

## Notes

Gating the conversion to closeless mappers is not viable (the mapper is an opaque `invokestatic lambda$…`), so the close is always synthesised, exactly as the JDK does it.

https://claude.ai/code/session_01SobE3Cvn6NZUEA6p1TjywR

---
_Generated by [Claude Code](https://claude.ai/code/session_01SobE3Cvn6NZUEA6p1TjywR)_