### PR TITLE
fix(#787): bump the caller max-stack in 502 for the spliced state prologue

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/502-distill-state-to-mapMulti.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/502-distill-state-to-mapMulti.phr
@@ -17,6 +17,26 @@
 # It fires only when the state block carries at least one opcode (the
 # leading 𝜏-state-first binding), which is exactly what keeps 501 —
 # matching an empty state — on the stateless path.
+#
+# The spliced prologue is DEEPER than the dispatch it replaces, so the caller's
+# declared max-stack has to grow with it (issue #787). javac sized max_stack for
+# the unfused invokeinterface chain — usually just [stream, function] — while the
+# prologue peaks well above that: with the source stream already on the stack the
+# `new`/`dup` pair alone reaches two cells above it, 307's append (dup;
+# newKeySet; List.add; pop) three, and 308's (the long[1] seed, two slots per
+# push) six. jeo never recomputes maxs — BytecodeMaxs.compute() gives up unless
+# BOTH maxs are -1, which never holds for a method disassembled from an existing
+# class, so BytecodeMethod.write re-emits whatever number was there — and no
+# later rule repairs it either; the "bounded peak" 307 and 308 talk about is
+# their own, not a DECLARED one. Left alone the class dies at load with
+# "Exceeded max stack size". So, exactly as 112 does for its relocated boxing
+# append, this rule splits `maxs` out of 𝐵-method-head and BUMPS max-stack by 6:
+# six covers the deepest state append (308's), the peak of every append is
+# measured from the same [.. stream, list] base no matter how many operators 401
+# fused, and over-allocating max_stack is always verifier-safe. jeo names the two
+# maxs bindings "m1" (max-stack) and "m2" (max-locals), so they are matched by
+# those literal names — a 𝜏- metavariable used as a binding NAME no longer binds
+# to a scalar value (see 112).
 name: distill-state-to-mapMulti
 pattern: |
   ⟦
@@ -30,7 +50,13 @@ pattern: |
     𝐵-class-head-after,
     𝜏-method ↦ ⟦
       φ ↦ Φ.jeo.method,
-      𝐵-method-head,
+      𝐵-method-head-before,
+      maxs ↦ ⟦
+        φ ↦ Φ.jeo.maxs,
+        m1 ↦ 𝑒-max-stack,
+        m2 ↦ 𝑒-max-locals
+      ⟧,
+      𝐵-method-head-after,
       body ↦ ⟦
         𝐵-body-head,
         𝜏-distill ↦ ⟦
@@ -68,7 +94,13 @@ result: |
     𝐵-class-head-after,
     𝜏-method ↦ ⟦
       φ ↦ Φ.jeo.method,
-      𝐵-method-head,
+      𝐵-method-head-before,
+      maxs ↦ ⟦
+        φ ↦ Φ.jeo.maxs,
+        m1 ↦ 𝑒-bumped-stack,
+        m2 ↦ 𝑒-max-locals
+      ⟧,
+      𝐵-method-head-after,
       body ↦ ⟦
         𝐵-body-head,
         𝜏-new-list ↦ ⟦ φ ↦ Φ.jeo.opcode.new, i1 ↦ "java/util/ArrayList" ⟧,
@@ -114,6 +146,14 @@ result: |
     ρ ↦ ∅
   ⟧
 where:
+  # Six is the peak of the deepest state append, 308's: from [.. list] it goes
+  # iconst_1, newarray, dup, iconst_0, <2-slot count push> before lastore
+  # collapses it back. 307's is three and the leading new/dup pair is two, so one
+  # bump covers them all, however many appends 401 fused into this distill —
+  # every append starts and ends at [.. list].
+  - meta: 𝑒-bumped-stack
+    function: sum
+    args: [𝑒-max-stack, '6']
   - meta: 𝜏-distill-lambda
     function: random-tau
   - meta: 𝜏-new-list

--- a/src/test/phino/502-distill-state-to-mapMulti.yml
+++ b/src/test/phino/502-distill-state-to-mapMulti.yml
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A stateful distill — one whose `state` block carries at least one opcode, here
+# the distinct append 307 produces — is lowered to a Φ.hone.mapMulti with a
+# java/util/List captured into the wrapper, and the ArrayList prologue plus the
+# relocated state opcodes are spliced into the CALLER, ahead of the dispatch.
+# That prologue is deeper than the invokeinterface chain javac sized max_stack
+# for, and jeo never recomputes maxs, so the rule bumps the caller's declared
+# max-stack by 6 — from 2 to 8 here — to make room for it (issue #787). Six
+# covers the deepest state append, 308's two-slot long[1] seed. max-locals (3) is
+# untouched, and the caller's other head bindings ride through unchanged.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/502-distill-state-to-mapMulti.phr
+input: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    version ↦ 68,
+    access ↦ 33,
+    modifiers ↦ ⟦ φ ↦ Φ.jeo.modifiers, interface ↦ Φ.false, static ↦ Φ.false ⟧,
+    name ↦ "Foo",
+    supername ↦ "java/lang/Object",
+    interfaces ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+    m$run ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      access ↦ 8,
+      modifiers ↦ ⟦ φ ↦ Φ.jeo.modifiers, static ↦ Φ.true ⟧,
+      name ↦ "run",
+      descriptor ↦ "(Ljava/util/List;)J",
+      signature ↦ "",
+      exceptions ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      maxs ↦ ⟦ φ ↦ Φ.jeo.maxs, m1 ↦ 2, m2 ↦ 3 ⟧,
+      params ↦ ⟦ φ ↦ Φ.jeo.params ⟧,
+      annotations ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      body ↦ ⟦
+        i20 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, v0 ↦ 0 ⟧,
+        i21 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/Collection", v1 ↦ "stream", v2 ↦ "()Ljava/util/stream/Stream;", v3 ↦ Φ.true ⟧,
+        i22 ↦ ⟦
+          φ ↦ Φ.hone.distill,
+          class ↦ "Foo",
+          bridge-input ↦ "Ljava/lang/Object;",
+          bridge-output ↦ "Ljava/lang/Object;",
+          start ↦ "distinct",
+          accepted ↦ "Ljava/lang/Object;",
+          returned ↦ "Ljava/lang/Object;",
+          static ↦ "true",
+          state ↦ ⟦
+            s1 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+            s2 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "java/util/concurrent/ConcurrentHashMap", i3 ↦ "newKeySet", i4 ↦ "()Ljava/util/concurrent/ConcurrentHashMap$KeySetView;", i5 ↦ Φ.false ⟧,
+            s3 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/List", i3 ↦ "add", i4 ↦ "(Ljava/lang/Object;)Z", i5 ↦ Φ.true ⟧,
+            s4 ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+            ρ ↦ ∅
+          ⟧,
+          body ↦ ⟦
+            b1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/util/concurrent/ConcurrentHashMap$KeySetView" ⟧,
+            b2 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧
+          ⟧
+        ⟧,
+        i23 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, v0 ↦ "java/util/stream/Stream", v1 ↦ "count", v2 ↦ "()J", v3 ↦ Φ.true ⟧,
+        i24 ↦ ⟦ φ ↦ Φ.jeo.opcode.lreturn ⟧
+      ⟧,
+      trycatchblocks ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+      local-variable-table ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧
+    ⟧
+  ⟧
+expected:
+  - ⟦ φ ↦ Φ.jeo.maxs, m1 ↦ 8, m2 ↦ 3 ⟧
+  - ⟦ 𝐵-a, 𝜏-new ↦ ⟦ φ ↦ Φ.jeo.opcode.new, i1 ↦ "java/util/ArrayList" ⟧, 𝐵-b ⟧
+  - ⟦ 𝐵-c, 𝜏-set ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "java/util/concurrent/ConcurrentHashMap", i3 ↦ "newKeySet", i4 ↦ "()Ljava/util/concurrent/ConcurrentHashMap$KeySetView;", i5 ↦ Φ.false ⟧, 𝐵-d ⟧
+  - ⟦ φ ↦ Φ.hone.mapMulti, 𝐵-e, captured ↦ "Ljava/util/List;", 𝐵-f ⟧
+  - ⟦ φ ↦ Φ.hone.distill-lambda, 𝐵-g, captured ↦ "Ljava/util/List;", 𝐵-h ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/maxstack.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/maxstack.yml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Regression for #787: the caller's DECLARED max-stack must grow with the state
+# prologue 502 splices in front of the dispatch.
+#
+# The pipeline lives in its own method, whose only stack traffic is the chain
+# itself, so javac sizes max_stack at just 2 — [stream, function] at the map's
+# invokedynamic. That is the tightest possible declaration, and every earlier
+# stateful fixture hides the bug behind a roomier one: `Stream.of(1, 2, ...)`
+# builds its varargs array with dup/index/box before each aastore and so declares
+# 4 or more all by itself.
+#
+# 216 -> 307 folds the distinct into a stateful distill, 401 fuses the preceding
+# map into it, and 502 lowers the pair to one Stream.mapMulti — splicing `new
+# java/util/ArrayList`, `dup`, `invokespecial <init>` and the relocated seen-set
+# append ahead of the dispatch, with the source stream already on the stack. That
+# prologue peaks at 4, two cells above what javac declared. jeo re-emits maxs
+# verbatim (BytecodeMaxs.compute() only fires when both are -1, never true for a
+# disassembled method), so before the fix the class died at load with
+# "VerifyError: Exceeded max stack size" and the run never printed anything —
+# hence "BUILD SUCCESS" and the result line are the assertion that matters here.
+#
+# [1, 2, 2, 3] --map(+1)--> [2, 3, 3, 4] --distinct--> [2, 3, 4] --count()--> 3.
+# `new` goes 0 -> 1: the one allocation is the ArrayList holding the captured
+# state, which is also the proof that 502 fired at all (the seen-set itself comes
+# from the static ConcurrentHashMap.newKeySet() factory, not from a `new`).
+java: |
+  package maxstack;
+  import java.util.List;
+  public class X {
+    static long count(List<Integer> list) {
+      return list.stream().map(x -> x + 1).distinct().count();
+    }
+    public static void main(String[] a) {
+      System.out.printf("The result is %d\n", count(List.of(1, 2, 2, 3)));
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 3"
+before:
+  new: 0
+after:
+  new: 1


### PR DESCRIPTION
Closes #787.

`502-distill-state-to-mapMulti.phr` splices `new java/util/ArrayList`, `dup`, `invokespecial <init>` and the relocated `state` opcodes into the caller ahead of the fused dispatch, while the caller's `Φ.jeo.maxs` formation travelled untouched through `𝐵-method-head`. The declared `max_stack` stayed at whatever `javac` sized for the unfused `invokeinterface` chain, and nothing downstream repairs it — `BytecodeMaxs.compute()` returns true only when both maxs are `-1`, never the case for a method disassembled from an existing class, so `BytecodeMethod.write` re-emits the stale number verbatim. The class then dies at load with `VerifyError: Operand stack overflow — Exceeded max stack size`.

## The fix

112's, applied to 502: split `maxs` out of `𝐵-method-head` in both the pattern and the result, and bind `m1` to `sum(𝑒-max-stack, 6)`.

Six is the peak of the deepest state append, 308's: from `[.. list]` it goes `iconst_1`, `newarray`, `dup`, `iconst_0`, then the two-slot count push before `lastore` collapses it back. 307's peaks at three and the leading `new`/`dup` pair at two, so one bump covers them all however many operators 401 fused into the distill — every append starts and ends at `[.. list]`. Over-allocating `max_stack` is always verifier-safe.

## Tests

* `src/test/phino/502-distill-state-to-mapMulti.yml` — single-rule pack asserting the 2 → 8 bump, the spliced prologue and the relocated append.
* `src/test/resources/org/eolang/hone/optimize/streams/maxstack.yml` — end-to-end. Its pipeline lives in its own method, so `javac` declares a `max_stack` of just 2; every existing stateful fixture hides the bug behind the roomier declaration that building a `Stream.of(...)` varargs array forces, which is why 38 e2e packs never caught this.

Verified against the pinned phino 0.0.106 (lifted out of `yegor256/hone:latest`, so no Docker fallback was needed):

* all 64 single-rule packs pass, including the new one;
* the new e2e fixture passes with the fix, and reverting only the `.phr` reproduces `java.lang.VerifyError: Operand stack overflow — Exceeded max stack size` — so it is a genuine regression test for #787;
* the rest of `mvn -Pdeep test` is unchanged. Two e2e packs (`all-ops.yml`, `stateful-ops.yml`) and five Docker-image-building tests do fail in the sandbox used to verify this, but the two packs emit byte-identical opcode tallies with and without the change, and the five build failures are `wget` inside the image build not reaching `archive.apache.org` through the sandbox proxy. Worth a look at the deep job on merge to confirm those two packs are green on the real runner.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PEfFHcZRfSPieSyThjzT1j)_