### PR TITLE
#783: Exclude summary output from collection

### DIFF
--- a/src/main/java/org/eolang/hone/Summary.java
+++ b/src/main/java/org/eolang/hone/Summary.java
@@ -53,9 +53,12 @@ public final class Summary {
     Path collect() {
         final List<CSV> found = new ArrayList<>(0);
         final String stats = "hone-statistics.csv";
+        final Path destination = this.target.resolve(stats);
+        final Path output = destination.toAbsolutePath().normalize();
         try (Stream<Path> paths = Files.walk(this.root)) {
             paths.filter(Files::isRegularFile)
                 .filter(path -> stats.equals(path.getFileName().toString()))
+                .filter(path -> !output.equals(path.toAbsolutePath().normalize()))
                 .map(CSV::new)
                 .forEach(found::add);
         } catch (final IOException exception) {
@@ -64,7 +67,6 @@ public final class Summary {
                 exception
             );
         }
-        final Path destination = this.target.resolve(stats);
         if (!found.isEmpty()) {
             Summary.reduce(found).flush(destination);
         }

--- a/src/test/java/org/eolang/hone/SummaryTest.java
+++ b/src/test/java/org/eolang/hone/SummaryTest.java
@@ -40,6 +40,23 @@ final class SummaryTest {
     }
 
     @Test
+    void excludesPreviousSummaryFromCollection(@Mktmp final Path temp) throws Exception {
+        final Path root = SummaryTest.modular(temp);
+        final Summary summary = new Summary(
+            root,
+            Files.createDirectories(root.resolve("target"))
+        );
+        final Path report = summary.collect();
+        final String expected = new TextOf(report).asString();
+        summary.collect();
+        MatcherAssert.assertThat(
+            "report must be stable across repeated collections",
+            new TextOf(report).asString(),
+            Matchers.equalTo(expected)
+        );
+    }
+
+    @Test
     void skipsModulesWithoutStatistics(@Mktmp final Path temp) throws Exception {
         final Path dir = SummaryTest.modular(temp);
         Files.deleteIfExists(dir.resolve("server/hone-statistics.csv"));


### PR DESCRIPTION
## Summary

- exclude the aggregate `hone-statistics.csv` destination from the statistics files discovered below the project root
- compare normalized absolute paths so equivalent target paths cannot be re-read
- add regression coverage that runs collection twice and verifies byte-for-byte stable output

## Root cause

`Summary.collect()` walked the project root before writing into a target directory nested below that same root. On every later run, the previously generated aggregate matched the same filename filter as module reports and was merged again.

## Validation

- `mvn -Dtest=SummaryTest test -DskipITs -Dstyle.color=never -ntp` — 3 tests passed
- `mvn clean install -ntp -Dinvoker.skip -Pqulice -e -B -Dstyle.color=never` — 47 tests passed, 1 environment-dependent test skipped; Qulice and JTCOP passed
- the full invoker build was also attempted, but the local Docker installation has neither a running daemon nor the `buildx` plugin required by the integration fixtures; it failed before exercising this summary change

Fixes #783
