### PR TITLE
#741: add PhinoTest covering available() return paths

### DIFF
--- a/src/main/java/org/eolang/hone/Phino.java
+++ b/src/main/java/org/eolang/hone/Phino.java
@@ -16,6 +16,26 @@ import java.io.IOException;
 final class Phino {
 
     /**
+     * The executable to run.
+     */
+    private final String executable;
+
+    /**
+     * Ctor.
+     */
+    Phino() {
+        this("phino");
+    }
+
+    /**
+     * Ctor.
+     * @param executable The executable to run, instead of "phino"
+     */
+    Phino(final String executable) {
+        this.executable = executable;
+    }
+
+    /**
      * Is it available?
      * @param expected This is the expected version
      * @return TRUE if available
@@ -23,7 +43,8 @@ final class Phino {
     boolean available(final String expected) {
         boolean available = false;
         try {
-            final Result result = new Jaxec("phino", "--version").withCheck(false).execUnsafe();
+            final Result result = new Jaxec(this.executable, "--version")
+                .withCheck(false).execUnsafe();
             if (result.code() == 0) {
                 final String version = result.stdout().trim();
                 if (version.equals(expected)) {

--- a/src/test/java/org/eolang/hone/PhinoTest.java
+++ b/src/test/java/org/eolang/hone/PhinoTest.java
@@ -1,0 +1,86 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.hone;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.EnumSet;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Test case for {@link Phino}.
+ * @since 0.17.0
+ */
+final class PhinoTest {
+
+    @Test
+    void returnsTrueWhenVersionMatches(@TempDir final Path dir) throws Exception {
+        MatcherAssert.assertThat(
+            "must be available when the reported version matches",
+            new Phino(
+                PhinoTest.fake(dir, String.format("echo '1.2.3'%nexit 0")).toString()
+            ).available("1.2.3"),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void returnsFalseWhenVersionMismatches(@TempDir final Path dir) throws Exception {
+        MatcherAssert.assertThat(
+            "must not be available when the reported version doesn't match",
+            new Phino(
+                PhinoTest.fake(dir, String.format("echo '1.2.3'%nexit 0")).toString()
+            ).available("9.9.9"),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void returnsFalseWhenExecutableExitsNonZero(@TempDir final Path dir) throws Exception {
+        MatcherAssert.assertThat(
+            "must not be available when the executable fails",
+            new Phino(PhinoTest.fake(dir, "exit 1").toString()).available("1.2.3"),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void returnsFalseWhenExecutableIsMissing(@TempDir final Path dir) {
+        MatcherAssert.assertThat(
+            "must not be available when the executable doesn't exist",
+            new Phino(dir.resolve("no-such-executable").toString()).available("1.2.3"),
+            Matchers.is(false)
+        );
+    }
+
+    /**
+     * Create a fake executable script in the given directory.
+     * @param dir The directory to create the script in
+     * @param body The body of the script, after the shebang line
+     * @return The path to the script
+     * @throws Exception If something goes wrong
+     */
+    private static Path fake(final Path dir, final String body) throws Exception {
+        final Path script = dir.resolve("phino");
+        Files.write(
+            script,
+            String.format("#!/bin/sh%n%s%n", body).getBytes(StandardCharsets.UTF_8)
+        );
+        Files.setPosixFilePermissions(
+            script,
+            EnumSet.of(
+                PosixFilePermission.OWNER_READ,
+                PosixFilePermission.OWNER_WRITE,
+                PosixFilePermission.OWNER_EXECUTE
+            )
+        );
+        return script;
+    }
+}


### PR DESCRIPTION
## What happens

`Phino` decides whether `OptimizeMojo`, `PullMojo`, `BuildMojo`, and `RmiMojo`
run the local `phino` binary or fall back to Docker, yet
`src/test/java/org/eolang/hone/` ships no `PhinoTest.java`. Every other
production class in `src/main/java/org/eolang/hone/` has a matching
`*Test.java` next to it.

`Phino.available()` shells out to `phino --version`, trims the stdout,
compares it to the expected version with `String.equals`, and returns `true`
only on exact match. This is silently relied on at `OptimizeMojo.java:404`,
`PullMojo.java:29`, `BuildMojo.java:59`, and `RmiMojo.java:26`, where a
`false` return forces a Docker pull. A regression in the version-string
comparison, the exit-code branch, or the `IOException` branch flips every
caller from local execution to Docker without any failing test.

## What should happen

`Phino.available()` should have test coverage for all three return paths:
matching version returns `true`, mismatched version (or non-zero exit) returns
`false`, and a missing executable returns `false`.

## Fix

`Phino.available()` always invokes the hardcoded `"phino"` binary, which
makes it untestable without a real `phino` installation or PATH
manipulation. Added a small constructor seam — `Phino(String executable)` —
so tests can point at a fake executable instead. The no-arg constructor still
delegates to `"phino"`, so none of the four production call sites change
behavior.

Added `PhinoTest.java` with 4 tests, each pointing `Phino` at a throwaway
shell script created in a JUnit `@TempDir`:

- `returnsTrueWhenVersionMatches` — script echoes the expected version, exits 0
- `returnsFalseWhenVersionMismatches` — script echoes a different version, exits 0
- `returnsFalseWhenExecutableExitsNonZero` — script exits 1
- `returnsFalseWhenExecutableIsMissing` — path points at a non-existent file

## Verification

- `mvn test -Dtest=PhinoTest` — 4 tests, 0 failures
- `mvn test` (full suite) — all green
- `mvn qulice:check -Pqulice` — no violations

Closes #741
