### PR TITLE
fix(#799): narrow the Object item across a dropWhile latch

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/3xx/310-dropwhile-to-distill.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/3xx/310-dropwhile-to-distill.phr
@@ -37,6 +37,15 @@
 # locals (4 = latch array, 5 = notZ) are dead at KEEP, so 503's four-local frame
 # is still correct; 512's max-locals is widened to 6 to make room for them.
 #
+# The latch prologue (the first six opcodes, up to and including the `ifne`) is
+# spelled out opcode by opcode in 509, which narrows the erased Object item a
+# distinct()/skip() ahead of this dropWhile leaves on the stack (#799): the
+# prologue sits between that guard's keep-frame and the `dup` this body makes
+# for its predicate, so neither 505 nor 508 can reach the typed predicate. Any
+# change to the prologue — its opcodes, their order, or scratch slot 4 — must be
+# mirrored there, or the cast silently stops being spliced and the class fails
+# JVM verification again.
+#
 # v1 scope (see 208): object java/util/stream/Stream, a static predicate whose
 # target returns Z, the element type preserved across any fused neighbours. A
 # lone dropWhile is NOT reverted to a native Stream.dropWhile the way 442 reverts

--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/505-distill-state-item-cast.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/505-distill-state-item-cast.phr
@@ -40,7 +40,9 @@
 # (spliced by 283, or by 431 after a fuse), breaking the frame → invokestatic
 # adjacency this rule anchors on; 508 is the twin that matches that
 # interleaving and casts in front of the dup, so both copies of the item are
-# narrowed (#788).
+# narrowed (#788). A dropWhile wedged there opens with 310's sticky-latch
+# prologue and only then dups, breaking both adjacencies at once; 509 is the
+# third twin, matching that prologue and casting in front of it (#799).
 name: distill-state-item-cast
 pattern: |
   ⟦

--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/508-distill-state-item-cast-dup.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/508-distill-state-item-cast-dup.phr
@@ -38,6 +38,11 @@
 # distill-lambda body into a method), applied at fixpoint: the checkcast it
 # inserts now sits between the frame and the dup, so neither this rule nor 505
 # re-matches the same site.
+#
+# Only a BARE dup is tolerated here. A dropWhile also arrives with a dup in
+# front of its predicate, but 310 puts its sticky-latch prologue between the
+# keep-frame and that dup, so this adjacency does not match either; 509 is the
+# third twin, matching that prologue and casting in front of it (#799).
 name: distill-state-item-cast-dup
 pattern: |
   ⟦

--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/509-distill-state-item-cast-latch.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/509-distill-state-item-cast-latch.phr
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The latch-tolerant third of the 505 family, closing the hole #799 reports.
+# 505 narrows the erased Object item that a distinct()/skip()-led pipeline
+# carries, by splicing a `checkcast` between the stateful guard's keep-frame and
+# the first body opcode that consumes the item as a NARROWER reference; it
+# anchors on a Φ.jeo.frame IMMEDIATELY followed by an invokestatic, and 508 is
+# the twin that tolerates the ONE `dup` a filter or a peek puts in that gap
+# (#788). A dropWhile riding the same pipeline breaks both adjacencies at once:
+# 310 opens its body with the sticky-latch prologue — fetch the captured int[1],
+# stash it in a scratch local, read cell 0 and jump straight to the keep-label
+# when the latch is already set — and only THEN dups the item for the predicate.
+# The joined body therefore reads frame → fetch [I → astore 4 → aload 4 →
+# iconst_0 → iaload → ifne → dup → invokestatic, neither 505 nor 508 matches, no
+# cast is spliced, and the Object item reaches the desugared predicate — typed
+# (Ljava/lang/Long;)Z for a Long element. The verifier rejects the class with
+# "Bad type on operand stack: Type 'java/lang/Object' is not assignable to
+# 'java/lang/Long'". It is not about Long: a String element fails identically,
+# and `distinct().dropWhile(...)` is ordinary code, not an exotic shape. The
+# prologue itself is happy with an Object — it never touches the item, it only
+# reads the latch array — and so is the guard above it (Set.add(Object), the
+# skip counter); only the first typed consumer is not.
+#
+# This rule matches exactly that interleaving and keeps 505's splice point: the
+# cast goes right after the frame, BEFORE the prologue, so the item is narrowed
+# on entry to the latch block and BOTH copies the `dup` makes are narrowed — the
+# one the predicate consumes and the one that survives on the keep path into the
+# rest of the fused body. The prologue leaves the stack exactly as it found it
+# ([item] in, [item] out: the fetch's array is stored away, the latch read is
+# consumed by the `ifne`), so casting in front of it is the same splice 508
+# makes in front of its `dup`, just one block earlier. The frame itself stays as
+# it is: the cast runs after it, so it still rightly declares Object, and 503 is
+# left unchanged, exactly as in 505 and 508. The latched branch jumps over the
+# `dup` to 310's own keep-label, where the frame 503 fills again declares Object
+# — correct, since a narrowed item is assignable to it.
+#
+# The prologue is spelled out opcode by opcode, including 310's fixed scratch
+# slot 4, so that only a dropWhile latch — not an arbitrary run of opcodes — is
+# tolerated in the gap; a body that computes something else between the frame
+# and the dup is deliberately left to fail loudly rather than be cast blindly.
+# The `when` guard is 505's and 508's: bridge-input must be Object (the distinct
+# / skip element-erasure signature) and the following invokestatic must take a
+# SINGLE non-Object reference argument, so an Object-accepting predicate is left
+# alone and a captured lambda$ (which takes the captured values plus the item) is
+# skipped. It runs after 503 (which turns the keep label's frame-item into a
+# Φ.jeo.frame) and before 512 (which wraps the distill-lambda body into a
+# method) and 521 (which resolves the Φ.hone.fetch this pattern anchors on),
+# applied at fixpoint: the checkcast it inserts now sits between the frame and
+# the fetch, so neither this rule nor 505 or 508 re-matches the same site, while
+# a second dropWhile further down the fused body still gets its own cast.
+name: distill-state-item-cast-latch
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ 𝑒-static,
+    bridge-input ↦ "Ljava/lang/Object;",
+    consumer ↦ 𝑒-consumer,
+    target-method ↦ 𝑒-target-method,
+    captured ↦ 𝑒-captured,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-frame ↦ ⟦ φ ↦ Φ.jeo.frame, 𝐵-frame-rest ⟧,
+      𝜏-fetch ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "[I" ⟧,
+      𝜏-astore ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, i1 ↦ 4 ⟧,
+      𝜏-aload ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 4 ⟧,
+      𝜏-index ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+      𝜏-iaload ↦ ⟦ φ ↦ Φ.jeo.opcode.iaload ⟧,
+      𝜏-ifne ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ 𝑒-latched-target ⟧,
+      𝜏-dup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+      𝜏-invoke ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokestatic,
+        i2 ↦ 𝑒-invoke-class,
+        i3 ↦ 𝑒-invoke-method,
+        i4 ↦ 𝑒-invoke-signature,
+        i5 ↦ 𝑒-invoke-is-interface
+      ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ 𝑒-static,
+    bridge-input ↦ "Ljava/lang/Object;",
+    consumer ↦ 𝑒-consumer,
+    target-method ↦ 𝑒-target-method,
+    captured ↦ 𝑒-captured,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-frame ↦ ⟦ φ ↦ Φ.jeo.frame, 𝐵-frame-rest ⟧,
+      𝜏-cast ↦ ⟦ φ ↦ Φ.jeo.opcode.checkcast, i1 ↦ 𝑒-cast-class ⟧,
+      𝜏-fetch ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "[I" ⟧,
+      𝜏-astore ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, i1 ↦ 4 ⟧,
+      𝜏-aload ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 4 ⟧,
+      𝜏-index ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+      𝜏-iaload ↦ ⟦ φ ↦ Φ.jeo.opcode.iaload ⟧,
+      𝜏-ifne ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ 𝑒-latched-target ⟧,
+      𝜏-dup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+      𝜏-invoke ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokestatic,
+        i2 ↦ 𝑒-invoke-class,
+        i3 ↦ 𝑒-invoke-method,
+        i4 ↦ 𝑒-invoke-signature,
+        i5 ↦ 𝑒-invoke-is-interface
+      ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+when:
+  and:
+    - matches: ['^\(L[^;]+;\)', 𝑒-invoke-signature]
+    - not:
+        matches: ['^\(Ljava/lang/Object;\)', 𝑒-invoke-signature]
+where:
+  - meta: 𝜏-cast
+    function: random-tau
+  - meta: 𝑒-cast-class
+    function: sed
+    args:
+      - 𝑒-invoke-signature
+      - '"s/^\\(L([^;]+);.*/$1/g"'

--- a/src/test/phino/509-distill-state-item-cast-latch.yml
+++ b/src/test/phino/509-distill-state-item-cast-latch.yml
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 509 is the latch-tolerant third of the 505 family (#799). A dropWhile fused
+# behind a distinct/skip guard opens with 310's sticky-latch prologue — fetch
+# the captured int[1], stash it in scratch slot 4, read cell 0 and branch
+# straight to the keep-label when the latch is already set — and only then dups
+# the item for its predicate. So after 503 has resolved the guard's keep-label
+# into a Φ.jeo.frame the body reads frame → fetch [I → astore → aload →
+# iconst_0 → iaload → ifne → dup → invokestatic: neither 505 (frame →
+# invokestatic) nor 508 (frame → dup → invokestatic) fires. The item is still
+# the erased Ljava/lang/Object; a distinct/skip-led distill carries, while the
+# desugared predicate takes (Ljava/lang/Long;)Z, so without a cast the class
+# fails verification with "Bad type on operand stack". This rule splices
+# `checkcast java/lang/Long` between the frame and the prologue — the prologue
+# leaves the stack as it found it, so the item is narrowed on entry to the latch
+# block and BOTH copies the dup makes are narrowed. The frame is untouched: it
+# correctly still declares Object, because the cast runs after it.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-state-frame.phr
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/509-distill-state-item-cast-latch.phr
+input: |
+  ⟦
+    body ↦ ⟦
+      op1 ↦ ⟦
+        φ ↦ Φ.hone.distill-lambda,
+        static ↦ "true",
+        bridge-input ↦ "Ljava/lang/Object;",
+        consumer ↦ "Ljava/util/function/Consumer;",
+        target-method ↦ "distill_0",
+        captured ↦ "Ljava/util/List;",
+        body ↦ ⟦
+          g1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/util/concurrent/ConcurrentHashMap$KeySetView" ⟧,
+          g2 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+          g3 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "[I" ⟧,
+          g4 ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, i1 ↦ 4 ⟧,
+          g5 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 4 ⟧,
+          g6 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+          g7 ↦ ⟦ φ ↦ Φ.jeo.opcode.iaload ⟧,
+          g8 ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L310777" ⟧ ⟧,
+          g9 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+          g10 ↦ ⟦
+            φ ↦ Φ.jeo.opcode.invokestatic,
+            i2 ↦ "A",
+            i3 ↦ "lambda$main$0",
+            i4 ↦ "(Ljava/lang/Long;)Z",
+            i5 ↦ Φ.false
+          ⟧,
+          ρ ↦ ∅
+        ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+expected:
+  - ⟦ φ ↦ Φ.jeo.opcode.checkcast, i1 ↦ "java/lang/Long" ⟧
+  - ⟦ 𝐵-p, 𝜏-f ↦ ⟦ φ ↦ Φ.jeo.frame, 𝐵-fr ⟧, 𝜏-c ↦ ⟦ φ ↦ Φ.jeo.opcode.checkcast, i1 ↦ "java/lang/Long" ⟧, 𝜏-l ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "[I" ⟧, 𝐵-q ⟧
+  - ⟦ 𝐵-p, 𝜏-i ↦ ⟦ φ ↦ Φ.jeo.opcode.iaload ⟧, 𝜏-b ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, 𝐵-t ⟧, 𝜏-d ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧, 𝜏-v ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, 𝐵-x, i3 ↦ "lambda$main$0", 𝐵-y ⟧, 𝐵-q ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/stateful-dropwhile-tail.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/stateful-dropwhile-tail.yml
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A dropWhile riding a pipeline that a distinct() or a skip() leads — the shape
+# #799 reports. distinct and skip erase the element type, so the fused stateful
+# distill carries bridge-input ↦ Ljava/lang/Object; and 503 frames the guard's
+# keep-label as Object; the dropWhile behind it opens with 310's sticky-latch
+# prologue (fetch the captured int[1], stash it in scratch slot 4, read cell 0
+# and branch to the keep-label when the latch is already set) and only then dups
+# the item for its desugared predicate, an (Ljava/lang/Long;)Z handle for a Long
+# element. That prologue breaks BOTH the frame → invokestatic adjacency 505
+# anchors on AND the frame → dup → invokestatic one 508 added for the filter
+# interleaving (#788), so before 509 no cast was spliced, the erased Object
+# reached the predicate, and the optimized class died in the verifier with "Bad
+# type on operand stack: Type 'java/lang/Object' is not assignable to
+# 'java/lang/Long'". 509 now splices the `checkcast` between the frame and the
+# prologue — the prologue leaves the stack as it found it, so the item is
+# narrowed on entry to the latch block and both copies the dup makes are
+# narrowed.
+#
+# Four pipelines, covering every axis the issue names:
+#   * boxed   — distinct-led, Long element (the reported reproduction, widened
+#     so the latch actually flips): distinct -> 3,5,1,2 -> drop while < 4 drops
+#     the leading 3, then 5 latches and 5,1,2 survive -> count 3.
+#   * text    — distinct-led, String element, proving it is not about Long:
+#     distinct -> "","x","yy" -> drop while empty drops the leading "" ->
+#     "x+yy". A re-evaluated predicate would wrongly drop nothing here, so the
+#     joined text also asserts the latch still sticks.
+#   * skipped — skip-led rather than distinct-led, the other element-erasing
+#     head: skip(1) -> "bb","ccc","dddd" -> drop while shorter than 3 drops
+#     "bb" -> count 2.
+#   * twice   — TWO dropWhiles behind one distinct, so the rule has to fire at
+#     fixpoint on the second latch block as well: distinct -> 1,2,9,3,8 -> drop
+#     while < 2 keeps 2,9,3,8 -> drop while < 9 keeps 9,3,8 -> count 3.
+# The `after` counts are left unasserted on purpose: this pack exists to prove
+# the optimized class VERIFIES and still computes the right answer, which the
+# printed line asserts end to end.
+java: |
+  package statefuldropwhiletail;
+  import java.util.stream.Collectors;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      long boxed = Stream.of(3L, 5L, 1L, 2L, 5L)
+        .distinct()
+        .dropWhile(n -> n < 4L)
+        .count();
+      String text = Stream.of("", "x", "", "yy")
+        .distinct()
+        .dropWhile(s -> s.isEmpty())
+        .collect(Collectors.joining("+"));
+      long skipped = Stream.of("a", "bb", "ccc", "dddd")
+        .skip(1L)
+        .dropWhile(s -> s.length() < 3)
+        .count();
+      long twice = Stream.of(1L, 2L, 9L, 3L, 8L)
+        .distinct()
+        .dropWhile(n -> n < 2L)
+        .dropWhile(n -> n < 9L)
+        .count();
+      System.out.printf("The result is %d/%s/%d/%d\n", boxed, text, skipped, twice);
+    }
+  }
+# None of these pipelines carries a `map` or a `filter`, so the production
+# default grep-in (see #449/#671/#705) would skip the class outright; the pack
+# opts the pre-filter off with `.*` so the rewrite actually runs.
+grep-in: ".*"
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 3/x+yy/2/3"


### PR DESCRIPTION
Closes #799.

## The bug

`Stream.of(3L, 1L, 2L).distinct().dropWhile(n -> n < 4L).count()`, rewritten with `streams/*`, dies at load:

```
java.lang.VerifyError: Bad type on operand stack
  Location: distill_5028152(Ljava/util/List;Ljava/lang/Object;Ljava/util/function/Consumer;)V @49: invokestatic
  Reason: Type 'java/lang/Object' (current frame, stack[1]) is not assignable to 'java/lang/Long'
```

`distinct()` and `skip()` erase the element type, so the fused stateful distill carries `bridge-input ↦ Ljava/lang/Object;`, while the desugared `dropWhile` predicate is typed `lambda$main$0(Ljava/lang/Long;)Z`. Narrowing that item is the job of `505-distill-state-item-cast` (anchors on a `Φ.jeo.frame` immediately followed by an `invokestatic`) and of `508-distill-state-item-cast-dup` (tolerates one `dup` in that gap, the filter/peek interleaving from #788).

`310-dropwhile-to-distill` opens its body with the sticky-latch prologue and only *then* dups the item for the predicate, so the joined body reads

```
frame → fetch [I → astore 4 → aload 4 → iconst_0 → iaload → ifne → dup → invokestatic
```

Neither adjacency matches, no `checkcast` is spliced, and the erased `Object` reaches the typed predicate.

## The fix

`509-distill-state-item-cast-latch.phr` — the latch-tolerant third of the 505 family. It matches that prologue opcode by opcode (including 310's fixed scratch slot 4, so only a dropWhile latch is tolerated in the gap, not an arbitrary run of opcodes) and keeps 505's splice point: the `checkcast` goes right after the keep-frame, before the prologue. The prologue leaves the stack exactly as it found it — the fetched array is stored away, the latch read is consumed by the `ifne` — so the item is narrowed on entry to the latch block and both copies the following `dup` makes are narrowed: the one the predicate eats and the one that survives on the keep path. The frame itself is untouched and still rightly declares `Object`, since the cast runs after it; 503 is left unchanged, exactly as in 505 and 508.

The `when` guard is 505's and 508's verbatim: `bridge-input` must be `Object` and the following `invokestatic` must take a single non-`Object` reference argument, so an `Object`-accepting predicate is left alone and a captured `lambda$` is skipped. It slots between 508 and 511 — after 503 has turned the keep-label's `frame-item` into a `Φ.jeo.frame`, before 512 wraps the body into a method and 521 resolves the `Φ.hone.fetch` this pattern anchors on.

Also updated the headers of 505 and 508 to cross-reference the new twin, and 310's header to record that its prologue shape is now load-bearing for 509.

## Tests

- `src/test/phino/509-distill-state-item-cast-latch.yml` — single-rule pack: 503 + 509 over the interleaved body, asserting the `checkcast java/lang/Long` lands between the frame and the fetch and that the latch block is otherwise untouched.
- `src/test/resources/org/eolang/hone/optimize/streams/stateful-dropwhile-tail.yml` — end-to-end, four pipelines covering every axis the issue names: distinct-led with a `Long` element (the reported reproduction, widened so the latch actually flips), distinct-led with a `String` element, a `skip`-led head, and two `dropWhile`s behind one `distinct` so the rule has to fire at fixpoint on the second latch block too.

## Verification

Run on this machine against phino `0.0.106` and jeo `0.15.3`, driving the real `jeo:disassemble → phino rewrite → jeo:assemble` pipeline with the production `--max-cycles 1 --max-depth 500`:

- The new fixture reproduces the reported `VerifyError` with 509 removed, and prints the correct `The result is 3/x+yy/2/3` with it in place — matching the unoptimized `javac` output.
- 509 fires five times across those pipelines (`Long`, `String`, `String` behind `skip`, and both latches of the chained case), each splicing the right wrapper.
- No regression on the existing fixtures exercised end to end the same way: `all-ops`, `dropwhile`, `full-non-terminal`, `stateful-ops`, `stateful-filter-tail`, `stateful-boxed-tail`, `stateful-object-tail`, `distinct`, `skip`, `peek-filter` — all identical to their `javac` baselines.
- `mvn test` → 47 tests, 0 failures. `mvn -Pdeep -Dtest='OptimizeMojoTest#appliesPhinoRulesAsSpecifiedInYamlPack' test` → 68 packs, 0 failures.
- The Docker-based `optimizesAsSpecifiedInYamlPack` deep run was not exercised here (no image build in this environment); CI covers it.

No opcode counts change for existing fixtures — none of them assert `checkcast`.

---
_Generated by [Claude Code](https://claude.ai/code/session_011toVZBZDE1GcXHL6e8wDiA)_