### PR TITLE
fix(#801): stop 241 minting the no-op type that 271 deletes

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/2xx/241-type-primitive-to-primitive-after-map.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/2xx/241-type-primitive-to-primitive-after-map.phr
@@ -2,6 +2,30 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
+# Where a primitive map hands its result to another primitive operation that
+# accepts a different primitive, the two need a conversion spliced between
+# them; this rule mints the Φ.hone.type node that performs it.
+#
+# It must NOT mint one when the conversion is an identity. 271 deletes every
+# type node whose `from` equals its `to`, so on a `from == to` pair the two
+# rules take turns — 241 minting the no-op node, 271 taking it away — and,
+# because the whole streams/* selection runs to fixpoint inside ONE `phino
+# rewrite` invocation, the expression comes back to a state it already had and
+# phino's loop detector aborts the run ("it seems rewriting is looping"),
+# killing the build (#801).
+#
+# An unboxing head is what exposes it: in
+# `INTEGERS.stream().mapToInt(Integer::intValue).map(n -> n + 2).sum()` the
+# oscillation is the only thing still changing the expression by the time it
+# starts, so the detector fires. Wherever some other rule is still rewriting,
+# the very same no-op node is minted and deleted harmlessly, which is why
+# `IntStream.of(1, 2, 3).map(n -> n + 2).map(n -> n * 3).sum()` finishes.
+#
+# The `having` below is that guard — the identical one the filter twin
+# 251-type-primitive-to-primitive-after-filter already carries. It costs
+# nothing else: with `from == to` the node is a no-op conversion, and the
+# `returned` / `bridge-output` updates this rule makes to 𝜏-second reduce to
+# the values it already holds.
 name: type-primitive-to-primitive-after-map
 pattern: |
   ⟦
@@ -140,3 +164,8 @@ where:
       - 𝑒-two
       - 𝑒-updated-filter-bridge-output-pattern
       - 𝑒-updated-map-bridge-output-pattern
+having:
+  not:
+    eq:
+      - 𝑒-type-from
+      - 𝑒-type-to

--- a/src/main/resources/org/eolang/hone/rules/streams/2xx/251-type-primitive-to-primitive-after-filter.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/2xx/251-type-primitive-to-primitive-after-filter.phr
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
+# The filter twin of 241: the same Φ.hone.type conversion node, spliced in
+# behind a filter rather than behind a map.
+#
+# The `having` guard at the bottom is load bearing, for the reason 241's
+# header spells out: a type node whose `from` equals its `to` is deleted by
+# 271 the moment it is minted, and the pair then oscillates until phino's
+# loop detector aborts the whole rewrite (#801). Do not drop it as redundant.
 name: type-primitive-to-primitive-after-filter
 pattern: |
   ⟦

--- a/src/test/phino/801-noop-type-no-loop.yml
+++ b/src/test/phino/801-noop-type-no-loop.yml
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Regression for #801: 2xx/241-type-primitive-to-primitive-after-map and
+# 2xx/271-remove-useless-types disagreed about a node neither of them needs.
+# 241 minted a Φ.hone.type between two adjacent primitive operations whenever
+# the first's `returned` was in [DFIJ] and the second's `accepted` in
+# [BCDFIJS], with nothing forbidding `from` from equalling `to`; 271 deletes
+# precisely the type nodes whose `from` equals its `to`. On an identity pair
+# the two took turns forever, and since the whole streams/* selection runs to
+# fixpoint inside ONE `phino rewrite` invocation, the expression returned to a
+# state it already had and phino's loop detector aborted the run
+# ("it seems rewriting is looping"), failing the optimize goal.
+#
+# Both maps below are `I -> I`, so 241 would derive `from ↦ "i", to ↦ "i"` —
+# exactly the no-op node the issue's small-steps dump caught being minted at
+# step 43 and deleted at step 49. 241 now carries the `having` guard its filter
+# twin 251 already had, so it declines, 271 finds nothing to remove and the
+# rewrite settles on the input. Loading BOTH rules is what makes this a
+# regression test: 241 alone terminates either way, because the minted node
+# separates the pair and stops the rule from matching a second time.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/2xx/241-type-primitive-to-primitive-after-map.phr
+  - src/main/resources/org/eolang/hone/rules/streams/2xx/271-remove-useless-types.phr
+input: |
+  ⟦
+    body ↦ ⟦
+      op1 ↦ ⟦
+        φ ↦ Φ.hone.map,
+        opcode ↦ "invokestatic",
+        class ↦ "probe/R",
+        bridge-input ↦ "Ljava/lang/Integer;",
+        bridge-output ↦ "Ljava/lang/Integer;",
+        accepted ↦ "I",
+        returned ↦ "I",
+        static ↦ "true",
+        target ↦ ⟦
+          handle ↦ 6,
+          class ↦ "probe/R",
+          method ↦ "lambda$main$0",
+          signature ↦ "(I)I",
+          is-interface ↦ Φ.false
+        ⟧
+      ⟧,
+      op2 ↦ ⟦
+        φ ↦ Φ.hone.map,
+        opcode ↦ "invokestatic",
+        class ↦ "probe/R",
+        bridge-input ↦ "Ljava/lang/Integer;",
+        bridge-output ↦ "Ljava/lang/Integer;",
+        accepted ↦ "I",
+        returned ↦ "I",
+        static ↦ "true",
+        target ↦ ⟦
+          handle ↦ 6,
+          class ↦ "probe/R",
+          method ↦ "lambda$main$1",
+          signature ↦ "(I)I",
+          is-interface ↦ Φ.false
+        ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+expected:
+  - ⟦ 𝐵-head, 𝜏-one ↦ ⟦ φ ↦ Φ.hone.map, 𝐵-one ⟧, 𝜏-two ↦ ⟦ φ ↦ Φ.hone.map, 𝐵-two ⟧, 𝐵-tail ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/unbox-primitive-map.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/unbox-primitive-map.yml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# An unboxing mapToX followed by a primitive map must not send the rewrite
+# into a loop (#801).
+#
+# 241 used to mint a Φ.hone.type between two adjacent primitive operations
+# without checking whether the conversion was an identity, and 271 deletes
+# exactly the type nodes whose `from` equals its `to`. The two then took turns
+# on the `I -> I` pair this pipeline lowers to. That is harmless for as long as
+# some other rule keeps changing the expression — which is why
+# `IntStream.of(1, 2, 3).map(n -> n + 2).map(n -> n * 3).sum()` always
+# finished, minting and deleting the very same no-op node on the way. A
+# METHOD-REFERENCE mapToX is the shape that leaves nothing else to do: 205 only
+# recognises a lambda-ised mapToX, so `mapToInt(Integer::intValue)` stays put,
+# the rest of the expression settles, and the oscillation becomes the only
+# thing still happening. phino's loop detector then saw a state it already had,
+# aborted with "it seems rewriting is looping", and the optimize goal died with
+# "Failed to execute docker, code=0x0001".
+#
+# Both the int and the long form are covered; the issue reports
+# mapToLong(Integer::longValue) failing identically. No opcode counts are
+# asserted — this pack is about the build finishing at all and the optimized
+# bytecode still summing to the same numbers.
+java: |
+  package unboxmap;
+  import java.util.Arrays;
+  import java.util.List;
+  public class X {
+    private static final List<Integer> INTEGERS = Arrays.asList(5, 3, 8, 2, 7);
+    public static void main(String[] a) {
+      int i = INTEGERS.stream()
+        .mapToInt(Integer::intValue)
+        .map(n -> n + 2)
+        .sum();
+      long j = INTEGERS.stream()
+        .mapToLong(Integer::longValue)
+        .map(n -> n + 2L)
+        .sum();
+      System.out.printf("The results are %d %d\n", i, j);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The results are 35 35"


### PR DESCRIPTION
Closes #801.

## The bug

`2xx/241-type-primitive-to-primitive-after-map` mints a `Φ.hone.type` between two adjacent primitive operations whenever the first's `returned` matches `^[DFIJ]$` and the second's `accepted` matches `^[BCDFIJS]$`. Nothing in its `when` forbade `from` from equalling `to`. `2xx/271-remove-useless-types` deletes precisely the type nodes whose `from` equals its `to`.

On an identity pair the two took turns. Because the whole `streams/*` selection runs to fixpoint inside **one** `phino rewrite` invocation, the expression came back to a state it already had, phino's loop detector aborted, and the optimize goal died:

```
[ERROR]: On rewriting step '1' of rule 'remove-useless-types' we got the same
         expression as we got at one of the previous step, it seems rewriting is looping
...
java.io.IOException: Failed to execute docker, code=0x0001
```

An unboxing head is what exposes it. Once
`INTEGERS.stream().mapToInt(Integer::intValue).map(n -> n + 2).sum()` settles, the oscillation is the only thing still changing the expression, so the detector fires. Where some other rule keeps rewriting, the very same no-op node is minted and deleted harmlessly — which is why the equivalent `IntStream.of(1, 2, 3).map(n -> n + 2).map(n -> n * 3).sum()` always finished. In small-steps mode every rule is its own process, so nothing notices there either.

## The fix

241 now carries the `having` guard its filter twin `251-type-primitive-to-primitive-after-filter` **already had** — so this PR only needs to add it in one place, not two as the issue anticipated:

```yaml
having:
  not:
    eq:
      - 𝑒-type-from
      - 𝑒-type-to
```

Nothing else is lost by declining. With `from == to` the node is an identity conversion, and the two other edits 241 makes to `𝜏-second` reduce to the values it already holds:

- `returned` — for `𝜏-two ↦ map` the sed chain resolves back to `𝑒-second-returned` unchanged; for a filter it resolves to `𝑒-first-returned`, which under `from == to` is the filter's own `accepted`, and every filter producer (231/232) already sets `returned = accepted`.
- `bridge-output` — same shape, and 231/232 likewise emit `bridge-output = bridge-input`, the boxed wrapper of the same primitive letter on both sides.

Both twins got a header comment explaining why the guard is load bearing, so it does not get deleted later as redundant.

## Tests

- `src/test/phino/801-noop-type-no-loop.yml` — a single-rule pack on two adjacent `I -> I` maps, the exact shape whose `from ↦ "i", to ↦ "i"` node the issue's small-steps dump caught being minted at step 43 and deleted at step 49. It loads **both** 241 and 271; that is what makes it a regression test, since 241 alone terminates either way (the minted node separates the pair and stops it matching again). Before the fix `phino rewrite` exits non-zero on the loop; after it, the rewrite settles on the input and the expected pattern asserts the two maps are still adjacent, i.e. nothing was spliced between them.
- `src/test/resources/org/eolang/hone/optimize/streams/unbox-primitive-map.yml` — the end-to-end repro, covering both the `mapToInt(Integer::intValue)` and the `mapToLong(Integer::longValue)` form the issue reports. No opcode counts are asserted; this pack is about the build finishing at all and the optimized bytecode still summing to the same numbers.

## Verification

`mvn test` passes (47 tests, 0 failures). The `deep` suites could not be exercised here — neither `phino` nor a working Docker daemon is available in this container, and `deep.yml` only runs on push to `master` — so the two new packs are unverified against a real `phino` binary. Worth a `mvn -Pdeep test` before merge. I did confirm out of band that the fixture's Java compiles and prints `The results are 35 35` unoptimized, matching its `log` assertion, and that both new YAML files pass `yamllint -c .yamllint.yml` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYQru4RyeWEcTJR8knbSKu)_