### PR TITLE
#516: drop stale @todo for already-conditional grep-in test

### DIFF
--- a/src/test/java/org/eolang/hone/OptimizeMojoTest.java
+++ b/src/test/java/org/eolang/hone/OptimizeMojoTest.java
@@ -45,14 +45,6 @@ import org.yaml.snakeyaml.Yaml;
 /**
  * Test case for {@link OptimizeMojo}.
  * @since 0.1.0
- * @todo #440:90min enable 'grep-in' tests.
- *  The following test is disabled because it fails on Rultor:
- *  <a href="https://github.com/objectionary/hone-maven-plugin/pull/458">PR</a>
- *  However, all the tests pass locally.
- *  We should find a reason why the following test fails on specific
- *  environment and fix it:
- *  - {@link OptimizeMojoTest#optimizesAsSpecifiedInYamlPack}
- *  When this test is fixed, remove @Disabled annotation.
  */
 @Execution(ExecutionMode.SAME_THREAD)
 @ExtendWith(RandomImageResolver.class)


### PR DESCRIPTION
The class-level @todo on OptimizeMojoTest asked the next agent to enable a disabled grep-in test and drop its @Disabled annotation once the Rultor-specific failure was understood. The referenced test, optimizesAsSpecifiedInYamlPack, no longer carries @Disabled. It runs under @DisabledWithoutDocker with @Tag("deep"), matching the conditional-skip pattern used elsewhere in the class for Docker-dependent fixtures, so the todo points at work that has already landed.

The visible effect is the puzzle bot no longer reopening this todo as #516 on every parse, and the class Javadoc no longer mislabels a Docker-gated test as outright disabled. No production code or test logic changes.

Verified with `mvn -B -q test-compile` (clean) and `mvn -B -q -Dtest=OptimizeMojoTest#skipsOptimizationOnFlag test` (passes).

Closes #516
