### PR TITLE
fix(#804): let 283 reach a dropWhile predecessor

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/2xx/283-insert-dup-before-filter-after-stateful.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/2xx/283-insert-dup-before-filter-after-stateful.phr
@@ -14,12 +14,25 @@
 # stateful guards and 𝜏-second is a filter, it splices the same Φ.hone.dup
 # between them. After
 # insertion the two are no longer adjacent, so it fires once per site.
+#
+# The three guards disagree about the ORDER of their bindings, and phino
+# matches bindings positionally — a 𝐵 meta swallows a run of them, everything
+# else has to line up one for one. 216 and 220 mint `class` directly behind
+# `φ`, but the Φ.hone.dropWhile that 208 mints carries `opcode` in between,
+# because it is a lambda-bearing pragma shaped like map and filter. A 𝜏-first
+# that spelled `class` out as the second binding therefore matched distinct
+# and skip and silently walked past every dropWhile: no dup was spliced, the
+# predicate ate the only copy of the item, and the class died at load with
+# "Inconsistent stackmap frames" (#804). 𝐵-first-head absorbs whatever the
+# guard puts between `φ` and `class` — none of it is anything this rule reads
+# — so the ordering a fourth guard picks will not matter either.
 name: insert-dup-before-filter-after-stateful
 pattern: |
   ⟦
     𝐵-before,
     𝜏-first ↦ ⟦
       φ ↦ Φ.hone.𝜏-one,
+      𝐵-first-head,
       class ↦ 𝑒-class,
       𝐵-first-rest
     ⟧,
@@ -41,6 +54,7 @@ result: |
     𝐵-before,
     𝜏-first ↦ ⟦
       φ ↦ Φ.hone.𝜏-one,
+      𝐵-first-head,
       class ↦ 𝑒-class,
       𝐵-first-rest
     ⟧,

--- a/src/test/java/org/eolang/hone/RandomPipeline.java
+++ b/src/test/java/org/eolang/hone/RandomPipeline.java
@@ -34,14 +34,13 @@ import java.util.Random;
  * the API allows to skip the traversal altogether.</p>
  *
  * <p>The grammar does not step around the operations that the rewrite has been
- * known to break — every shape behind #787, #788, #790, #794, #798 and #799 is
- * still reachable, since a generator that avoids the defects we already know
- * about would only prove that we know about them, and nothing about a
- * regression. Two shapes are quarantined all the same, in
- * {@code quarantined()}: they break the rewrite today, they are filed as #804
- * and #805, and a suite that fails on them every night reports nothing new.
- * Each is named by its issue, so closing the issue widens the walk by deleting
- * one clause.</p>
+ * known to break — every shape behind #787, #788, #790, #794, #798, #799 and
+ * #804 is still reachable, since a generator that avoids the defects we already
+ * know about would only prove that we know about them, and nothing about a
+ * regression. One shape is quarantined all the same, in
+ * {@code quarantined()}: it breaks the rewrite today, it is filed as #805, and
+ * a suite that fails on it every night reports nothing new. It is named by its
+ * issue, so closing the issue widens the walk by deleting one clause.</p>
  *
  * @since 0.30.0
  * @todo #791:60min Reach the last corners of the API. There is no
@@ -574,11 +573,11 @@ final class RandomPipeline {
     /**
      * The issue that quarantines this walk, if one does.
      *
-     * <p>Two shapes break the rewrite today, both emitting a class the verifier
-     * rejects, and both are reported upstream. A walk that reaches one of them
-     * is re-rolled from a derived seed instead of being generated, so the suite
-     * stays a net for regressions rather than a standing failure. Delete a
-     * clause here the day its issue closes, and the walk widens again.</p>
+     * <p>One shape breaks the rewrite today, emitting a class the verifier
+     * rejects, and it is reported upstream. A walk that reaches it is re-rolled
+     * from a derived seed instead of being generated, so the suite stays a net
+     * for regressions rather than a standing failure. Delete a clause here the
+     * day its issue closes, and the walk widens again.</p>
      *
      * <p>Each clause is as narrow as the shape it owns. #805 wants three things
      * at once: a conversion into an object domain, so the type the guard's frame
@@ -594,31 +593,10 @@ final class RandomPipeline {
      */
     private static String quarantined(final List<String> walk) {
         String issue = "";
-        if (RandomPipeline.dropsThenFilters(walk)) {
-            issue = "#804";
-        } else if (RandomPipeline.retypesThenGuards(walk)) {
+        if (RandomPipeline.retypesThenGuards(walk)) {
             issue = "#805";
         }
         return issue;
-    }
-
-    /**
-     * Does a {@code filter} follow a {@code dropWhile}, which loses its dup?
-     * @param walk The lines the walk picked
-     * @return TRUE if the walk reaches the shape of #804
-     */
-    private static boolean dropsThenFilters(final List<String> walk) {
-        boolean found = false;
-        boolean dropped = false;
-        for (final String line : walk) {
-            final String code = RandomPipeline.code(line);
-            if (dropped && code.startsWith("filter(")) {
-                found = true;
-                break;
-            }
-            dropped = dropped || code.startsWith("dropWhile(");
-        }
-        return found;
     }
 
     /**

--- a/src/test/phino/283-insert-dup-before-filter-after-distinct.yml
+++ b/src/test/phino/283-insert-dup-before-filter-after-distinct.yml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The other half of #804: the guard that 216 mints for distinct puts `class`
+# directly behind `φ` and carries no `opcode` at all, so the 𝐵-first-head meta
+# that lets 283 reach a dropWhile has to bind the empty run of bindings here
+# and leave this site rewritten exactly as it was before.
+#
+# The dup opcode is read off the filter's `bridge-input`, a reference type
+# here, so it is the one-slot `dup` rather than `dup2`; distinct erases the
+# element type, hence the Object.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/2xx/283-insert-dup-before-filter-after-stateful.phr
+input: |
+  ⟦
+    body ↦ ⟦
+      op1 ↦ ⟦
+        φ ↦ Φ.hone.distinct,
+        class ↦ "dist/X",
+        stream-class ↦ "java/util/stream/Stream"
+      ⟧,
+      op2 ↦ ⟦
+        φ ↦ Φ.hone.o-filter,
+        opcode ↦ "invokestatic",
+        class ↦ "dist/X",
+        bridge-input ↦ "Ljava/lang/Object;",
+        bridge-output ↦ "Ljava/lang/Object;",
+        accepted ↦ "Ljava/lang/String;",
+        returned ↦ "Ljava/lang/Object;",
+        static ↦ "true",
+        target ↦ ⟦
+          handle ↦ 6,
+          class ↦ "dist/X",
+          method ↦ "lambda$main$0",
+          signature ↦ "(Ljava/lang/String;)Z",
+          is-interface ↦ Φ.false
+        ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+expected:
+  - ⟦ 𝐵-head, 𝜏-distinct ↦ ⟦ φ ↦ Φ.hone.distinct, 𝐵-distinct ⟧, 𝜏-dup ↦ ⟦ φ ↦ Φ.hone.dup, opcode ↦ "dup", class ↦ "dist/X" ⟧, 𝜏-filter ↦ ⟦ φ ↦ Φ.hone.o-filter, 𝐵-filter ⟧, 𝐵-tail ⟧

--- a/src/test/phino/283-insert-dup-before-filter-after-dropwhile.yml
+++ b/src/test/phino/283-insert-dup-before-filter-after-dropwhile.yml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A filter that directly follows a DROPWHILE must get its guard `dup` spliced
+# in between the two, exactly like a filter that follows a distinct or a
+# skip (#804).
+#
+# The pragma 208 mints for dropWhile is lambda-bearing, so — unlike the ones
+# 216 and 220 mint for distinct and skip — it carries `opcode` between `φ` and
+# `class`. phino matches bindings positionally, so 283 used to walk straight
+# past it: no dup, the predicate ate the only copy of the item, and the keep
+# label was reached with an empty stack against a frame promising the element,
+# which is the "Inconsistent stackmap frames" the issue reports.
+#
+# The dup opcode is read off the filter's `bridge-input`, a reference type
+# here, so it is the one-slot `dup` rather than `dup2`. After the insertion the
+# dropWhile and the filter are no longer adjacent, so the rule fires once.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/2xx/283-insert-dup-before-filter-after-stateful.phr
+input: |
+  ⟦
+    body ↦ ⟦
+      op1 ↦ ⟦
+        φ ↦ Φ.hone.dropWhile,
+        opcode ↦ "invokestatic",
+        class ↦ "drop/X",
+        bridge-input ↦ "Ljava/lang/Long;",
+        bridge-output ↦ "Ljava/lang/Long;",
+        accepted ↦ "Ljava/lang/Long;",
+        returned ↦ "Ljava/lang/Long;",
+        static ↦ "true",
+        target ↦ ⟦
+          handle ↦ 6,
+          class ↦ "drop/X",
+          method ↦ "lambda$main$0",
+          signature ↦ "(Ljava/lang/Long;)Z",
+          is-interface ↦ Φ.false
+        ⟧
+      ⟧,
+      op2 ↦ ⟦
+        φ ↦ Φ.hone.p-filter,
+        opcode ↦ "invokestatic",
+        class ↦ "drop/X",
+        bridge-input ↦ "Ljava/lang/Long;",
+        bridge-output ↦ "Ljava/lang/Long;",
+        accepted ↦ "Ljava/lang/Long;",
+        returned ↦ "Ljava/lang/Long;",
+        static ↦ "true",
+        target ↦ ⟦
+          handle ↦ 6,
+          class ↦ "drop/X",
+          method ↦ "lambda$main$1",
+          signature ↦ "(Ljava/lang/Long;)Z",
+          is-interface ↦ Φ.false
+        ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+expected:
+  - ⟦ 𝐵-head, 𝜏-drop ↦ ⟦ φ ↦ Φ.hone.dropWhile, 𝐵-drop ⟧, 𝜏-dup ↦ ⟦ φ ↦ Φ.hone.dup, opcode ↦ "dup", class ↦ "drop/X" ⟧, 𝜏-filter ↦ ⟦ φ ↦ Φ.hone.p-filter, 𝐵-filter ⟧, 𝐵-tail ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/dropwhile-filter.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/dropwhile-filter.yml
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A filter riding behind a dropWhile() — the shape #804 reports. A filter guard
+# spends the item on its predicate, so 283 splices a Φ.hone.dup in front of it
+# whenever a stateful guard leads; the dup is what the keep path pops when the
+# predicate says yes. The Φ.hone.dropWhile pragma 208 mints is lambda-bearing,
+# so it carries `opcode` between `φ` and `class`, while the distinct and skip
+# pragmas 216 and 220 mint put `class` directly behind `φ`. phino matches
+# bindings positionally, so 283's 𝜏-first — which spelled `class` out as the
+# second binding — matched the two of them and never the dropWhile. No dup was
+# spliced, the predicate ate the only copy of the item, and the keep label was
+# reached with an empty stack against a frame promising the element:
+# "Inconsistent stackmap frames at branch target" at load time.
+#
+# Four pipelines, one class:
+#   * plain  — the reported reproduction: dropWhile(< 2) sees 3 first, so its
+#     latch sticks at once and 3, 1, 2 all survive; filter(> 1) keeps 3 and 2
+#     -> count 2.
+#   * text   — the same shape on a String element, proving it is not about
+#     Long: the leading "" is dropped, filter(length > 1) keeps "aa" and "ccc"
+#     -> "aa+ccc". A re-evaluated predicate would drop "b" as well, so the
+#     joined text also asserts the latch still sticks.
+#   * mapped — a map behind the filter, so the whole run fuses into one
+#     mapMulti and the dup has to survive fusion: 1, 2 dropped, filter keeps
+#     the odd 3 and 5, times ten -> 80.
+#   * twice  — TWO filters behind one dropWhile, so the rule has to fire again
+#     at fixpoint on the pair it left adjacent: 5 latches the guard, filter
+#     (> 1) keeps 5, 6, 2, 7 and filter(< 7) keeps 5, 6, 2 -> count 3.
+# The `after` counts are left unasserted on purpose: this pack exists to prove
+# the optimized class VERIFIES and still computes the right answer, which the
+# printed line asserts end to end.
+java: |
+  package dropwhilefilter;
+  import java.util.stream.Collectors;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      long plain = Stream.of(3L, 1L, 2L)
+        .dropWhile(n -> n < 2L)
+        .filter(n -> n > 1L)
+        .count();
+      String text = Stream.of("", "aa", "b", "ccc")
+        .dropWhile(s -> s.isEmpty())
+        .filter(s -> s.length() > 1)
+        .collect(Collectors.joining("+"));
+      long mapped = Stream.of(1L, 2L, 3L, 4L, 5L)
+        .dropWhile(n -> n < 3L)
+        .filter(n -> n % 2L == 1L)
+        .map(n -> n * 10L)
+        .reduce(0L, Long::sum);
+      long twice = Stream.of(5L, 1L, 6L, 2L, 7L)
+        .dropWhile(n -> n < 4L)
+        .filter(n -> n > 1L)
+        .filter(n -> n < 7L)
+        .count();
+      System.out.printf("The result is %d/%s/%d/%d\n", plain, text, mapped, twice);
+    }
+  }
+# The production default grep-in (see #449/#671/#705) would already select this
+# class via its `filter` and `map` tokens, but the pack opts the pre-filter off
+# with `.*` so it stays decoupled from the exact set of method names the
+# default happens to include.
+grep-in: ".*"
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 2/aa+ccc/80/3"


### PR DESCRIPTION
Closes #804.

## The defect

`283-insert-dup-before-filter-after-stateful.phr` splices a `Φ.hone.dup` between a stateful guard and the filter behind it, so the predicate has a copy of the item to eat and the keep path still finds the item on the stack. Its `𝜏-first` spelled `class` out as the *second* binding of the guard:

```
𝜏-first ↦ ⟦ φ ↦ Φ.hone.𝜏-one, class ↦ 𝑒-class, 𝐵-first-rest ⟧
```

phino matches bindings **positionally** (`matchBindings` walks the two lists in lockstep; only a `𝐵` meta absorbs a run). That shape fits the pragmas `216` and `220` mint for `distinct` and `skip`, which put `class` directly behind `φ` — but not the one `208` mints for `dropWhile`, which carries `opcode` in between because it is lambda-bearing, like `map` and `filter`. So the rule matched the first two and walked past every `dropWhile`: no dup was spliced, the predicate ate the only copy of the item, and the keep label was reached with an empty stack against a frame promising the element.

```
java.lang.VerifyError: Inconsistent stackmap frames at branch target 52
  Location: distill_5021652(Ljava/util/List;Ljava/lang/Long;Ljava/util/function/Consumer;)V @48: ifne
```

## The fix

A `𝐵-first-head` meta now absorbs whatever the guard puts between `φ` and `class` — none of it is anything this rule reads — so all three guards match and the binding order a fourth one picks will not matter either. The rule is otherwise untouched: `when` still narrows `𝜏-one` to `distinct`/`skip`/`dropWhile`, and `𝑒-dup-opcode` is still read off the filter's `bridge-input`.

## Tests

- `src/test/phino/283-insert-dup-before-filter-after-dropwhile.yml` — the binding order that regressed; asserts the `Φ.hone.dup` lands between the two pragmas.
- `src/test/phino/283-insert-dup-before-filter-after-distinct.yml` — the other order, where the new meta has to bind the empty run and leave the site rewritten exactly as before.
- `src/test/resources/org/eolang/hone/optimize/streams/dropwhile-filter.yml` — end to end: the reported reproduction, the same shape on a `String` element, a `map` behind the filter so the whole run fuses into one `mapMulti`, and two filters behind one `dropWhile` so the rule has to fire again at fixpoint. Asserts what the four pipelines print. **On `master` this pack fails with the exact `VerifyError` above; with the fix it passes.**
- `RandomPipeline` loses its `#804` quarantine clause (`dropsThenFilters`), so the walk reaches the shape again. 2 of the 120 default seeds put a `filter` behind a `dropWhile`, and `preservesWhatRandomPipelinesPrint` is green with them in.

## What was run

Against phino `0.0.106` on the host (no Docker), `LC_ALL=C.UTF-8`:

| Command | Result |
| --- | --- |
| `mvn test` | 52 run, 0 failures |
| `mvn -Pdeep test -Dtest='OptimizeMojoTest#appliesPhinoRulesAsSpecifiedInYamlPack'` | 76 run, 0 failures |
| `mvn -Pdeep test -Dtest='OptimizeMojoTest#preservesWhatRandomPipelinesPrint'` | passed |
| `mvn -Pdeep test -Dtest='OptimizeMojoTest#optimizesAsSpecifiedInYamlPack'` | 48 run, 2 failures — both pre-existing, see below |
| `mvn clean install -DskipTests -Pqulice` | BUILD SUCCESS |

## Pre-existing failures, not touched here

`all-ops.yml` and `stateful-ops.yml` fail their `after` opcode counts, identically before and after this change (verified by running the same suite on `master`). Both are the two packs that contain a `dropWhile`, and both look like counts recorded before `#718` taught `208`/`310` to recognise it — `stateful-ops.yml` still says in prose that "takeWhile and dropWhile are NOT recognised yet", while its fused `dropWhile` now allocates a second `ArrayList` (`new` 1 → 2). They are a separate defect from this one, so this PR leaves them alone rather than re-recording numbers measured on a different JDK than the reference image.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FSP6qGpbA3Pn85u6dcSBes)_