### PR TITLE
#736: keep flatMap native when a short-circuit is downstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,24 @@ Instead, `limit` and `takeWhile` act as barriers:
   fuse into their own `mapMulti` calls independently,
   while the native short-circuiting call stays in place.
 
+The same blind spot reaches `flatMap` from the other direction (#736).
+A `flatMap` is fusable — `455-flatMap-to-mapMulti` and its primitive siblings
+  rewrite it into a `mapMulti` whose adapter drains each inner stream with
+  `result.sequential().forEach(c)` — but that adapter, being just a `mapMulti`
+  body, cannot see `cancellationRequested()` either.
+The JDK's `ReferencePipeline.flatMap` does forward cancellation:
+  once a downstream short-circuit has fired it stops part-way through an inner
+  stream, so `Stream.of(1L).flatMap(x -> Stream.iterate(x, i -> i + 1)).limit(5)`
+  yields five elements and terminates; the fused `forEach` adapter, by contrast,
+  runs to completion for every source element and hangs forever on the
+  unbounded inner stream.
+Because a `mapMulti` cannot honour cancellation, the cure mirrors the
+  revert-on-parallel guard above rather than patching the adapter:
+  `454-flatMap-revert-on-short-circuit` reverts the lifted `flatMap` back to its
+  native call whenever the same method body reaches a `limit`, `takeWhile`,
+  `findFirst`, `findAny`, `anyMatch`, `allMatch`, or `noneMatch` downstream of
+  it, so those `flatMap`s stay unfused.
+
 ## Why `skip` Is Only Fused on Sequential Pipelines
 
 `skip(n)` is fused (it lowers to a countdown counter inside the

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/454-flatMap-revert-on-short-circuit.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/454-flatMap-revert-on-short-circuit.phr
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Guards 455/456/457/458 against downstream short-circuiting (#736).
+#
+# 455 (and its primitive siblings 456/457/458) rewrite a user `Stream.flatMap`
+# into a `Stream.mapMulti` whose synthesised adapter drains every inner stream
+# with an unconditional `result.sequential().forEach(c)`. That reproduces
+# flatMap's per-element fan-out, null-skip and auto-close — but NOT its
+# downstream short-circuiting. The JDK's `ReferencePipeline.flatMap` forwards
+# `cancellationRequested()` and, once a short-circuiting stage has fired,
+# switches from `forEach` to a `tryAdvance` loop that stops part-way through an
+# inner stream. `mapMulti` hands its lambda a plain `Consumer`, so `forEach`
+# always runs to completion for every source element: with a finite inner
+# stream this merely wastes work, but with an unbounded one feeding a
+# short-circuit it never stops —
+# `Stream.of(1L).flatMap(x -> Stream.iterate(x, i -> i + 1)).limit(5)` yields
+# five elements natively but hangs forever after fusion.
+#
+# A `mapMulti` cannot honour cancellation, so — exactly as `222` keeps a skip
+# native on a parallel pipeline rather than patching the adapter — this rule
+# leaves the flatMap native whenever the same method body can reach a
+# short-circuiting operator (`limit`, `takeWhile`, `findFirst`, `findAny`,
+# `anyMatch`, `allMatch`, `noneMatch`) downstream of it. phino patterns cannot
+# test a binding group for the ABSENCE of such a call, so instead of gating
+# 455-458 on a marker this rule takes the dual, positive route used by `442`
+# and `222`: once `111` has lifted the flatMap into a Φ.hone.lambda, if a
+# short-circuit invoke sits AFTER it in the body, the lambda is reverted
+# straight back to the native `invokedynamic` + `invokeinterface` pair `701`
+# would otherwise emit — before `455` (later in the 4xx pass) ever converts it.
+# Because the lambda is gone, 455/456/457/458 simply never match it.
+#
+# The reverted `invokeinterface` carries `reverted ↦ Φ.true` as a fifth
+# operand, the same guard `442`/`222` use: `111`'s lift pattern is closed on
+# the four-operand opcode jeo emits, so the extra binding stops it
+# re-recognising this flatMap and the 111 → 454 → 701 cycle cannot spin. jeo
+# ignores the extra binding when assembling, so the bytecode is an ordinary
+# flatMap call.
+#
+# Detection is intentionally over-broad: any matching short-circuit anywhere
+# after the flatMap in the method reverts it, even one on an unrelated,
+# locally-consumed stream. Over-reverting only forfeits the mapMulti fusion on
+# that method (the native flatMap stays correct), so erring this way keeps the
+# pass sound. Binding groups are order-preserving, and a short-circuit BEFORE
+# the flatMap is upstream of it — not reachable downstream — so a single
+# pattern with the flatMap ahead of the call is exactly the case to guard; the
+# mirror layout needs no sibling.
+name: flatMap-revert-on-short-circuit
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-flatmap ↦ ⟦
+      φ ↦ Φ.hone.lambda,
+      class ↦ 𝑒-class,
+      method ↦ 𝑒-method,
+      interface ↦ 𝑒-interface,
+      lambda-signature ↦ 𝑒-lambda-signature,
+      bridge-signature ↦ 𝑒-bridge-signature,
+      static ↦ "true",
+      opcode ↦ 𝑒-opcode,
+      target ↦ ⟦
+        handle ↦ 𝑒-target-handle,
+        class ↦ 𝑒-target-class,
+        method ↦ 𝑒-target-method,
+        signature ↦ 𝑒-target-signature,
+        is-interface ↦ 𝑒-target-is-interface
+      ⟧,
+      stream ↦ ⟦
+        class ↦ 𝑒-stream-class,
+        method ↦ 𝑒-stream-method,
+        signature ↦ 𝑒-stream-signature
+      ⟧
+    ⟧,
+    𝐵-between,
+    𝜏-short ↦ ⟦
+      φ ↦ Φ.jeo.opcode.𝜏-op,
+      𝜏-sclass ↦ 𝑒-sclass,
+      𝜏-smethod ↦ 𝑒-smethod,
+      𝐵-short-rest
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-invokedynamic ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokedynamic,
+      i2 ↦ 𝑒-method,
+      i3 ↦ 𝑒-interface,
+      i4 ↦ ⟦
+        φ ↦ Φ.jeo.handle,
+        i1 ↦ 6,
+        i2 ↦ "java/lang/invoke/LambdaMetafactory",
+        i3 ↦ "metafactory",
+        i4 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+        i5 ↦ Φ.false
+      ⟧,
+      i5 ↦ ⟦
+        φ ↦ Φ.jeo.type,
+        i1 ↦ 𝑒-lambda-signature
+      ⟧,
+      i6 ↦ ⟦
+        φ ↦ Φ.jeo.handle,
+        i1 ↦ 𝑒-target-handle,
+        i2 ↦ 𝑒-target-class,
+        i3 ↦ 𝑒-target-method,
+        i4 ↦ 𝑒-target-signature,
+        i5 ↦ 𝑒-target-is-interface
+      ⟧,
+      i7 ↦ ⟦
+        φ ↦ Φ.jeo.type,
+        i1 ↦ 𝑒-bridge-signature
+      ⟧
+    ⟧,
+    𝜏-invokeinterface ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      i2 ↦ 𝑒-stream-class,
+      i3 ↦ 𝑒-stream-method,
+      i4 ↦ 𝑒-stream-signature,
+      i5 ↦ Φ.true,
+      reverted ↦ Φ.true
+    ⟧,
+    𝐵-between,
+    𝜏-short ↦ ⟦
+      φ ↦ Φ.jeo.opcode.𝜏-op,
+      𝜏-sclass ↦ 𝑒-sclass,
+      𝜏-smethod ↦ 𝑒-smethod,
+      𝐵-short-rest
+    ⟧,
+    𝐵-after
+  ⟧
+when:
+  and:
+    - or:
+        - eq: [𝜏-op, 'invokeinterface']
+        - eq: [𝜏-op, 'invokevirtual']
+    - matches: ['^flatMap(ToInt|ToLong|ToDouble)?$', 𝑒-stream-method]
+    - matches: ['^(limit|takeWhile|findFirst|findAny|anyMatch|allMatch|noneMatch)$', 𝑒-smethod]
+where:
+  - meta: 𝜏-invokedynamic
+    function: random-tau
+  - meta: 𝜏-invokeinterface
+    function: random-tau

--- a/src/test/phino/454-flatMap-revert-on-short-circuit.yml
+++ b/src/test/phino/454-flatMap-revert-on-short-circuit.yml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 454 reverts a flatMap Φ.hone.lambda back to its native invokedynamic +
+# invokeinterface pair when the same method body reaches a short-circuiting
+# operator downstream of it (here a `.limit(J)` call), so 455-458 never fuse a
+# flatMap whose mapMulti adapter could not honour cancellation (#736). The
+# reverted invokeinterface carries the `reverted ↦ Φ.true` guard that stops
+# 111 re-lifting it. The downstream limit call is left untouched.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/4xx/454-flatMap-revert-on-short-circuit.phr
+input: |
+  {⟦
+    φ ↦ Φ.jeo.class,
+    name ↦ "Foo",
+    jm$main ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      name ↦ "main",
+      body ↦ ⟦
+        φ ↦ Φ.jeo.seq.of,
+        op0 ↦ ⟦
+          φ ↦ Φ.hone.lambda,
+          class ↦ "Foo",
+          method ↦ "apply",
+          interface ↦ "()Ljava/util/function/Function;",
+          lambda-signature ↦ "(Ljava/lang/Object;)Ljava/lang/Object;",
+          bridge-signature ↦ "(Ljava/lang/Long;)Ljava/util/stream/Stream;",
+          static ↦ "true",
+          opcode ↦ "invokestatic",
+          target ↦ ⟦ handle ↦ 6, class ↦ "Foo", method ↦ "lambda$main$0", signature ↦ "(Ljava/lang/Long;)Ljava/util/stream/Stream;", is-interface ↦ Φ.false ⟧,
+          stream ↦ ⟦ class ↦ "java/util/stream/Stream", method ↦ "flatMap", signature ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;" ⟧
+        ⟧,
+        op1 ↦ ⟦
+          φ ↦ Φ.jeo.opcode.invokeinterface,
+          i2 ↦ "java/util/stream/Stream",
+          i3 ↦ "limit",
+          i4 ↦ "(J)Ljava/util/stream/Stream;",
+          i5 ↦ Φ.true
+        ⟧,
+        ρ ↦ ∅
+      ⟧
+    ⟧,
+    ρ ↦ ∅
+  ⟧}
+expected:
+  - ⟦ φ ↦ Φ.jeo.opcode.invokedynamic, i2 ↦ "apply", i3 ↦ "()Ljava/util/function/Function;", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/stream/Stream", i3 ↦ "flatMap", i4 ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;", i5 ↦ Φ.true, reverted ↦ Φ.true ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/stream/Stream", i3 ↦ "limit", 𝐵-rest ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/flatmap-short-circuit.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/flatmap-short-circuit.yml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A flatMap whose inner stream is unbounded, feeding a downstream short-circuit
+# (issue #736). Native ReferencePipeline.flatMap forwards cancellation: once
+# limit(5) has taken its five elements it stops pulling, so
+# Stream.of(1L).flatMap(x -> Stream.iterate(x, i -> i + 1)).limit(5) yields
+# exactly 1+2+3+4+5 = 15 and terminates. A mapMulti adapter cannot honour that
+# cancellation — its `result.sequential().forEach(c)` drains the whole inner
+# stream — so fusing this flatMap into a mapMulti (455) would loop forever on
+# the unbounded Stream.iterate. 454-flatMap-revert-on-short-circuit detects the
+# downstream limit and reverts the lifted flatMap straight back to its native
+# invokedynamic + invokeinterface pair, leaving it unfused. The build therefore
+# finishes and prints 15; before the guard it hung.
+#
+# Counts: the guard reverts the flatMap to byte-identical native form and
+# nothing else in the chain fuses (limit and reduce are not fusable, and
+# Stream.iterate's i -> i + 1 lambda is an argument to a static factory, not a
+# pipeline stage), so both opcode tallies are unchanged. invokedynamic stays at
+# 3 (the flatMap mapper, the iterate UnaryOperator, and the Long::sum reduce
+# accumulator). invokeinterface stays at 3 (Stream.flatMap, Stream.limit,
+# Stream.reduce); Stream.of and Stream.iterate are static. Crucially there is no
+# Stream.mapMulti call site — the flatMap was left native rather than converted.
+java: |
+  package flatmapshortcircuit;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      long n = Stream.of(1L)
+        .flatMap(x -> Stream.iterate(x, i -> i + 1))
+        .limit(5)
+        .reduce(0L, Long::sum);
+      System.out.printf("The result is %d\n", n);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 15"
+before:
+  invokedynamic: 3
+  invokeinterface: 3
+after:
+  invokedynamic: 3
+  invokeinterface: 3


### PR DESCRIPTION
Fixes #736.

## Problem

`455-flatMap-to-mapMulti` (and its primitive siblings `456`/`457`/`458`) rewrite a user `Stream.flatMap` into a `mapMulti` whose synthesised adapter drains every inner stream with an unconditional `result.sequential().forEach(c)`. The adapter reproduces flatMap's per-element fan-out, null-skip and auto-close — but it drops **downstream short-circuiting**.

The JDK's `ReferencePipeline.flatMap` forwards `cancellationRequested()` and, once a short-circuiting stage has fired, stops part-way through an inner stream. A `mapMulti` body is handed a plain `Consumer`, so `forEach` always runs to completion. With an unbounded inner stream feeding a short-circuit it never stops:

```java
Stream.of(1L).flatMap(x -> Stream.iterate(x, i -> i + 1)).limit(5)
```

yields five elements with native flatMap but **hangs forever** after fusion. No `sabj25` benchmark combines an unbounded inner stream with a downstream short-circuit, so the suite never exposed it.

## Fix

A `mapMulti` cannot honour cancellation, so — exactly as `222-parallel-reverts-skip` keeps a skip native on a parallel pipeline rather than patching the adapter — the new **`454-flatMap-revert-on-short-circuit`** leaves the flatMap native whenever the same method body can reach a short-circuiting operator (`limit`, `takeWhile`, `findFirst`, `findAny`, `anyMatch`, `allMatch`, `noneMatch`) downstream of it.

Once `111` has lifted the flatMap into a `Φ.hone.lambda`, the guard reverts it straight back to the native `invokedynamic` + `invokeinterface` pair `701` would otherwise emit — before `455` (later in the 4xx pass) ever converts it. The reverted `invokeinterface` carries the `reverted ↦ Φ.true` fifth-operand marker (same trick `442`/`222` use) so `111`'s four-operand lift pattern cannot re-recognise it and the `111 → 454 → 701` cycle cannot spin. Because the lambda is gone, `455`/`456`/`457`/`458` simply never match — no change to those rules is needed.

Detection is intentionally over-broad (any matching short-circuit anywhere after the flatMap reverts it); over-reverting only forfeits the mapMulti fusion on that method, so it stays sound.

## Tests / docs

- `src/test/phino/454-flatMap-revert-on-short-circuit.yml` — single-rule pack asserting a flatMap lambda followed by `limit` reverts to native `invokedynamic`/`invokeinterface` with the `reverted` guard, leaving the limit call untouched.
- `src/test/resources/org/eolang/hone/optimize/streams/flatmap-short-circuit.yml` — end-to-end fixture with an unbounded inner stream + `limit(5)` that now terminates and prints `15` (it hung before the guard).
- `README.md` — documents the guard in the short-circuiting section.

https://claude.ai/code/session_017b3dCmGuPdSw9qhZjyKrpT

---
_Generated by [Claude Code](https://claude.ai/code/session_017b3dCmGuPdSw9qhZjyKrpT)_