### PR TITLE
fix(#790): give a filter behind peek() its guard dup

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/2xx/281-insert-dup-before-filter.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/2xx/281-insert-dup-before-filter.phr
@@ -2,6 +2,20 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
+# A filter guard consumes the item with its predicate, so it needs a
+# throwaway copy duplicated in front of it. This rule splices that
+# Φ.hone.dup between a point-wise producer and the filter that follows it.
+#
+# `peek` belongs in the producer list next to `map` and the two filters
+# (see #790). A peek forwards the element unchanged, so it looks pointwise
+# to 401-fuse, but its own body spends the `dup` that 309 emits on the void
+# Consumer call and hands the next stage a single item — exactly what a map
+# or a filter hands over. Without this rule a `.peek(...).filter(...)` pair
+# reached 4xx with no guard at all, 401 fused it into a distill that
+# inherited the HEAD's `start ↦ "peek"`, and 431 — which only ever sees
+# `start ↦ "filter"` — could no longer put the guard in. The predicate then
+# ate the only item and the keep label was reached with an empty stack,
+# against a frame promising the element: VerifyError at link time.
 name: insert-dup-before-filter
 pattern: |
   ⟦
@@ -68,6 +82,7 @@ when:
         - eq: [𝜏-one, 'map']
         - eq: [𝜏-one, 'o-filter']
         - eq: [𝜏-one, 'p-filter']
+        - eq: [𝜏-one, 'peek']
     - or:
         - eq: [𝜏-two, 'o-filter']
         - eq: [𝜏-two, 'p-filter']

--- a/src/test/phino/281-insert-dup-before-filter-after-peek.yml
+++ b/src/test/phino/281-insert-dup-before-filter-after-peek.yml
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A filter that directly follows a PEEK must get its guard `dup` spliced in
+# between the two, exactly like a filter that follows a map (#790).
+#
+# A peek forwards its element unchanged, so to 401-fuse it looks as pointwise
+# as a map — but 309 gives its body a `dup` that the void Consumer call spends,
+# so the filter behind it receives a single item and its predicate would eat
+# it. Before this rule covered `peek`, the pair reached 4xx unguarded, 401
+# fused it into a distill carrying the head's `start ↦ "peek"`, and 431 (which
+# only matches `start ↦ "filter"`) could never insert the guard afterwards.
+#
+# The dup opcode is chosen from the peek's `returned`, a reference type here,
+# so it is the one-slot `dup` rather than `dup2`. After the insertion the peek
+# and the filter are no longer adjacent, so the rule fires exactly once.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/2xx/281-insert-dup-before-filter.phr
+input: |
+  ⟦
+    body ↦ ⟦
+      op1 ↦ ⟦
+        φ ↦ Φ.hone.peek,
+        opcode ↦ "invokestatic",
+        class ↦ "peek/X",
+        bridge-input ↦ "Ljava/lang/Long;",
+        bridge-output ↦ "Ljava/lang/Long;",
+        accepted ↦ "Ljava/lang/Long;",
+        returned ↦ "Ljava/lang/Long;",
+        static ↦ "true",
+        target ↦ ⟦
+          handle ↦ 6,
+          class ↦ "peek/X",
+          method ↦ "lambda$main$0",
+          signature ↦ "(Ljava/lang/Long;)V",
+          is-interface ↦ Φ.false
+        ⟧
+      ⟧,
+      op2 ↦ ⟦
+        φ ↦ Φ.hone.p-filter,
+        opcode ↦ "invokestatic",
+        class ↦ "peek/X",
+        bridge-input ↦ "Ljava/lang/Long;",
+        bridge-output ↦ "Ljava/lang/Long;",
+        accepted ↦ "Ljava/lang/Long;",
+        returned ↦ "Ljava/lang/Long;",
+        static ↦ "true",
+        target ↦ ⟦
+          handle ↦ 6,
+          class ↦ "peek/X",
+          method ↦ "lambda$main$1",
+          signature ↦ "(Ljava/lang/Long;)Z",
+          is-interface ↦ Φ.false
+        ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+expected:
+  - ⟦ 𝐵-head, 𝜏-peek ↦ ⟦ φ ↦ Φ.hone.peek, 𝐵-peek ⟧, 𝜏-dup ↦ ⟦ φ ↦ Φ.hone.dup, opcode ↦ "dup", class ↦ "peek/X" ⟧, 𝜏-filter ↦ ⟦ φ ↦ Φ.hone.p-filter, 𝐵-filter ⟧, 𝐵-tail ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/peek-filter.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/peek-filter.yml
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A `.peek(...)` immediately followed by a `.filter(...)` — the shape that used
+# to produce a class the JVM refused to load (#790).
+#
+# Both operators are point-wise, so 401 fuses them into a single distill and the
+# whole pipeline lowers to ONE Stream.mapMulti: invokedynamic drops from 3 (peek
+# lambda + filter lambda + Long::sum) to 2 (the fused mapMulti + the untouched
+# reduce accumulator).
+#
+# The fused body needs TWO guard copies of the element, one per consumer that
+# eats it: 309 emits the peek's `dup` for the void Consumer call, and 281 splices
+# the filter's own `dup` in front of the predicate. Before 281 covered `peek` as
+# a predecessor the second one was never emitted — 401 gave the fused distill the
+# head's `start ↦ "peek"`, so 431, which only matches `start ↦ "filter"`, could
+# not add it afterwards. The predicate then consumed the only copy and the keep
+# label was reached with an empty stack against a frame promising the element:
+# `VerifyError: Inconsistent stackmap frames at branch target`. The `dup` tally
+# (6 -> 8, both new ones inside the synthesised distill) pins that guard down,
+# and the printed line proves the class loads and the pipeline still computes
+# what javac's version computed.
+#
+#   [5,3,6,11] --peek(SUM += n)--> (forwarded unchanged, SUM == 25)
+#              --filter(even)--> [6] --reduce(0, Long::sum)--> 6
+java: |
+  package peek;
+  import java.util.stream.*;
+  public class PeekFilter {
+    private static final long[] SUM = new long[1];
+    public static void main(String[] args) {
+      long n = Stream.of(5L, 3L, 6L, 11L)
+        .peek(x -> SUM[0] += x)
+        .filter(x -> x % 2L == 0L)
+        .reduce(0L, Long::sum);
+      System.out.printf("The result is %d, after peeking %d%n", n, SUM[0]);
+    }
+  }
+log:
+  - "Modified 1/1 PeekFilter.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 6, after peeking 25"
+before:
+  invokedynamic: 3
+  invokeinterface: 3
+  dup: 6
+  ifne: 1
+after:
+  invokedynamic: 2
+  invokeinterface: 3
+  dup: 8
+  ifne: 2


### PR DESCRIPTION
Closes #790.

## The defect

`281-insert-dup-before-filter.phr` splices the filter's guard `dup` in only when
the filter follows a `map` or another `filter`. `peek` was missing from that
list, so a `.peek(...).filter(...)` pair reached `4xx` with no guard at all,
`401-fuse` folded it into a distill carrying the *head's* `start ↦ "peek"`, and
`431-dup-before-filter-distill` — which only matches `start ↦ "filter"` — could
no longer put the guard in. The only `dup` left in the body was the one
`309-peek-to-distill` emits for the peek, and the void `Consumer` spent it: the
predicate consumed the only copy of the element and the keep label was reached
with an empty stack against a frame promising the element.

Reproduced exactly as reported, on the pipeline from the issue:

```
java.lang.VerifyError: Inconsistent stackmap frames at branch target 12
  Location: repro/X.distill_5019480(Ljava/lang/Long;Ljava/util/function/Consumer;)V @8: ifne
  Reason: Current frame's stack size doesn't match stackmap.
```

## The fix

A peek forwards its element unchanged and hands the next stage exactly one item —
the same contract a map or a filter hands over — so it belongs in `281`'s
producer list. One line in the `when` clause, plus a comment block recording why.

The synthesised distill body now carries both copies, one per consumer that eats
the element:

```
aload_0; dup; invokestatic lambda$main$0   <- peek's dup, spent by the void Consumer
         dup; invokestatic lambda$main$1   <- the filter's guard, spent by the predicate
         ifne 13; return; 13: aload_1; dup_x1; pop; Consumer.accept; return
```

The class loads, prints the same result javac's version prints, and the pipeline
still collapses into a single `Stream.mapMulti` — invokedynamic drops 3 → 2, so
the fix costs no optimization.

## Why not the `401` guard suggested in the issue

The issue's first suggestion — `when: not: matches: ['^filter$', 𝑒-second-start]`
on `401-fuse` — would double-guard every case that already works. For
`.map(...).filter(...)` the `Φ.hone.dup` pragma is *already* spliced in at `2xx`,
so blocking `401` from fusing into a filter-start distill would leave that distill
in place for `431` to prepend a *second* `dup`, unbalancing the stack the other
way. Closing the hole at `281` keeps a single mechanism: every filter body carries
exactly one guard, minted by `281`/`282`/`283` when it has a predecessor, by `431`
when it is the pipeline head, and by `314` itself when it is capturing.

## Tests

- `src/test/phino/281-insert-dup-before-filter-after-peek.yml` — single-rule pack
  pinning the `Φ.hone.dup` insertion between a peek and the filter behind it.
- `src/test/resources/org/eolang/hone/optimize/streams/peek-filter.yml` —
  end-to-end fixture for the issue's pipeline. Asserts the runtime line (the
  class would not even load before), the `dup` tally 6 → 8 (both new ones inside
  the synthesised distill), and invokedynamic 3 → 2 to prove the pair still fuses.

Verified with `mvn -Pdeep test` against phino 0.0.106 on JDK 21 (matching the
`deep` workflow). All 66 single-rule packs pass, and all 41 end-to-end fixtures
run — the new one among them.

Two pre-existing failures showed up in my sandbox and are **not** from this
change: the after-stage opcode counts in `all-ops.yml` and `stateful-ops.yml`.
I confirmed they are unrelated by measuring both classes with and without the
one-line rule change — the opcode tallies come out byte-identical, so the
expectations in those two fixtures are simply stale against current `master`.
Five further errors are environmental: tests that force `alwaysWithDocker` cannot
build the image here because the sandbox blocks the Maven tarball download from
`archive.apache.org`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XoccEBUga9SonPQXB4Vm9g)_