### PR TITLE
fix(#794): frame an object-predicate filter from its predicate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,10 @@ rule, how to test, and what to avoid*.
    places it correctly. Execution order is alphabetical by filename
    (`Collections.sort` in `Rules.discover()`), so the prefix *is* the
    schedule. Check `streams/` for the nearest neighbours before choosing.
+   When the slot you need is between two *consecutive* numbers, reuse the lower
+   one and let the name carry the ordering — the sort is over the whole
+   filename, so `506-distill-filter-frame` < `506-distill-predicate-frame` <
+   `507-distill-filter-frame-fallback` — and say so in the header comment.
 2. **Write the `.phr` file** under
    `src/main/resources/org/eolang/hone/rules/streams/Nxx/` (the `Nxx/`
    subdirectory whose digit matches the rule's hundreds prefix). Start from

--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/506-distill-filter-frame.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/506-distill-filter-frame.phr
@@ -26,10 +26,11 @@
 #     `returned` primitive there (its `accepted` is the wrapper), so `returned`
 #     (= J -> long) names it, while bridge-input would wrongly declare a one-slot
 #     java/lang/Long and fail JVM verification ("Inconsistent stackmap frames").
-# Every other marker — an OBJECT-predicate filter such as a boxed-roundtrip
-# `(Ljava/lang/Integer;)Z`, whose survivor IS bridge-input even though trailing
-# maps make `returned` a different (re-boxed or primitive) type — falls through
-# to 507, which derives from bridge-input. A same-locals-1 frame is enough — a
+# An OBJECT-predicate filter — a boxed-roundtrip `(Ljava/lang/Integer;)Z` or the
+# `(Ljava/lang/String;)Z` left by a type-changing map fused ahead of the filter
+# (#794) — is claimed by `506-distill-predicate-frame`, which reads the survivor
+# off the predicate's own parameter; only a marker with no predicate in front of
+# it reaches 507 and its bridge-input. A same-locals-1 frame is enough — a
 # stateless wrapper owns no per-call counter. Scoped to a distill-lambda WITHOUT
 # `captured`, so stateful keep-labels stay with 503/504.
 name: distill-filter-frame

--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/506-distill-predicate-frame.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/506-distill-predicate-frame.phr
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Resolves the Φ.hone.frame-item marker that 304 leaves at a STATELESS filter
+# guard's keep-label, for the OBJECT-predicate filters — those whose target
+# signature is `(L<type>;)Z`. The survivor kept at the keep-label is the value
+# the guard's `dup` copied, which is exactly the value handed to the predicate,
+# so the predicate's own parameter type names it.
+#
+# While the filter sits at the head of the distill that type IS the distill's
+# `bridge-input` — 201/232 derive both from the same instantiated SAM type, and
+# 103/104/107 give their synthetic wrappers that very signature — which is why
+# 507 got away with bridge-input for so long. Fusion breaks the identity: when
+# 401 fuses a type-changing map in AHEAD of the filter, the distill's
+# bridge-input becomes the head map's input while the predicate keeps testing
+# the map's output. For `Stream.of(5L, 3L, 6L).map(Object::toString)
+# .filter(s -> !s.isEmpty())` (#794) the distill receives a java/lang/Long, the
+# head `lambda$hone$N:(Ljava/lang/Long;)Ljava/lang/String;` turns it into a
+# java/lang/String, and the stack at the keep-label holds that String — a frame
+# derived from bridge-input declares java/lang/Long and the class fails JVM
+# verification with "Type 'java/lang/String' ... is not assignable to
+# 'java/lang/Long'". The predicate's `(Ljava/lang/String;)Z` names the survivor
+# in both shapes, fused or not.
+#
+# Ordering: 506 claims the PRIMITIVE-predicate markers (#704, #713) and derives
+# them from `returned`; this rule claims the OBJECT-predicate ones; whatever is
+# left — a marker with no predicate in front of it — falls through to the 507
+# fallback and its bridge-input. Since alphabetical filename order IS the
+# schedule and no integer is free between 506 and 507, this rule shares 506's
+# number and relies on `506-distill-filter-frame` < `506-distill-predicate-frame`
+# < `507-distill-filter-frame-fallback`. The two 506 guards are disjoint anyway
+# (primitive vs object predicate signature), so only the position relative to
+# the fallback matters. A same-locals-1 frame is enough — a stateless wrapper
+# owns no per-call counter. Scoped to a distill-lambda WITHOUT `captured`, so
+# stateful keep-labels stay with 503/504.
+name: distill-predicate-frame
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ 𝑒-static,
+    bridge-input ↦ 𝑒-bridge-input,
+    returned ↦ 𝑒-returned,
+    consumer ↦ 𝑒-consumer,
+    target-method ↦ 𝑒-target-method,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-predicate ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokestatic,
+        i2 ↦ 𝑒-predicate-class,
+        i3 ↦ 𝑒-predicate-method,
+        i4 ↦ 𝑒-predicate-signature,
+        i5 ↦ 𝑒-predicate-is-interface
+      ⟧,
+      𝜏-ifne ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ 𝑒-ifne-target ⟧,
+      𝜏-return ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      𝜏-keep-label ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-keep-label ⟧,
+      𝜏-frame ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ 𝑒-static,
+    bridge-input ↦ 𝑒-bridge-input,
+    returned ↦ 𝑒-returned,
+    consumer ↦ 𝑒-consumer,
+    target-method ↦ 𝑒-target-method,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-predicate ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokestatic,
+        i2 ↦ 𝑒-predicate-class,
+        i3 ↦ 𝑒-predicate-method,
+        i4 ↦ 𝑒-predicate-signature,
+        i5 ↦ 𝑒-predicate-is-interface
+      ⟧,
+      𝜏-ifne ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ 𝑒-ifne-target ⟧,
+      𝜏-return ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      𝜏-keep-label ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-keep-label ⟧,
+      𝜏-frame ↦ ⟦
+        φ ↦ Φ.jeo.frame,
+        type ↦ 4,
+        nlocal ↦ 0,
+        locals ↦ ⟦ φ ↦ Φ.jeo.seq.of0 ⟧,
+        nstack ↦ 1,
+        stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, item ↦ 𝑒-frame-item ⟧
+      ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+when:
+  and:
+    - matches:
+        - '^\(L[^;]+;\)Z$'
+        - 𝑒-predicate-signature
+where:
+  - meta: 𝑒-frame-item
+    function: sed
+    args:
+      - 𝑒-predicate-signature
+      - '"s/^\\(L(.+);\\)Z$/$1/g"'

--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/507-distill-filter-frame-fallback.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/507-distill-filter-frame-fallback.phr
@@ -7,17 +7,20 @@
 # frame whose single stack item is the distill's `bridge-input`. This is the
 # right type for every filter whose survivor IS the element it received — the
 # common case — including a pure-primitive LongStream.filter (bridge-input J ->
-# `long`) and an OBJECT-predicate filter whose `(Ljava/lang/Integer;)Z` keeps a
-# wrapper survivor even when trailing maps drive the distill's `returned` to a
-# different (re-boxed or primitive) type (the boxed-roundtrip shape).
+# `long`).
 #
-# Runs AFTER 506, which has already claimed the two PRIMITIVE-predicate shapes
-# whose survivor is not bridge-input (#704 boxed filter, #713 head-fused
-# unboxing map) and resolved their markers from `returned`. Whatever marker 506
-# left untouched lands here, so this rule needs no guard. By 507 the distill is
-# a Φ.hone.distill-lambda (501) whose bridge-input is final and 511 has not yet
-# wrapped it into a method, so the marker never reaches jeo. Scoped to a
-# distill-lambda WITHOUT `captured`, so stateful keep-labels stay with 503/504.
+# Runs AFTER both 506 rules, which have already claimed every marker sitting
+# behind a recognised predicate: `506-distill-filter-frame` takes the two
+# PRIMITIVE-predicate shapes whose survivor is not bridge-input (#704 boxed
+# filter, #713 head-fused unboxing map) and resolves them from `returned`, and
+# `506-distill-predicate-frame` takes the OBJECT-predicate ones and resolves
+# them from the predicate's parameter — the survivor the guard's `dup` copied,
+# which a type-changing map fused ahead of the filter drives away from
+# bridge-input (#794). Whatever marker they left untouched lands here, so this
+# rule needs no guard. By 507 the distill is a Φ.hone.distill-lambda (501) whose
+# bridge-input is final and 511 has not yet wrapped it into a method, so the
+# marker never reaches jeo. Scoped to a distill-lambda WITHOUT `captured`, so
+# stateful keep-labels stay with 503/504.
 name: distill-filter-frame-fallback
 pattern: |
   ⟦

--- a/src/test/phino/506-distill-predicate-frame.yml
+++ b/src/test/phino/506-distill-predicate-frame.yml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Reproduction of #794 at the rule level: a type-changing object map fused in
+# AHEAD of an OBJECT-predicate filter. The distill receives a java/lang/Long
+# (bridge-input), the head `lambda$hone$1:(Ljava/lang/Long;)Ljava/lang/String;`
+# retypes it, the guard's `dup` copies the java/lang/String and the predicate
+# `(Ljava/lang/String;)Z` tests it — so the survivor at the keep-label is a
+# String. 506 declines the marker because the predicate parameter is not a
+# primitive; the object rule claims it and reads java/lang/String off the
+# predicate's signature. Before the fix the marker fell through to the 507
+# fallback, which declared bridge-input (java/lang/Long) and the class failed
+# JVM verification at the branch target.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/506-distill-filter-frame.phr
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/506-distill-predicate-frame.phr
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/507-distill-filter-frame-fallback.phr
+input: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ "true",
+    bridge-input ↦ "Ljava/lang/Long;",
+    returned ↦ "Ljava/lang/String;",
+    consumer ↦ "Ljava/util/function/Consumer;",
+    target-method ↦ "distill_1",
+    body ↦ ⟦
+      i1 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 0 ⟧,
+      i2 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$hone$1", i4 ↦ "(Ljava/lang/Long;)Ljava/lang/String;", i5 ↦ Φ.false ⟧,
+      i3 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+      i4 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$0", i4 ↦ "(Ljava/lang/String;)Z", i5 ↦ Φ.false ⟧,
+      i5 ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L1" ⟧ ⟧,
+      i6 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      i7 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L1" ⟧,
+      i8 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+expected:
+  - ⟦ φ ↦ Φ.jeo.frame, type ↦ 4, 𝐵-e ⟧
+  - ⟦ φ ↦ Φ.jeo.seq.of1, item ↦ "java/lang/String" ⟧

--- a/src/test/phino/507-distill-filter-frame-fallback.yml
+++ b/src/test/phino/507-distill-filter-frame-fallback.yml
@@ -12,6 +12,12 @@
 # primitive, so 507 resolves it from bridge-input (Ljava/lang/Integer; ->
 # java/lang/Integer). Deriving from `returned` here would wrongly declare
 # `double` over a one-slot Integer and fail JVM verification.
+#
+# Only 506 and 507 are listed, so this pack pins the fallback's own derivation.
+# In the full pipeline `506-distill-predicate-frame` reaches this marker first
+# and reads java/lang/Integer off the predicate's `(Ljava/lang/Integer;)Z` —
+# the same type, since nothing is fused ahead of a head filter to move the
+# element away from bridge-input.
 rules:
   - src/main/resources/org/eolang/hone/rules/streams/5xx/506-distill-filter-frame.phr
   - src/main/resources/org/eolang/hone/rules/streams/5xx/507-distill-filter-frame-fallback.phr

--- a/src/test/resources/org/eolang/hone/optimize/streams/map-retype-filter.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/map-retype-filter.yml
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Reproduction of #794: an object map that CHANGES the element type sitting in
+# front of an object-predicate filter. 401 fuses the map in ahead of the filter,
+# so the synthesized distill still receives the pipeline's element
+# (distill_501N(java.lang.Long, java.util.function.Consumer)) while the head
+# `lambda$hone$N:(Ljava/lang/Long;)Ljava/lang/String;` has already retyped it:
+# the guard's `dup` copies a java/lang/String, the predicate
+# `(Ljava/lang/String;)Z` tests it, and the survivor waiting at the keep-label
+# is that String.
+#
+# Before the fix the keep-frame came from 507 (the fallback), which reads the
+# distill's `bridge-input` unconditionally, so it promised a java/lang/Long over
+# a String and the class did not load: "java.lang.VerifyError: Inconsistent
+# stackmap frames at branch target 12 ... Type 'java/lang/String' (current
+# frame, stack[0]) is not assignable to 'java/lang/Long' (stack map, stack[0])".
+# 506 could not have claimed it either — its guard admits only PRIMITIVE
+# predicates. `506-distill-predicate-frame` now resolves such markers from the
+# predicate's own parameter type, which names the survivor whether or not a map
+# was fused ahead of the filter. Keeping the element type identical hides the
+# bug (`.map(n -> n + 1L).filter(n -> n > 0L)` in the same position always ran),
+# which is why every other fixture passed.
+#
+# Both retyping shapes are here, one per pipeline:
+#   * methodref map — Object::toString, desugared by 107 into a wrapper whose
+#     signature is (Ljava/lang/Long;)Ljava/lang/String;. {5, 3, 6} stringified,
+#     none empty, count = 3.
+#   * lambda map — an Integer -> String lambda. {1, 2, 3} become "x", "xx",
+#     "xxx", two of which are longer than one char, count = 2.
+# Each pipeline collapses its map + filter into a single Stream.mapMulti, so
+# invokedynamic drops 4 -> 2; the printed line asserts end to end that the
+# optimized class VERIFIES and still computes the right answer.
+java: |
+  package mapretypefilter;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      long words = Stream.of(5L, 3L, 6L)
+        .map(Object::toString)
+        .filter(s -> !s.isEmpty())
+        .count();
+      long longer = Stream.of(1, 2, 3)
+        .map(n -> "x".repeat(n))
+        .filter(s -> s.length() > 1)
+        .count();
+      System.out.printf("The result is %d/%d\n", words, longer);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 3/2"
+before:
+  invokedynamic: 4
+after:
+  invokedynamic: 2


### PR DESCRIPTION
Closes #794.

## The bug

A type-changing object map fused ahead of an object-predicate filter left the guard's keep-label frame naming the type the distill *received* rather than the one on the stack. For `Stream.of(5L, 3L, 6L).map(Object::toString).filter(s -> !s.isEmpty()).count()` the synthesised `distill_501N(Ljava/lang/Long;Ljava/util/function/Consumer;)V` promised a `java/lang/Long` over the `java/lang/String` the map had produced, and the class did not load:

```
java.lang.VerifyError: Inconsistent stackmap frames at branch target 12
  Location: distill_501918(Ljava/lang/Long;Ljava/util/function/Consumer;)V @12: aload_1
  Reason: Type 'java/lang/String' (current frame, stack[0]) is not assignable to
          'java/lang/Long' (stack map, stack[0])
```

The `Φ.hone.frame-item` marker 304 leaves at the keep-label fell through to `507-distill-filter-frame-fallback`, which resolves it from the distill's `bridge-input` unconditionally; `506-distill-filter-frame` could not claim it because its guard admits only primitive predicates.

## The fix

`506-distill-predicate-frame` matches the same `invokestatic`/`ifne`/`return`/keep-label/marker run as 506, guards on an object predicate signature `(L…;)Z`, and takes the frame item from the predicate's own parameter type. That names the value the guard's `dup` copied whether or not a map was fused ahead — while the filter sits at the head of a distill the predicate parameter *is* `bridge-input` (201/232 derive both from the same instantiated SAM type, and 103/104/107 give their wrappers that signature), and 401 is what breaks the identity. Markers with no predicate in front of them still land on 507 and its `bridge-input`.

Alphabetical filename order is the schedule and no integer is free between 506 and 507, so the rule shares 506's number: `506-distill-filter-frame` < `506-distill-predicate-frame` < `507-distill-filter-frame-fallback`. The two 506 guards are disjoint (primitive vs object predicate), so only the position relative to the fallback matters. Header comments on 506 and 507 and the note in `CLAUDE.md` were updated to say so.

## Tests

* `src/test/phino/506-distill-predicate-frame.yml` — single-rule pack over the #794 shape. With the rule the marker resolves to `java/lang/String`; with only 506 + 507 it resolves to `java/lang/Long`.
* `src/test/resources/org/eolang/hone/optimize/streams/map-retype-filter.yml` — end-to-end fixture with both retyping shapes (an `Object::toString` methodref map and an `Integer -> String` lambda map) in front of object-predicate filters. Each pipeline collapses map + filter into one `Stream.mapMulti`, invokedynamic 4 -> 2.
* `src/test/phino/507-distill-filter-frame-fallback.yml` — comment updated: the pack still pins the fallback's own derivation, and the boxed-roundtrip marker it covers resolves to the same `java/lang/Integer` through the new rule in the full pipeline.

## Verification

Run locally with phino 0.0.106 on the host (no Docker):

* Reproduced first: with the new rule removed, `mvn process-classes` on the fixture's program fails with exactly the `VerifyError` above; with the rule it prints `The result is 3/2` and the keep-frame reads `stack = [ class java/lang/String ]`.
* `mvn test` — 47/47 green.
* `mvn -Pdeep test -Dtest='OptimizeMojoTest#appliesPhinoRulesAsSpecifiedInYamlPack'` — 66/66 packs green.
* End-to-end fixtures: `all-ops` and `stateful-ops` fail their `after` opcode counts in this sandbox, and they do so independently of this change — running the whole rule set over their `.phi` with and without the new rule produces byte-identical output, and both programs still print the right answer. Every other fixture, including the new one, is green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JxhGd6or215fCCHVeUQL6c)_