### PR TITLE
Give every name-minting rule its own namespace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,9 @@ rule, how to test, and what to avoid*.
    subdirectory whose digit matches the rule's hundreds prefix). Start from
    the closest existing rule and keep its header block (`SPDX` +
    `# yamllint disable rule:line-length`).
+   If the rule mints a synthetic name with `random-string`, embed its own
+   `NNN` in the format pattern (`distill_501%d`, not `distill_%d`), so that no
+   two rules can ever draw the same name; `RulesTest` enforces this.
 3. **Run small-steps locally** on a representative `.phi` to see what your
    rule produces:
 
@@ -128,6 +131,13 @@ every `@Tag("deep")` test runs against the real `phino` binary on the host.
   unfolded pragma at `350-` would silently break fusion on that method.
 - Do not change `Collections.sort(names)` in `Rules.discover()`. The pipeline
   depends on alphabetical ordering as its scheduling mechanism.
+- Do not let two rules share one `random-string` pattern. Phino guarantees
+  minted names are unique only inside a single process, and it seeds its
+  generator identically on every run since 0.0.106, so in small-steps mode —
+  one process per rule — both rules draw the very same name and produce two
+  methods with one name in one class. `711` then reverts an invokedynamic
+  through the wrong wrapper and the class dies at link time with
+  `LambdaConversionException` (see #777).
 - Do not hand-edit `.class` files in `target/classes-before-hone/`. That
   directory is the backup the plugin makes before mutation; it is the only way
   to recover the pre-optimization bytecode without recompiling.

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/103-methodref-to-lambda.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/103-methodref-to-lambda.phr
@@ -245,7 +245,7 @@ where:
     function: random-tau
   - meta: 𝑒-wrapper-name
     function: random-string
-    args: ['"lambda$hone$%d"']
+    args: ['"lambda$hone$103%d"']
   - meta: 𝑒-return-op
     function: sed
     args:

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/104-static-methodref-to-lambda.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/104-static-methodref-to-lambda.phr
@@ -217,7 +217,7 @@ where:
     function: random-tau
   - meta: 𝑒-wrapper-name
     function: random-string
-    args: ['"lambda$hone$%d"']
+    args: ['"lambda$hone$104%d"']
   - meta: 𝑒-param
     function: sed
     args:

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/105-methodref-peek-to-lambda.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/105-methodref-peek-to-lambda.phr
@@ -250,7 +250,7 @@ where:
     function: random-tau
   - meta: 𝑒-wrapper-name
     function: random-string
-    args: ['"lambda$hone$%d"']
+    args: ['"lambda$hone$105%d"']
   - meta: 𝑒-drop-op
     function: sed
     args:

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/107-methodref-ref-return-to-lambda.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/107-methodref-ref-return-to-lambda.phr
@@ -226,7 +226,7 @@ where:
     function: random-tau
   - meta: 𝑒-wrapper-name
     function: random-string
-    args: ['"lambda$hone$%d"']
+    args: ['"lambda$hone$107%d"']
   - meta: 𝑒-return-class
     function: sed
     args:

--- a/src/main/resources/org/eolang/hone/rules/streams/3xx/304-primitive-filter-to-distill.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/3xx/304-primitive-filter-to-distill.phr
@@ -60,7 +60,7 @@ result: |
 where:
   - meta: 𝑒-label
     function: random-string
-    args: ['"L%d"']
+    args: ['"L304%d"']
   - meta: 𝜏-opcode
     function: tau
     args: [𝑒-opcode]

--- a/src/main/resources/org/eolang/hone/rules/streams/3xx/305-object-filter-to-distill.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/3xx/305-object-filter-to-distill.phr
@@ -77,7 +77,7 @@ result: |
 where:
   - meta: 𝑒-label
     function: random-string
-    args: ['"L%d"']
+    args: ['"L305%d"']
   - meta: 𝜏-opcode
     function: tau
     args: [𝑒-opcode]

--- a/src/main/resources/org/eolang/hone/rules/streams/3xx/307-distinct-to-distill.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/3xx/307-distinct-to-distill.phr
@@ -92,7 +92,7 @@ result: |
 where:
   - meta: 𝑒-label
     function: random-string
-    args: ['"L%d"']
+    args: ['"L307%d"']
   - meta: 𝜏-dup-list
     function: random-tau
   - meta: 𝜏-new-set

--- a/src/main/resources/org/eolang/hone/rules/streams/3xx/308-skip-to-distill.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/3xx/308-skip-to-distill.phr
@@ -91,7 +91,7 @@ result: |
 where:
   - meta: 𝑒-label
     function: random-string
-    args: ['"L%d"']
+    args: ['"L308%d"']
   - meta: 𝜏-alen
     function: random-tau
   - meta: 𝜏-new-cnt

--- a/src/main/resources/org/eolang/hone/rules/streams/3xx/310-dropwhile-to-distill.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/3xx/310-dropwhile-to-distill.phr
@@ -123,7 +123,7 @@ result: |
 where:
   - meta: 𝑒-label
     function: random-string
-    args: ['"L%d"']
+    args: ['"L310%d"']
   - meta: 𝜏-opcode
     function: tau
     args: [𝑒-opcode]

--- a/src/main/resources/org/eolang/hone/rules/streams/3xx/314-cp-filter-to-distill.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/3xx/314-cp-filter-to-distill.phr
@@ -89,7 +89,7 @@ result: |
 where:
   - meta: 𝑒-label
     function: random-string
-    args: ['"L%d"']
+    args: ['"L314%d"']
   - meta: 𝜏-dup
     function: random-tau
   - meta: 𝜏-park

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/455-flatMap-to-mapMulti.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/455-flatMap-to-mapMulti.phr
@@ -285,31 +285,31 @@ where:
     function: random-tau
   - meta: 𝑒-l-try
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L455%d"' ]
   - meta: 𝑒-l-end
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L455%d"' ]
   - meta: 𝑒-l-handler
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L455%d"' ]
   - meta: 𝑒-l-close2
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L455%d"' ]
   - meta: 𝑒-l-close2end
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L455%d"' ]
   - meta: 𝑒-l-handler2
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L455%d"' ]
   - meta: 𝑒-l-rethrow
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L455%d"' ]
   - meta: 𝑒-l-done
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L455%d"' ]
   - meta: 𝑒-adapter-name
     function: random-string
-    args: [ '"flatadapt_%d"' ]
+    args: [ '"flatadapt_455%d"' ]
   - meta: 𝑒-flatmap-input
     function: sed
     args:

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/456-flatMapToInt-to-mapMultiToInt.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/456-flatMapToInt-to-mapMultiToInt.phr
@@ -260,31 +260,31 @@ where:
     function: random-tau
   - meta: 𝑒-l-try
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L456%d"' ]
   - meta: 𝑒-l-end
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L456%d"' ]
   - meta: 𝑒-l-handler
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L456%d"' ]
   - meta: 𝑒-l-close2
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L456%d"' ]
   - meta: 𝑒-l-close2end
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L456%d"' ]
   - meta: 𝑒-l-handler2
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L456%d"' ]
   - meta: 𝑒-l-rethrow
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L456%d"' ]
   - meta: 𝑒-l-done
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L456%d"' ]
   - meta: 𝑒-adapter-name
     function: random-string
-    args: [ '"flatadapt_%d"' ]
+    args: [ '"flatadapt_456%d"' ]
   - meta: 𝑒-flatmap-input
     function: sed
     args:

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/457-flatMapToLong-to-mapMultiToLong.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/457-flatMapToLong-to-mapMultiToLong.phr
@@ -260,31 +260,31 @@ where:
     function: random-tau
   - meta: 𝑒-l-try
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L457%d"' ]
   - meta: 𝑒-l-end
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L457%d"' ]
   - meta: 𝑒-l-handler
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L457%d"' ]
   - meta: 𝑒-l-close2
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L457%d"' ]
   - meta: 𝑒-l-close2end
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L457%d"' ]
   - meta: 𝑒-l-handler2
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L457%d"' ]
   - meta: 𝑒-l-rethrow
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L457%d"' ]
   - meta: 𝑒-l-done
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L457%d"' ]
   - meta: 𝑒-adapter-name
     function: random-string
-    args: [ '"flatadapt_%d"' ]
+    args: [ '"flatadapt_457%d"' ]
   - meta: 𝑒-flatmap-input
     function: sed
     args:

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/458-flatMapToDouble-to-mapMultiToDouble.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/458-flatMapToDouble-to-mapMultiToDouble.phr
@@ -260,31 +260,31 @@ where:
     function: random-tau
   - meta: 𝑒-l-try
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L458%d"' ]
   - meta: 𝑒-l-end
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L458%d"' ]
   - meta: 𝑒-l-handler
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L458%d"' ]
   - meta: 𝑒-l-close2
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L458%d"' ]
   - meta: 𝑒-l-close2end
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L458%d"' ]
   - meta: 𝑒-l-handler2
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L458%d"' ]
   - meta: 𝑒-l-rethrow
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L458%d"' ]
   - meta: 𝑒-l-done
     function: random-string
-    args: [ '"L%d"' ]
+    args: [ '"L458%d"' ]
   - meta: 𝑒-adapter-name
     function: random-string
-    args: [ '"flatadapt_%d"' ]
+    args: [ '"flatadapt_458%d"' ]
   - meta: 𝑒-flatmap-input
     function: sed
     args:

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/461-fuse-mapMulti.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/461-fuse-mapMulti.phr
@@ -227,10 +227,10 @@ where:
     function: random-tau
   - meta: 𝑒-fused-name
     function: random-string
-    args: [ '"fused_%d"' ]
+    args: [ '"fused_461%d"' ]
   - meta: 𝑒-wrap-name
     function: random-string
-    args: [ '"wrap_%d"' ]
+    args: [ '"wrap_461%d"' ]
   - meta: 𝑒-first-input
     function: sed
     args:

--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/501-distill-to-mapMulti.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/501-distill-to-mapMulti.phr
@@ -88,7 +88,7 @@ where:
     function: random-tau
   - meta: 𝑒-target-method
     function: random-string
-    args: [ '"distill_%d"' ]
+    args: [ '"distill_501%d"' ]
   # Stream.mapMultiToX takes a plain BiConsumer<T, XConsumer>, so the SAM
   # type and its erased samMethodType are decided by the distill INPUT
   # exactly as for an ordinary mapMulti — only the XConsumer the body

--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/502-distill-state-to-mapMulti.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/502-distill-state-to-mapMulti.phr
@@ -124,7 +124,7 @@ where:
     function: random-tau
   - meta: 𝑒-target-method
     function: random-string
-    args: [ '"distill_%d"' ]
+    args: [ '"distill_502%d"' ]
   - meta: 𝑒-map-multi-consumer
     function: sed
     args:

--- a/src/test/java/org/eolang/hone/RulesTest.java
+++ b/src/test/java/org/eolang/hone/RulesTest.java
@@ -7,7 +7,18 @@ package org.eolang.hone;
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -87,6 +98,36 @@ final class RulesTest {
                 "copies/streams/7xx/701-static-lambda-to-invokedynamic.phr"
             ).toFile().exists(),
             Matchers.is(true)
+        );
+    }
+
+    @Test
+    void mintsSyntheticNamesInDisjointNamespaces(@Mktmp final Path temp) throws IOException {
+        new Rules("*").copyTo(temp);
+        final Pattern minting = Pattern.compile(
+            "function:\\s*random-string\\s*\\R\\s*args:\\s*\\[\\s*'\"([^\"]+)\""
+        );
+        final Map<String, Collection<String>> minters = new HashMap<>(0);
+        final List<Path> files;
+        try (Stream<Path> walk = Files.walk(temp)) {
+            files = walk.filter(Files::isRegularFile).collect(Collectors.toList());
+        }
+        for (final Path file : files) {
+            final Matcher found = minting.matcher(
+                Files.readString(file, StandardCharsets.UTF_8)
+            );
+            while (found.find()) {
+                minters.computeIfAbsent(found.group(1), key -> new HashSet<>(0))
+                    .add(temp.relativize(file).toString());
+            }
+        }
+        MatcherAssert.assertThat(
+            "two rules cannot mint synthetic names from one pattern, since every phino process draws the same sequence and the duplicates collide inside one class (see #777)",
+            minters.entrySet().stream()
+                .filter(entry -> entry.getValue().size() > 1)
+                .map(Map.Entry::toString)
+                .collect(Collectors.toList()),
+            Matchers.empty()
         );
     }
 


### PR DESCRIPTION
Sixteen `.phr` rules mint synthetic names through phino's `random-string`, and until now they shared four format patterns between them: `lambda$hone$%d` across 103/104/105/107, `L%d` across 304..314 and 455..458, `flatadapt_%d` across 455..458, and `distill_%d` across 501/502. Each pattern now carries the number of the rule that owns it, so two rules can no longer draw the same name. `RulesTest` walks the shipped rule set and fails if a pattern ever gets a second minter again.

The sharing was harmless while phino drew from process entropy, but 0.0.106 seeds its generator identically on every run, so every phino process now mints `lambda$hone$8152` first. In small-steps mode each rule gets its own phino process, so 103 and 104 both hand out that name and the class ends up with two methods called `lambda$hone$8152`. Rule 711 then reverts an invokedynamic through whichever wrapper it matches first — on the sabj25 benchmarks it repointed the `Long::toString` call site in `Main.<init>` at `Long.longValue`, and the class died at link time with `Invalid receiver type long; not a subtype of implementation type class java.lang.Long`. That is the failure in #777, and after this change the same build links and runs.

One thing worth flagging: I could not reproduce #777 in normal mode. On hone 0.29.1 with phino 0.0.106 and jeo 0.15.3 on JDK 26.0.1, sabj25's `Main` optimizes and constructs fine both through host phino and through the `yegor256/hone:0.29.1` image — normal mode runs one phino process per class, and phino does keep names unique inside a process. Only `-Dhone.small-steps=true` breaks, deterministically. So 603 and 111 turned out to be innocent, and nothing needs fixing in phino.

Closes #777