### PR TITLE
fix(#798): frame a stateful guard from its survivor

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-distinct-frame.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-distinct-frame.phr
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Resolves the Φ.hone.frame-item marker that 307 leaves at a distinct() guard's
+# keep-label when an operator was fused in AHEAD of that guard, so the survivor
+# waiting on the stack is no longer the value the wrapper was handed.
+#
+# 503 fills BOTH the local at slot 1 and the single stack item of the keep-frame
+# from the distill's `bridge-input`. The local is right — it is the bridge
+# method's declared parameter, the item 512 loads with `aload 1`. The stack item
+# is not: distinct is type-transparent, so the value alive at the keep-label is
+# whatever the body produced just before the guard, and 401 is free to fuse a
+# type-CHANGING map in ahead of it. For `Stream.of("a", "bb")
+# .map(s -> Long.valueOf(s.length())).distinct()` (#798) the distill still
+# receives a java/lang/String, the head `lambda$main$0:(Ljava/lang/String;)
+# Ljava/lang/Long;` has already retyped it, and the frame 503 writes promises a
+# java/lang/String over a java/lang/Long: "java.lang.VerifyError: Inconsistent
+# stackmap frames at branch target 29 ... Type 'java/lang/Long' (current frame,
+# stack[0]) is not assignable to 'java/lang/String' (stack map, stack[0])".
+# Keeping the element type identical hides it (`map(x -> x + 1).distinct()` in
+# `distinct.yml` always ran), which is why every other fixture passed.
+#
+# This is the stateful twin of #794, fixed by `506-distill-predicate-frame` for
+# the stateless filter branch: leave the LOCAL on bridge-input and derive only
+# the STACK item from the survivor. A filter names its survivor through the
+# predicate's own parameter; distinct's guard only ever sees `Set.add(Object)`,
+# so the name comes from the other side — the return type of the invokestatic
+# that produced the item, matched immediately in front of the guard's fetch
+# marker. That adjacency is exact: a distill body is emit-shaped (one item in,
+# one item out), so the last opcode before the guard IS the item's producer,
+# and 307 opens its guard with the fetch. It fires only for an object return
+# (`(...)L<type>;`); a void one (a peek fused ahead) or a primitive one leaves
+# the marker to 503, whose bridge-input is right for a type-preserving
+# neighbour and for a guard with nothing fused ahead of it at all.
+#
+# `503-distill-skip-frame` does the same for 308's countdown guard, which is
+# just as blind to the element type; `503-distill-dropwhile-frame` covers 310's
+# latch guard, which does not need the producer at all because its own
+# predicate names the survivor.
+#
+# Ordering: 503 claims EVERY frame-item in a stateful distill-lambda, so these
+# three have to reach the retyped ones first. No integer is free between 502 and
+# 503, so they share 503's number and rely on alphabetical filename order being
+# the schedule: `503-distill-distinct-frame` < `503-distill-dropwhile-frame` <
+# `503-distill-skip-frame` < `503-distill-state-frame`. It runs before 512 wraps
+# the lambda into a method (503 < 512), so the marker never reaches jeo. Scoped
+# to a distill-lambda WITH `captured`, like 503 itself, so stateless filter
+# keep-labels stay with 506/507.
+name: distill-distinct-frame
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ 𝑒-static,
+    bridge-input ↦ 𝑒-bridge-input,
+    consumer ↦ 𝑒-consumer,
+    target-method ↦ 𝑒-target-method,
+    captured ↦ 𝑒-captured,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-head ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokestatic,
+        i2 ↦ 𝑒-head-class,
+        i3 ↦ 𝑒-head-method,
+        i4 ↦ 𝑒-head-signature,
+        i5 ↦ 𝑒-head-is-interface
+      ⟧,
+      𝜏-fetch ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ 𝑒-fetch-type ⟧,
+      𝜏-swap ↦ ⟦ φ ↦ Φ.jeo.opcode.swap ⟧,
+      𝜏-dup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup_x1 ⟧,
+      𝜏-add ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokevirtual,
+        i1 ↦ 𝑒-add-class,
+        i2 ↦ 𝑒-add-method,
+        i3 ↦ 𝑒-add-signature,
+        i4 ↦ 𝑒-add-is-interface
+      ⟧,
+      𝜏-ifne ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ 𝑒-ifne-target ⟧,
+      𝜏-pop ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+      𝜏-return ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      𝜏-keep-label ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-keep-label ⟧,
+      𝜏-frame ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ 𝑒-static,
+    bridge-input ↦ 𝑒-bridge-input,
+    consumer ↦ 𝑒-consumer,
+    target-method ↦ 𝑒-target-method,
+    captured ↦ 𝑒-captured,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-head ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokestatic,
+        i2 ↦ 𝑒-head-class,
+        i3 ↦ 𝑒-head-method,
+        i4 ↦ 𝑒-head-signature,
+        i5 ↦ 𝑒-head-is-interface
+      ⟧,
+      𝜏-fetch ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ 𝑒-fetch-type ⟧,
+      𝜏-swap ↦ ⟦ φ ↦ Φ.jeo.opcode.swap ⟧,
+      𝜏-dup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup_x1 ⟧,
+      𝜏-add ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokevirtual,
+        i1 ↦ 𝑒-add-class,
+        i2 ↦ 𝑒-add-method,
+        i3 ↦ 𝑒-add-signature,
+        i4 ↦ 𝑒-add-is-interface
+      ⟧,
+      𝜏-ifne ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ 𝑒-ifne-target ⟧,
+      𝜏-pop ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+      𝜏-return ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      𝜏-keep-label ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-keep-label ⟧,
+      𝜏-frame ↦ ⟦
+        φ ↦ Φ.jeo.frame,
+        type ↦ 0,
+        locals ↦ ⟦
+          φ ↦ Φ.jeo.seq.of4,
+          x0 ↦ 𝑒-frame-captured,
+          x1 ↦ 𝑒-frame-input,
+          x2 ↦ 𝑒-frame-consumer,
+          x3 ↦ "integer"
+        ⟧,
+        stack ↦ ⟦
+          φ ↦ Φ.jeo.seq.of1,
+          x0 ↦ 𝑒-frame-item
+        ⟧
+      ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+when:
+  and:
+    - matches:
+        - '^\(.*\)L[^;]+;$'
+        - 𝑒-head-signature
+where:
+  - meta: 𝑒-frame-item
+    function: sed
+    args:
+      - 𝑒-head-signature
+      - '"s/^\\(.*\\)L(.+);$/$1/g"'
+  - meta: 𝑒-frame-input
+    function: sed
+    args:
+      - 𝑒-bridge-input
+      - '"s/^B$/byte/g"'
+      - '"s/^C$/char/g"'
+      - '"s/^D$/double/g"'
+      - '"s/^F$/float/g"'
+      - '"s/^I$/integer/g"'
+      - '"s/^J$/long/g"'
+      - '"s/^S$/short/g"'
+      - '"s/^Z$/boolean/g"'
+      - '"s/^L(.+);$/$1/g"'
+  - meta: 𝑒-frame-captured
+    function: sed
+    args:
+      - 𝑒-captured
+      - '"s/^L(.+);$/$1/g"'
+  - meta: 𝑒-frame-consumer
+    function: sed
+    args:
+      - 𝑒-consumer
+      - '"s/^L(.+);$/$1/g"'

--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-dropwhile-frame.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-dropwhile-frame.phr
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The dropWhile() member of the #798 trio — see `503-distill-distinct-frame`
+# for the defect. 310's latch guard is type-transparent too, so a type-CHANGING
+# map fused in AHEAD of it leaves a survivor at the keep-label that is NOT the
+# distill's `bridge-input`, and the frame 503 writes from bridge-input fails JVM
+# verification: `Stream.of("a", "bb", "ccc").map(s -> Long.valueOf(s.length()))
+# .dropWhile(v -> v < 2L)` dies with "Type 'java/lang/Long' (current frame,
+# stack[0]) is not assignable to 'java/lang/String' (stack map, stack[0])".
+#
+# Unlike distinct's seen-set and skip's countdown — whose guards only ever see
+# `Set.add(Object)` and a long[], so the survivor has to be read off the
+# operator fused in front — dropWhile CARRIES its own name for the item: the
+# predicate it tests the item with, matched here between the guard's `dup` and
+# the latch update. This rule therefore needs no producer in front of it and
+# reads the survivor the way `506-distill-predicate-frame` does for the
+# stateless filter branch (#794), which is also why it is right for an unfused
+# dropWhile, where the predicate parameter and bridge-input coincide.
+#
+# Both `ifne` arms jump to the same keep-label — the already-dropping arm (the
+# latch is set, the predicate is not even evaluated) and the arm that has just
+# evaluated it — and both leave only the item on the stack, so one frame
+# describes both. The scratch locals 4 and 5 that 310 borrows are dead by then,
+# so the four-local frame 512 sizes for still holds.
+#
+# Fires only for an object predicate (`(L<type>;)Z`); anything else falls
+# through to 503 and its bridge-input. Ordering: shares 503's number, since no
+# integer is free between 502 and 503, and relies on
+# `503-distill-dropwhile-frame` < `503-distill-state-frame` alphabetically.
+# Scoped to a distill-lambda WITH `captured`, so stateless keep-labels stay
+# with 506/507.
+name: distill-dropwhile-frame
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ 𝑒-static,
+    bridge-input ↦ 𝑒-bridge-input,
+    consumer ↦ 𝑒-consumer,
+    target-method ↦ 𝑒-target-method,
+    captured ↦ 𝑒-captured,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-fetch ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ 𝑒-fetch-type ⟧,
+      𝜏-park-latch ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, i1 ↦ 4 ⟧,
+      𝜏-load-latch ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 4 ⟧,
+      𝜏-latch-index ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+      𝜏-read-latch ↦ ⟦ φ ↦ Φ.jeo.opcode.iaload ⟧,
+      𝜏-if-dropping ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ 𝑒-dropping-target ⟧,
+      𝜏-dup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+      𝜏-predicate ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokestatic,
+        i2 ↦ 𝑒-predicate-class,
+        i3 ↦ 𝑒-predicate-method,
+        i4 ↦ 𝑒-predicate-signature,
+        i5 ↦ 𝑒-predicate-is-interface
+      ⟧,
+      𝜏-one ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_1 ⟧,
+      𝜏-negate ↦ ⟦ φ ↦ Φ.jeo.opcode.ixor ⟧,
+      𝜏-park-verdict ↦ ⟦ φ ↦ Φ.jeo.opcode.istore, i1 ↦ 5 ⟧,
+      𝜏-reload-latch ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 4 ⟧,
+      𝜏-store-index ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+      𝜏-load-verdict ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, i1 ↦ 5 ⟧,
+      𝜏-write-latch ↦ ⟦ φ ↦ Φ.jeo.opcode.iastore ⟧,
+      𝜏-reload-verdict ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, i1 ↦ 5 ⟧,
+      𝜏-if-keep ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ 𝑒-keep-target ⟧,
+      𝜏-return ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      𝜏-keep-label ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-keep-label ⟧,
+      𝜏-frame ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ 𝑒-static,
+    bridge-input ↦ 𝑒-bridge-input,
+    consumer ↦ 𝑒-consumer,
+    target-method ↦ 𝑒-target-method,
+    captured ↦ 𝑒-captured,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-fetch ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ 𝑒-fetch-type ⟧,
+      𝜏-park-latch ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, i1 ↦ 4 ⟧,
+      𝜏-load-latch ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 4 ⟧,
+      𝜏-latch-index ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+      𝜏-read-latch ↦ ⟦ φ ↦ Φ.jeo.opcode.iaload ⟧,
+      𝜏-if-dropping ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ 𝑒-dropping-target ⟧,
+      𝜏-dup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+      𝜏-predicate ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokestatic,
+        i2 ↦ 𝑒-predicate-class,
+        i3 ↦ 𝑒-predicate-method,
+        i4 ↦ 𝑒-predicate-signature,
+        i5 ↦ 𝑒-predicate-is-interface
+      ⟧,
+      𝜏-one ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_1 ⟧,
+      𝜏-negate ↦ ⟦ φ ↦ Φ.jeo.opcode.ixor ⟧,
+      𝜏-park-verdict ↦ ⟦ φ ↦ Φ.jeo.opcode.istore, i1 ↦ 5 ⟧,
+      𝜏-reload-latch ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 4 ⟧,
+      𝜏-store-index ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+      𝜏-load-verdict ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, i1 ↦ 5 ⟧,
+      𝜏-write-latch ↦ ⟦ φ ↦ Φ.jeo.opcode.iastore ⟧,
+      𝜏-reload-verdict ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, i1 ↦ 5 ⟧,
+      𝜏-if-keep ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ 𝑒-keep-target ⟧,
+      𝜏-return ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      𝜏-keep-label ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-keep-label ⟧,
+      𝜏-frame ↦ ⟦
+        φ ↦ Φ.jeo.frame,
+        type ↦ 0,
+        locals ↦ ⟦
+          φ ↦ Φ.jeo.seq.of4,
+          x0 ↦ 𝑒-frame-captured,
+          x1 ↦ 𝑒-frame-input,
+          x2 ↦ 𝑒-frame-consumer,
+          x3 ↦ "integer"
+        ⟧,
+        stack ↦ ⟦
+          φ ↦ Φ.jeo.seq.of1,
+          x0 ↦ 𝑒-frame-item
+        ⟧
+      ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+when:
+  and:
+    - matches:
+        - '^\(L[^;]+;\)Z$'
+        - 𝑒-predicate-signature
+where:
+  - meta: 𝑒-frame-item
+    function: sed
+    args:
+      - 𝑒-predicate-signature
+      - '"s/^\\(L(.+);\\)Z$/$1/g"'
+  - meta: 𝑒-frame-input
+    function: sed
+    args:
+      - 𝑒-bridge-input
+      - '"s/^B$/byte/g"'
+      - '"s/^C$/char/g"'
+      - '"s/^D$/double/g"'
+      - '"s/^F$/float/g"'
+      - '"s/^I$/integer/g"'
+      - '"s/^J$/long/g"'
+      - '"s/^S$/short/g"'
+      - '"s/^Z$/boolean/g"'
+      - '"s/^L(.+);$/$1/g"'
+  - meta: 𝑒-frame-captured
+    function: sed
+    args:
+      - 𝑒-captured
+      - '"s/^L(.+);$/$1/g"'
+  - meta: 𝑒-frame-consumer
+    function: sed
+    args:
+      - 𝑒-consumer
+      - '"s/^L(.+);$/$1/g"'

--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-skip-frame.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-skip-frame.phr
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The skip() twin of `503-distill-distinct-frame` — read its header for the
+# reasoning; only the guard shape differs. skip is "a filter that owns a
+# countdown counter" and is just as type-transparent as distinct, so when 401
+# fuses a type-CHANGING map in AHEAD of it the survivor waiting at 308's
+# keep-label is the map's return type, not the distill's `bridge-input`, and
+# the frame 503 writes fails JVM verification the same way (#798):
+# `Stream.of("a", "bb", "ccc").map(s -> Long.valueOf(s.length())).skip(1L)`
+# dies with "Type 'java/lang/Long' (current frame, stack[0]) is not assignable
+# to 'java/lang/String' (stack map, stack[0])".
+#
+# The local at slot 1 stays on bridge-input (it IS the bridge method's declared
+# parameter); only the stack item is derived, from the return type of the
+# invokestatic matched immediately in front of 308's fetch marker. 308's guard
+# consumes its long[] counter before the branch, so the keep-label leaves only
+# the item on the stack, exactly like 307's.
+#
+# Ordering: shares 503's number, since no integer is free between 502 and 503,
+# and relies on `503-distill-skip-frame` < `503-distill-state-frame`
+# alphabetically so the retyped markers are claimed before the fallback reads
+# bridge-input for the rest.
+name: distill-skip-frame
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ 𝑒-static,
+    bridge-input ↦ 𝑒-bridge-input,
+    consumer ↦ 𝑒-consumer,
+    target-method ↦ 𝑒-target-method,
+    captured ↦ 𝑒-captured,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-head ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokestatic,
+        i2 ↦ 𝑒-head-class,
+        i3 ↦ 𝑒-head-method,
+        i4 ↦ 𝑒-head-signature,
+        i5 ↦ 𝑒-head-is-interface
+      ⟧,
+      𝜏-fetch ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ 𝑒-fetch-type ⟧,
+      𝜏-index ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+      𝜏-dup-slot ↦ ⟦ φ ↦ Φ.jeo.opcode.dup2 ⟧,
+      𝜏-load-count ↦ ⟦ φ ↦ Φ.jeo.opcode.laload ⟧,
+      𝜏-dup-count ↦ ⟦ φ ↦ Φ.jeo.opcode.dup2_x2 ⟧,
+      𝜏-one ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_1 ⟧,
+      𝜏-decrement ↦ ⟦ φ ↦ Φ.jeo.opcode.lsub ⟧,
+      𝜏-store-count ↦ ⟦ φ ↦ Φ.jeo.opcode.lastore ⟧,
+      𝜏-zero ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_0 ⟧,
+      𝜏-compare ↦ ⟦ φ ↦ Φ.jeo.opcode.lcmp ⟧,
+      𝜏-ifle ↦ ⟦ φ ↦ Φ.jeo.opcode.ifle, i2 ↦ 𝑒-ifle-target ⟧,
+      𝜏-pop ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+      𝜏-return ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      𝜏-keep-label ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-keep-label ⟧,
+      𝜏-frame ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ 𝑒-static,
+    bridge-input ↦ 𝑒-bridge-input,
+    consumer ↦ 𝑒-consumer,
+    target-method ↦ 𝑒-target-method,
+    captured ↦ 𝑒-captured,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-head ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokestatic,
+        i2 ↦ 𝑒-head-class,
+        i3 ↦ 𝑒-head-method,
+        i4 ↦ 𝑒-head-signature,
+        i5 ↦ 𝑒-head-is-interface
+      ⟧,
+      𝜏-fetch ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ 𝑒-fetch-type ⟧,
+      𝜏-index ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+      𝜏-dup-slot ↦ ⟦ φ ↦ Φ.jeo.opcode.dup2 ⟧,
+      𝜏-load-count ↦ ⟦ φ ↦ Φ.jeo.opcode.laload ⟧,
+      𝜏-dup-count ↦ ⟦ φ ↦ Φ.jeo.opcode.dup2_x2 ⟧,
+      𝜏-one ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_1 ⟧,
+      𝜏-decrement ↦ ⟦ φ ↦ Φ.jeo.opcode.lsub ⟧,
+      𝜏-store-count ↦ ⟦ φ ↦ Φ.jeo.opcode.lastore ⟧,
+      𝜏-zero ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_0 ⟧,
+      𝜏-compare ↦ ⟦ φ ↦ Φ.jeo.opcode.lcmp ⟧,
+      𝜏-ifle ↦ ⟦ φ ↦ Φ.jeo.opcode.ifle, i2 ↦ 𝑒-ifle-target ⟧,
+      𝜏-pop ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+      𝜏-return ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      𝜏-keep-label ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-keep-label ⟧,
+      𝜏-frame ↦ ⟦
+        φ ↦ Φ.jeo.frame,
+        type ↦ 0,
+        locals ↦ ⟦
+          φ ↦ Φ.jeo.seq.of4,
+          x0 ↦ 𝑒-frame-captured,
+          x1 ↦ 𝑒-frame-input,
+          x2 ↦ 𝑒-frame-consumer,
+          x3 ↦ "integer"
+        ⟧,
+        stack ↦ ⟦
+          φ ↦ Φ.jeo.seq.of1,
+          x0 ↦ 𝑒-frame-item
+        ⟧
+      ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+when:
+  and:
+    - matches:
+        - '^\(.*\)L[^;]+;$'
+        - 𝑒-head-signature
+where:
+  - meta: 𝑒-frame-item
+    function: sed
+    args:
+      - 𝑒-head-signature
+      - '"s/^\\(.*\\)L(.+);$/$1/g"'
+  - meta: 𝑒-frame-input
+    function: sed
+    args:
+      - 𝑒-bridge-input
+      - '"s/^B$/byte/g"'
+      - '"s/^C$/char/g"'
+      - '"s/^D$/double/g"'
+      - '"s/^F$/float/g"'
+      - '"s/^I$/integer/g"'
+      - '"s/^J$/long/g"'
+      - '"s/^S$/short/g"'
+      - '"s/^Z$/boolean/g"'
+      - '"s/^L(.+);$/$1/g"'
+  - meta: 𝑒-frame-captured
+    function: sed
+    args:
+      - 𝑒-captured
+      - '"s/^L(.+);$/$1/g"'
+  - meta: 𝑒-frame-consumer
+    function: sed
+    args:
+      - 𝑒-consumer
+      - '"s/^L(.+);$/$1/g"'

--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-state-frame.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-state-frame.phr
@@ -21,9 +21,19 @@
 # COMPUTE_FRAMES on jeo:assemble would let every hone rule, this one and
 # filter's 305 alike, drop hand-built frames. Tracked as a jeo follow-up.)
 #
-# v1 reads the type off `bridge-input`, correct when every operator
-# before distinct in the fused body preserves the element type (true for
-# the map/filter pipelines exercised today).
+# This is the FALLBACK of the keep-frame family: it reads the stack item
+# off `bridge-input`, which names the survivor only while every operator
+# ahead of the guard in the fused body preserves the element type. When a
+# type-CHANGING map is fused ahead, bridge-input is the head map's INPUT
+# while the value at the keep-label is its OUTPUT, and the frame written
+# here fails JVM verification (#798). The three rules that sort in front
+# of this one — `503-distill-distinct-frame`,
+# `503-distill-dropwhile-frame`, `503-distill-skip-frame` — claim those
+# markers first and derive the stack item from the survivor, leaving this
+# rule the guards with a type-preserving neighbour or nothing fused ahead
+# of them at all, where bridge-input is right. The LOCAL at slot 1 is
+# bridge-input in every case: it is the bridge method's declared
+# parameter, whatever the body later does to the item.
 name: distill-state-frame
 pattern: |
   ⟦

--- a/src/test/phino/503-distill-distinct-frame.yml
+++ b/src/test/phino/503-distill-distinct-frame.yml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Reproduction of #798 at the rule level: a type-changing object map fused in
+# AHEAD of a distinct() guard. The wrapper receives a java/lang/String
+# (bridge-input), the head `lambda$main$0:(Ljava/lang/String;)Ljava/lang/Long;`
+# retypes it, and the value the guard's dup_x1 leaves alive at the keep-label is
+# that java/lang/Long. The local at slot 1 must still be the String (it is the
+# bridge method's declared parameter, loaded by 512's `aload 1`), so only the
+# STACK item follows the survivor — read off the producer's return type. Before
+# the fix 503 filled both from bridge-input and the class failed JVM
+# verification at the branch target. 503 is listed here too, to prove the
+# alphabetical order leaves it nothing to fall back on.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-distinct-frame.phr
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-dropwhile-frame.phr
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-skip-frame.phr
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-state-frame.phr
+input: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ "true",
+    bridge-input ↦ "Ljava/lang/String;",
+    consumer ↦ "Ljava/util/function/Consumer;",
+    target-method ↦ "distill_1",
+    captured ↦ "Ljava/util/List;",
+    body ↦ ⟦
+      i1 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$0", i4 ↦ "(Ljava/lang/String;)Ljava/lang/Long;", i5 ↦ Φ.false ⟧,
+      i2 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/util/concurrent/ConcurrentHashMap$KeySetView" ⟧,
+      i3 ↦ ⟦ φ ↦ Φ.jeo.opcode.swap ⟧,
+      i4 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup_x1 ⟧,
+      i5 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, i1 ↦ "java/util/concurrent/ConcurrentHashMap$KeySetView", i2 ↦ "add", i3 ↦ "(Ljava/lang/Object;)Z", i4 ↦ Φ.false ⟧,
+      i6 ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L1" ⟧ ⟧,
+      i7 ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+      i8 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      i9 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L1" ⟧,
+      i10 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+expected:
+  - ⟦ φ ↦ Φ.jeo.frame, type ↦ 0, 𝐵-e ⟧
+  - ⟦ φ ↦ Φ.jeo.seq.of1, x0 ↦ "java/lang/Long" ⟧
+  - ⟦ φ ↦ Φ.jeo.seq.of4, x0 ↦ "java/util/List", x1 ↦ "java/lang/String", x2 ↦ "java/util/function/Consumer", x3 ↦ "integer" ⟧

--- a/src/test/phino/503-distill-dropwhile-frame.yml
+++ b/src/test/phino/503-distill-dropwhile-frame.yml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The dropWhile() half of #798: a type-changing object map fused in AHEAD of
+# 310's latch guard. The wrapper receives a java/lang/String, the head
+# `lambda$main$0:(Ljava/lang/String;)Ljava/lang/Long;` retypes it, and the
+# survivor waiting at the keep-label — reachable from both `ifne` arms — is that
+# java/lang/Long, while the local at slot 1 stays the declared String. Unlike
+# distinct and skip, this guard names the survivor itself, through the predicate
+# `(Ljava/lang/Long;)Z` it tests the item with, so no producer anchor is needed.
+# 503 is listed too, to prove the alphabetical order gets the marker to the
+# dropWhile rule before the bridge-input fallback sees it.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-distinct-frame.phr
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-dropwhile-frame.phr
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-skip-frame.phr
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-state-frame.phr
+input: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ "true",
+    bridge-input ↦ "Ljava/lang/String;",
+    consumer ↦ "Ljava/util/function/Consumer;",
+    target-method ↦ "distill_1",
+    captured ↦ "Ljava/util/List;",
+    body ↦ ⟦
+      i1 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$0", i4 ↦ "(Ljava/lang/String;)Ljava/lang/Long;", i5 ↦ Φ.false ⟧,
+      i2 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "[I" ⟧,
+      i3 ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, i1 ↦ 4 ⟧,
+      i4 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 4 ⟧,
+      i5 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+      i6 ↦ ⟦ φ ↦ Φ.jeo.opcode.iaload ⟧,
+      i7 ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L1" ⟧ ⟧,
+      i8 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+      i9 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$1", i4 ↦ "(Ljava/lang/Long;)Z", i5 ↦ Φ.false ⟧,
+      i10 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_1 ⟧,
+      i11 ↦ ⟦ φ ↦ Φ.jeo.opcode.ixor ⟧,
+      i12 ↦ ⟦ φ ↦ Φ.jeo.opcode.istore, i1 ↦ 5 ⟧,
+      i13 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 4 ⟧,
+      i14 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+      i15 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, i1 ↦ 5 ⟧,
+      i16 ↦ ⟦ φ ↦ Φ.jeo.opcode.iastore ⟧,
+      i17 ↦ ⟦ φ ↦ Φ.jeo.opcode.iload, i1 ↦ 5 ⟧,
+      i18 ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L1" ⟧ ⟧,
+      i19 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      i20 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L1" ⟧,
+      i21 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+expected:
+  - ⟦ φ ↦ Φ.jeo.frame, type ↦ 0, 𝐵-e ⟧
+  - ⟦ φ ↦ Φ.jeo.seq.of1, x0 ↦ "java/lang/Long" ⟧
+  - ⟦ φ ↦ Φ.jeo.seq.of4, x0 ↦ "java/util/List", x1 ↦ "java/lang/String", x2 ↦ "java/util/function/Consumer", x3 ↦ "integer" ⟧

--- a/src/test/phino/503-distill-skip-frame.yml
+++ b/src/test/phino/503-distill-skip-frame.yml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The skip() half of #798: the same type-changing object map, this time fused in
+# AHEAD of 308's countdown guard. The wrapper receives a java/lang/String, the
+# head `lambda$main$0:(Ljava/lang/String;)Ljava/lang/Long;` retypes it, and the
+# survivor left at the keep-label once the long[] counter is consumed is that
+# java/lang/Long — while the local at slot 1 stays the declared String. 503 is
+# listed too, to prove the alphabetical order gets the retyped marker to the
+# fused rule before the bridge-input fallback sees it.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-distinct-frame.phr
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-dropwhile-frame.phr
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-skip-frame.phr
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-state-frame.phr
+input: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ "true",
+    bridge-input ↦ "Ljava/lang/String;",
+    consumer ↦ "Ljava/util/function/Consumer;",
+    target-method ↦ "distill_1",
+    captured ↦ "Ljava/util/List;",
+    body ↦ ⟦
+      i1 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$0", i4 ↦ "(Ljava/lang/String;)Ljava/lang/Long;", i5 ↦ Φ.false ⟧,
+      i2 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "[J" ⟧,
+      i3 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+      i4 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup2 ⟧,
+      i5 ↦ ⟦ φ ↦ Φ.jeo.opcode.laload ⟧,
+      i6 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup2_x2 ⟧,
+      i7 ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_1 ⟧,
+      i8 ↦ ⟦ φ ↦ Φ.jeo.opcode.lsub ⟧,
+      i9 ↦ ⟦ φ ↦ Φ.jeo.opcode.lastore ⟧,
+      i10 ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_0 ⟧,
+      i11 ↦ ⟦ φ ↦ Φ.jeo.opcode.lcmp ⟧,
+      i12 ↦ ⟦ φ ↦ Φ.jeo.opcode.ifle, i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L1" ⟧ ⟧,
+      i13 ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+      i14 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      i15 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L1" ⟧,
+      i16 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+expected:
+  - ⟦ φ ↦ Φ.jeo.frame, type ↦ 0, 𝐵-e ⟧
+  - ⟦ φ ↦ Φ.jeo.seq.of1, x0 ↦ "java/lang/Long" ⟧
+  - ⟦ φ ↦ Φ.jeo.seq.of4, x0 ↦ "java/util/List", x1 ↦ "java/lang/String", x2 ↦ "java/util/function/Consumer", x3 ↦ "integer" ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/map-retype-stateful.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/map-retype-stateful.yml
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Reproduction of #798: an object map that CHANGES the element type sitting in
+# front of a STATEFUL guard — the distinct / skip / dropWhile twin of #794's
+# filter shape. 401 fuses the map in ahead of the guard, so the synthesized
+# wrapper still receives the pipeline's element (distill_502N(java.util.List,
+# java.lang.String, java.util.function.Consumer)) while the head
+# `lambda$main$N:(Ljava/lang/String;)Ljava/lang/Long;` has already retyped it:
+# the value alive at the guard's keep-label is that Long.
+#
+# Before the fix the keep-frame came from 503, which fills BOTH the local at
+# slot 1 and the single stack item from the distill's `bridge-input`. The local
+# is right — it is the bridge method's declared parameter, the item 512 loads
+# with `aload 1` — but the stack item is not, so the frame promised a
+# java/lang/String over a Long and the class did not load:
+# "java.lang.VerifyError: Inconsistent stackmap frames at branch target 29 ...
+# Type 'java/lang/Long' (current frame, stack[0]) is not assignable to
+# 'java/lang/String' (stack map, stack[0])". `503-distill-distinct-frame`,
+# `503-distill-dropwhile-frame` and `503-distill-skip-frame` now claim such
+# markers and derive only the STACK item from the survivor, leaving the local on
+# bridge-input the way 504 already does. Keeping the element type identical
+# hides the bug (`map(x -> x + 1).distinct()` in `distinct.yml` always ran),
+# which is why every other stateful fixture passed.
+#
+# All three guards are here, plus both retyping shapes, one per pipeline:
+#   * lambda map + distinct — 307's seen-set guard. String -> Long lengths
+#     {1, 2, 2, 3}, three of them distinct.
+#   * lambda map + skip — 308's countdown guard. Three elements, one skipped,
+#     count = 2.
+#   * lambda map + dropWhile — 310's latch guard, the one that names its own
+#     survivor through the predicate it tests the item with. Lengths
+#     {1, 2, 3, 1}, the leading 1 dropped, count = 3.
+#   * methodref map + distinct — Object::toString, desugared by 107 into a
+#     wrapper whose signature is (Ljava/lang/Long;)Ljava/lang/String;, so this
+#     one retypes the other way round ("Type 'java/lang/String' ... is not
+#     assignable to 'java/lang/Long'"). {5, 3, 5, 6, 7} stringified, four
+#     distinct.
+# Each pipeline collapses its map + stateful operator into a single
+# Stream.mapMulti: invokedynamic drops 5 -> 4 (dropWhile's map and predicate
+# share one dispatch, the other three pipelines had one lambda each all along),
+# the four captured java/util/List holders show up as new == 4, and the skip's
+# long[1] countdown plus dropWhile's int[1] latch as newarray == 2. The printed
+# line asserts end to end that the optimized class VERIFIES and still computes
+# the right answers.
+java: |
+  package mapretypestateful;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      long kinds = Stream.of("a", "bb", "cc", "ddd")
+        .map(s -> Long.valueOf(s.length()))
+        .distinct()
+        .count();
+      long tails = Stream.of("a", "bb", "ccc")
+        .map(s -> Long.valueOf(s.length()))
+        .skip(1L)
+        .count();
+      long longer = Stream.of("a", "bb", "ccc", "d")
+        .map(s -> Long.valueOf(s.length()))
+        .dropWhile(v -> v < 2L)
+        .count();
+      long texts = Stream.of(5L, 3L, 5L, 6L, 7L)
+        .map(Object::toString)
+        .distinct()
+        .count();
+      System.out.printf("The result is %d/%d/%d/%d\n", kinds, tails, longer, texts);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 3/2/3/4"
+before:
+  invokedynamic: 5
+  invokeinterface: 12
+  invokestatic: 16
+  invokevirtual: 5
+  new: 0
+  newarray: 0
+after:
+  invokedynamic: 4
+  invokeinterface: 20
+  invokestatic: 23
+  invokevirtual: 8
+  new: 4
+  newarray: 2


### PR DESCRIPTION
Closes #798.

## The defect

`503-distill-state-frame` fills **both** the local at slot 1 **and** the single stack item of a stateful guard's keep-frame from the distill's `bridge-input`. The local is right — it is the bridge method's declared parameter, the item `512` loads with `aload 1`. The stack item is not: a stateful guard is type-transparent, so the value alive at the keep-label is whatever the fused body produced just before it, and `401` is free to fuse a type-**changing** map in ahead.

```
java.lang.VerifyError: Inconsistent stackmap frames at branch target 29
  Location: distill_5029480(Ljava/util/List;Ljava/lang/String;Ljava/util/function/Consumer;)V @29
  Reason: Type 'java/lang/Long' (current frame, stack[0]) is not assignable
          to 'java/lang/String' (stack map, stack[0])
```

This is the stateful twin of #794, which fixed the same mistake on the stateless filter branch. All three stateful guards are affected, each reproduced and confirmed locally before the fix:

| guard | pipeline | error |
| --- | --- | --- |
| `307` distinct | `.map(s -> Long.valueOf(s.length())).distinct()` | `'java/lang/Long'` not assignable to `'java/lang/String'` |
| `308` skip | `.map(s -> Long.valueOf(s.length())).skip(1L)` | same, at branch target 33 |
| `310` dropWhile | `.map(s -> Long.valueOf(s.length())).dropWhile(v -> v < 2L)` | same, at branch target 48 |

A method-reference map retypes it the other way round and fails just as hard (`.map(Object::toString).distinct()` → `'java/lang/String'` not assignable to `'java/lang/Long'`).

## The fix

Three rules that sort in front of `503` and derive **only** the stack item from the survivor, leaving the local on `bridge-input` the way `504` already does:

- `503-distill-distinct-frame` and `503-distill-skip-frame` — these guards only ever see `Set.add(Object)` and a `long[]`, so the survivor has to come from the other side: the return type of the `invokestatic` matched immediately in front of the guard's `fetch` marker. That adjacency is exact — a distill body is emit-shaped, so the last opcode before the guard *is* the item's producer, and `307`/`308` open with the fetch. They fire only for an object return; a void one (a `peek` fused ahead) or a primitive one falls through.
- `503-distill-dropwhile-frame` — `310`'s guard names its own survivor, through the predicate it tests the item with, so it needs no producer in front of it. Reads it the way `506-distill-predicate-frame` does for the stateless filter branch.

No integer is free between 502 and 503, so all three share 503's number and rely on alphabetical filename order being the schedule: `503-distill-distinct-frame` < `503-distill-dropwhile-frame` < `503-distill-skip-frame` < `503-distill-state-frame`. `503` keeps the guards whose neighbour preserves the element type, or that have nothing fused ahead of them at all, where `bridge-input` is right; its header now says so instead of carrying the "v1" caveat the issue quoted.

## Tests

- `src/test/phino/503-distill-{distinct,dropwhile,skip}-frame.yml` — one single-rule pack per guard, each listing `503` alongside the new rule so the ordering is asserted too.
- `src/test/resources/org/eolang/hone/optimize/streams/map-retype-stateful.yml` — end-to-end, all three guards plus both retyping shapes in one class; the printed line asserts the optimized class verifies *and* still computes the right answers.

## Verification

Docker is unavailable in this environment, so the `@DisabledWithoutDocker` optimize fixtures were run through an equivalent host-`phino` harness (phino 0.0.106, the pinned version, JDK 21):

- 70/70 `src/test/phino` packs pass (`mvn -Pdeep test`), 67 before this change.
- 43 optimize fixtures: all pass except `all-ops` and `stateful-ops`, which fail **identically with the new rules removed** — `stateful-ops` pins `after new: 1` while dropWhile now folds into a second captured `List`, and `all-ops` differs in four counts. Both are pre-existing and untouched by this change.
- Negative controls: the new fixture fails with `VerifyError` when all three rules are removed, and still fails when only `503-distill-dropwhile-frame` is removed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MbeMLvuMsp86r5Q3txeeJT)_