### PR TITLE
#788: narrow the item through a filter behind distinct()/skip()

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/505-distill-state-item-cast.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/505-distill-state-item-cast.phr
@@ -34,12 +34,13 @@
 # method), applied at fixpoint — a checkcast it already inserted now sits
 # between the frame and the invoke, so the adjacency does not re-match.
 #
-# Limitation: only the FIRST typed op directly after the (last) guard is
-# reached, which is exactly the boxed()/mapToX-after-distinct/skip shape #649
-# reports. A filter or peek wedged between the guard and the boxing tail opens
-# its body with a dup, breaking the frame → invokestatic adjacency; narrowing
-# through that interleaving is a follow-up puzzle on the same shared-state
-# channel.
+# Scope: only the FIRST typed op directly after the (last) guard is reached,
+# which is exactly the boxed()/mapToX-after-distinct/skip shape #649 reports. A
+# filter wedged between the guard and the typed tail opens its body with a dup
+# (spliced by 283, or by 431 after a fuse), breaking the frame → invokestatic
+# adjacency this rule anchors on; 508 is the twin that matches that
+# interleaving and casts in front of the dup, so both copies of the item are
+# narrowed (#788).
 name: distill-state-item-cast
 pattern: |
   ⟦

--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/508-distill-state-item-cast-dup.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/508-distill-state-item-cast-dup.phr
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The dup-tolerant twin of 505, closing the follow-up its header leaves open
+# (#788). 505 narrows the erased Object item that a distinct()/skip()-led
+# pipeline carries, by splicing a `checkcast` between the stateful guard's
+# keep-frame and the first body opcode that consumes the item as a NARROWER
+# reference; it anchors on a Φ.jeo.frame IMMEDIATELY followed by an
+# invokestatic. A filter riding the same pipeline breaks that adjacency: 283
+# splices a Φ.hone.dup in front of a filter that follows a stateful guard (431
+# does the same after a fuse), because the predicate eats the item and the keep
+# path needs a copy — and a peek, whose body 309 shapes as `dup` + the consumer
+# invocation, arrives with the very same opening. The joined body therefore
+# reads frame → dup → invokestatic, 505 does not match, no cast is spliced, and
+# the Object item reaches the desugared predicate — typed (Ljava/lang/String;)Z
+# for a String element. The verifier rejects the class with "Bad type on
+# operand stack: Type 'java/lang/Object' is not assignable to
+# 'java/lang/String'". The guard above is untouched by this: Set.add(Object)
+# and the skip counter are happy with an Object, only the first typed consumer
+# is not — and `distinct().filter(...)` is ordinary code, not an exotic shape.
+#
+# This rule matches exactly that interleaving and keeps 505's splice point: the
+# cast goes right after the frame, BEFORE the dup, so BOTH copies of the item
+# are narrowed — the one the predicate consumes and the one that survives on
+# the keep path into the rest of the fused body. The frame itself stays as it
+# is: the cast runs after it, so it still rightly declares Object, and 503 is
+# left unchanged, exactly as in 505.
+#
+# The `when` guard is 505's: bridge-input must be Object (the distinct / skip
+# element-erasure signature) and the following invokestatic must take a SINGLE
+# non-Object reference argument, so an Object-accepting predicate is left alone
+# and a captured lambda$ (which takes the captured values plus the item) is
+# skipped. Only the one-slot `dup` is tolerated — the two-slot `dup2` that 283
+# picks for a primitive item cannot occur here, since an Object bridge-input
+# means the item is a reference. It runs after 503 (which turns the keep
+# label's frame-item into a Φ.jeo.frame) and before 512 (which wraps the
+# distill-lambda body into a method), applied at fixpoint: the checkcast it
+# inserts now sits between the frame and the dup, so neither this rule nor 505
+# re-matches the same site.
+name: distill-state-item-cast-dup
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ 𝑒-static,
+    bridge-input ↦ "Ljava/lang/Object;",
+    consumer ↦ 𝑒-consumer,
+    target-method ↦ 𝑒-target-method,
+    captured ↦ 𝑒-captured,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-frame ↦ ⟦ φ ↦ Φ.jeo.frame, 𝐵-frame-rest ⟧,
+      𝜏-dup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+      𝜏-invoke ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokestatic,
+        i2 ↦ 𝑒-invoke-class,
+        i3 ↦ 𝑒-invoke-method,
+        i4 ↦ 𝑒-invoke-signature,
+        i5 ↦ 𝑒-invoke-is-interface
+      ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ 𝑒-static,
+    bridge-input ↦ "Ljava/lang/Object;",
+    consumer ↦ 𝑒-consumer,
+    target-method ↦ 𝑒-target-method,
+    captured ↦ 𝑒-captured,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-frame ↦ ⟦ φ ↦ Φ.jeo.frame, 𝐵-frame-rest ⟧,
+      𝜏-cast ↦ ⟦ φ ↦ Φ.jeo.opcode.checkcast, i1 ↦ 𝑒-cast-class ⟧,
+      𝜏-dup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+      𝜏-invoke ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokestatic,
+        i2 ↦ 𝑒-invoke-class,
+        i3 ↦ 𝑒-invoke-method,
+        i4 ↦ 𝑒-invoke-signature,
+        i5 ↦ 𝑒-invoke-is-interface
+      ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+when:
+  and:
+    - matches: ['^\(L[^;]+;\)', 𝑒-invoke-signature]
+    - not:
+        matches: ['^\(Ljava/lang/Object;\)', 𝑒-invoke-signature]
+where:
+  - meta: 𝜏-cast
+    function: random-tau
+  - meta: 𝑒-cast-class
+    function: sed
+    args:
+      - 𝑒-invoke-signature
+      - '"s/^\\(L([^;]+);.*/$1/g"'

--- a/src/test/phino/508-distill-state-item-cast-dup.yml
+++ b/src/test/phino/508-distill-state-item-cast-dup.yml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 508 is the dup-tolerant twin of 505 (#788). A filter fused behind a
+# distinct/skip guard carries a `dup` in front of its predicate — 283 splices
+# it so the predicate has a throwaway copy to eat and the keep path still sees
+# the item — so after 503 has resolved the guard's keep-label into a
+# Φ.jeo.frame the body reads frame → dup → invokestatic, and 505 (which anchors
+# on frame → invokestatic) does not fire. The item is still the erased
+# Ljava/lang/Object; a distinct/skip-led distill carries, while the desugared
+# predicate takes (Ljava/lang/String;)Z, so without a cast the class fails
+# verification with "Bad type on operand stack". This rule splices
+# `checkcast java/lang/String` between the frame and the dup, so BOTH copies
+# are narrowed. The frame is untouched — it correctly still declares Object,
+# because the cast runs after it.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-state-frame.phr
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/508-distill-state-item-cast-dup.phr
+input: |
+  ⟦
+    body ↦ ⟦
+      op1 ↦ ⟦
+        φ ↦ Φ.hone.distill-lambda,
+        static ↦ "true",
+        bridge-input ↦ "Ljava/lang/Object;",
+        consumer ↦ "Ljava/util/function/Consumer;",
+        target-method ↦ "distill_0",
+        captured ↦ "Ljava/util/List;",
+        body ↦ ⟦
+          g1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/util/HashSet" ⟧,
+          g2 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+          g3 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+          g4 ↦ ⟦
+            φ ↦ Φ.jeo.opcode.invokestatic,
+            i2 ↦ "A",
+            i3 ↦ "lambda$main$0",
+            i4 ↦ "(Ljava/lang/String;)Z",
+            i5 ↦ Φ.false
+          ⟧,
+          ρ ↦ ∅
+        ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+expected:
+  - ⟦ φ ↦ Φ.jeo.opcode.checkcast, i1 ↦ "java/lang/String" ⟧
+  - ⟦ 𝐵-p, 𝜏-f ↦ ⟦ φ ↦ Φ.jeo.frame, 𝐵-fr ⟧, 𝜏-c ↦ ⟦ φ ↦ Φ.jeo.opcode.checkcast, i1 ↦ "java/lang/String" ⟧, 𝜏-d ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧, 𝜏-i ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, 𝐵-x, i3 ↦ "lambda$main$0", 𝐵-y ⟧, 𝐵-q ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/stateful-filter-tail.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/stateful-filter-tail.yml
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A filter riding a pipeline that a distinct() or a skip() leads — the shape
+# #788 reports. distinct and skip erase the element type, so the fused stateful
+# distill carries bridge-input ↦ Ljava/lang/Object; and 503 frames the guard's
+# keep-label as Object; the filter behind it opens with a `dup` (283 splices it
+# so the predicate has a copy to eat and the keep path still sees the item) and
+# then invokes the desugared predicate, an (Ljava/lang/String;)Z handle for a
+# String element. That dup breaks the frame → invokestatic adjacency 505
+# anchors on, so before 508 no cast was spliced, the erased Object reached the
+# predicate, and the optimized class died in the verifier with "Bad type on
+# operand stack: Type 'java/lang/Object' is not assignable to
+# 'java/lang/String'". 508 now splices a `checkcast java/lang/String` between
+# the frame and the dup, narrowing BOTH copies of the item — the one the
+# predicate consumes and the one that survives on the keep path.
+#
+# Both pipelines the issue reports are here, one per stateful head:
+#   * distinct-led — takeWhile() is a fusion barrier (short-circuiting, never
+#     fused), so distinct heads the fused run: distinct + filter + map collapse
+#     into one mapMulti. of("alpha","beta","alpha") -> distinct -> alpha, beta
+#     -> all non-empty -> upper-cased -> findFirst = ALPHA.
+#   * skip-led — skip(1) drops 1.5, mapToObj stringifies the rest, distinct
+#     heads the fused run again: "2.25", "1.5" -> length > 3 keeps "2.25" only,
+#     count = 1.
+# The `after` counts are left unasserted on purpose: this pack exists to prove
+# the optimized class VERIFIES and still computes the right answer, which the
+# printed line asserts end to end.
+java: |
+  package statefulfiltertail;
+  import java.util.stream.DoubleStream;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      String first = Stream.of("alpha", "beta", "alpha")
+        .takeWhile(s -> s.length() < 12)
+        .distinct()
+        .filter(s -> !s.isEmpty())
+        .map(String::toUpperCase)
+        .findFirst()
+        .orElse("none");
+      long kept = DoubleStream.of(1.5, 2.25, 1.5)
+        .skip(1L)
+        .mapToObj(Double::toString)
+        .distinct()
+        .filter(s -> s.length() > 3)
+        .count();
+      System.out.printf("The result is %s/%d\n", first, kept);
+    }
+  }
+# The production default grep-in (see #449/#671/#705) would already select this
+# class via its `filter`, `map` and `distinct` tokens, but the pack opts the
+# pre-filter off with `.*` so it stays decoupled from the exact set of method
+# names the default happens to include.
+grep-in: ".*"
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is ALPHA/1"


### PR DESCRIPTION
Closes #788.

## The gap

`505-distill-state-item-cast` anchors the narrowing `checkcast` on a `Φ.jeo.frame` **immediately** followed by an `invokestatic`. When a `filter(...)` rides a pipeline that `distinct()` or `skip()` leads, that adjacency never holds: `283-insert-dup-before-filter-after-stateful` (or `431-dup-before-filter-distill` after a fuse) has already put a `dup` in front of the predicate, so the joined body reads `frame → dup → invokestatic`. 505 does not match, no cast is spliced, and the erased `Object` item reaches the desugared predicate — typed `(Ljava/lang/String;)Z` for a `String` element — so the verifier rejects the class with `Bad type on operand stack: Type 'java/lang/Object' is not assignable to 'java/lang/String'`.

## The fix

A new rule `508-distill-state-item-cast-dup` — the dup-tolerant twin of 505 — matches exactly that interleaving and keeps 505's splice point: the cast goes right after the frame, **before** the dup, so both copies of the item are narrowed, the one the predicate consumes and the one that survives on the keep path. The frame is untouched (it correctly still declares `Object`, since the cast runs after it), so 503 is unchanged.

Guards are 505's, unchanged: `bridge-input` must be `Ljava/lang/Object;` (the distinct/skip element-erasure signature) and the invoke must take a single non-`Object` reference argument, which leaves an `Object`-accepting predicate alone and skips a captured `lambda$` (it takes the captured values plus the item). Only the one-slot `dup` is tolerated — the two-slot `dup2` that 283 picks for a primitive item cannot occur under an `Object` `bridge-input`. A `peek` behind a stateful guard has the same `dup` + invoke opening (`309-peek-to-distill`), so it is covered by the same pattern.

`508` sits after `503` (which turns the keep label's `frame-item` into a `Φ.jeo.frame`) and before `511`/`512` (which wrap the body into a method). At fixpoint the inserted checkcast sits between the frame and the dup, so neither 508 nor 505 re-matches the same site.

## Changes

- `src/main/resources/org/eolang/hone/rules/streams/5xx/508-distill-state-item-cast-dup.phr` — the new rule.
- `src/main/resources/org/eolang/hone/rules/streams/5xx/505-distill-state-item-cast.phr` — header only: the "Limitation" paragraph that left this as an open puzzle now points at 508.
- `src/test/phino/508-distill-state-item-cast-dup.yml` — single-rule pack: `503` + `508` over a body shaped `fetch, frame-item, dup, invokestatic (Ljava/lang/String;)Z`, asserting the `checkcast java/lang/String` lands between the frame and the dup.
- `src/test/resources/org/eolang/hone/optimize/streams/stateful-filter-tail.yml` — end-to-end fixture with both shapes the issue reports (the `takeWhile().distinct().filter().map().findFirst()` one and the `skip(1).mapToObj().distinct().filter().count()` one) in a single class; it asserts the optimized class verifies and still prints `The result is ALPHA/1`. `after` opcode counts are deliberately left unasserted — the point of the pack is that the class verifies and computes the right answer.

Note that `full-non-terminal.yml` already chains `.distinct().skip(0L).filter(...)` and passes today: it leads with a typed `filter`/`map`, which pins `bridge-input` to the wrapper, so no narrowing is needed. That is why the shape stayed latent, and why the new fixture leads with the stateful operator.

## Verification — please read

`mvn test` (non-deep) is green locally: 47 tests, `RulesTest` included. **The two new tests have not been executed anywhere yet**, and this PR's checks will not execute them either:

- Both live under the `deep` profile, and `.github/workflows/deep.yml` triggers only on `push` to `master` — not on pull requests.
- The sandbox this was written in has neither a `phino` binary nor a working Docker daemon (and the egress policy blocks the phino release downloads), so `mvn -Pdeep test` could not be run here at all.

So the rule is reasoned from the pipeline (503 → the fused body's `frame → dup → invokestatic`, mirroring 505's shape exactly) rather than observed firing. Worth a local `mvn -Pdeep test` — or at least `phino rewrite --rule .../508-distill-state-item-cast-dup.phr` on a `.phi` from the new fixture — before merging. Keeping it as a draft for that reason.