### PR TITLE
fix(#805): frame a stateful guard across a relay

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-distinct-frame-peeked.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-distinct-frame-peeked.phr
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The peek() member of the relayed family (#805) — read
+# `510-distill-distinct-frame-relayed` for the defect it shares.
+#
+# A peek fused ahead of a distinct() guard is the one relay that leaves no
+# stackmap frame behind it: 309 shapes its body as `dup` + a call to the
+# desugared consumer, so what the guard's `Φ.hone.fetch` marker follows is an
+# invokestatic that returns nothing. `503-distill-distinct-frame` fires only for
+# an object return, its header calling a void one right for
+# `503-distill-state-frame` and its `bridge-input` — which it is not, because a
+# peek does not change the item, so the survivor is still whatever was produced
+# BEFORE the peek. `Stream.of("a", "bb").map(s -> new Pair(1L, s))
+# .peek(p -> SUM[0] += p.key()).distinct().count()` therefore dies with "Type
+# 'probe/Pair' (current frame, stack[0]) is not assignable to
+# 'java/lang/String' (stack map, stack[0])".
+#
+# The consumer names the survivor itself, the way dropWhile's predicate does in
+# `503-distill-dropwhile-frame` and the filter's does in
+# `506-distill-predicate-frame`: the item the guard keeps is the value the
+# peek's `dup` copied, which is the value handed to the consumer, so the
+# consumer's own parameter type is that item's type. Reading it there also
+# means a RUN of peeks needs no separate rule — the last one is the one in front
+# of the fetch, and every peek in the run names the same item.
+#
+# It fires only for a single object parameter, and not for Ljava/lang/Object;.
+# The parameter is an upper bound of the survivor rather than its exact type
+# (`peek((Object o) -> ...)` compiles onto a Stream of anything), and a frame
+# that widens the item is safe at the branch but starves a narrower consumer
+# further down the fused body, where 505 only splices a `checkcast` for the
+# Object bridge-input of a distinct/skip-led pipeline. Java writes these lambdas
+# with an inferred parameter, so an Object one means the pipeline was declared
+# that way, and the fallback's bridge-input is the better answer for it.
+#
+# Ordering: shares 503's number, since no integer is free between 502 and 503,
+# and needs only to sort in front of the `503-distill-state-frame` fallback,
+# which it does — `503-distill-distinct-frame-peeked` <
+# `503-distill-state-frame`. Where it lands relative to
+# `503-distill-distinct-frame` does not matter: a void return and an object one
+# are disjoint, so at most one of the two can claim a marker. Scoped to a
+# distill-lambda WITH `captured`, like 503 itself.
+name: distill-distinct-frame-peeked
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ 𝑒-static,
+    bridge-input ↦ 𝑒-bridge-input,
+    consumer ↦ 𝑒-consumer,
+    target-method ↦ 𝑒-target-method,
+    captured ↦ 𝑒-captured,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-head ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokestatic,
+        i2 ↦ 𝑒-head-class,
+        i3 ↦ 𝑒-head-method,
+        i4 ↦ 𝑒-head-signature,
+        i5 ↦ 𝑒-head-is-interface
+      ⟧,
+      𝜏-fetch ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ 𝑒-fetch-type ⟧,
+      𝜏-swap ↦ ⟦ φ ↦ Φ.jeo.opcode.swap ⟧,
+      𝜏-dup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup_x1 ⟧,
+      𝜏-add ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokevirtual,
+        i1 ↦ 𝑒-add-class,
+        i2 ↦ 𝑒-add-method,
+        i3 ↦ 𝑒-add-signature,
+        i4 ↦ 𝑒-add-is-interface
+      ⟧,
+      𝜏-ifne ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ 𝑒-ifne-target ⟧,
+      𝜏-pop ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+      𝜏-return ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      𝜏-keep-label ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-keep-label ⟧,
+      𝜏-frame ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ 𝑒-static,
+    bridge-input ↦ 𝑒-bridge-input,
+    consumer ↦ 𝑒-consumer,
+    target-method ↦ 𝑒-target-method,
+    captured ↦ 𝑒-captured,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-head ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokestatic,
+        i2 ↦ 𝑒-head-class,
+        i3 ↦ 𝑒-head-method,
+        i4 ↦ 𝑒-head-signature,
+        i5 ↦ 𝑒-head-is-interface
+      ⟧,
+      𝜏-fetch ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ 𝑒-fetch-type ⟧,
+      𝜏-swap ↦ ⟦ φ ↦ Φ.jeo.opcode.swap ⟧,
+      𝜏-dup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup_x1 ⟧,
+      𝜏-add ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokevirtual,
+        i1 ↦ 𝑒-add-class,
+        i2 ↦ 𝑒-add-method,
+        i3 ↦ 𝑒-add-signature,
+        i4 ↦ 𝑒-add-is-interface
+      ⟧,
+      𝜏-ifne ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ 𝑒-ifne-target ⟧,
+      𝜏-pop ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+      𝜏-return ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      𝜏-keep-label ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-keep-label ⟧,
+      𝜏-frame ↦ ⟦
+        φ ↦ Φ.jeo.frame,
+        type ↦ 0,
+        locals ↦ ⟦
+          φ ↦ Φ.jeo.seq.of4,
+          x0 ↦ 𝑒-frame-captured,
+          x1 ↦ 𝑒-frame-input,
+          x2 ↦ 𝑒-frame-consumer,
+          x3 ↦ "integer"
+        ⟧,
+        stack ↦ ⟦
+          φ ↦ Φ.jeo.seq.of1,
+          x0 ↦ 𝑒-frame-item
+        ⟧
+      ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+when:
+  and:
+    - matches:
+        - '^\(L[^;]+;\)V$'
+        - 𝑒-head-signature
+    - not:
+        matches:
+          - '^\(Ljava/lang/Object;\)V$'
+          - 𝑒-head-signature
+where:
+  - meta: 𝑒-frame-item
+    function: sed
+    args:
+      - 𝑒-head-signature
+      - '"s/^\\(L(.+);\\)V$/$1/g"'
+  - meta: 𝑒-frame-input
+    function: sed
+    args:
+      - 𝑒-bridge-input
+      - '"s/^B$/byte/g"'
+      - '"s/^C$/char/g"'
+      - '"s/^D$/double/g"'
+      - '"s/^F$/float/g"'
+      - '"s/^I$/integer/g"'
+      - '"s/^J$/long/g"'
+      - '"s/^S$/short/g"'
+      - '"s/^Z$/boolean/g"'
+      - '"s/^L(.+);$/$1/g"'
+  - meta: 𝑒-frame-captured
+    function: sed
+    args:
+      - 𝑒-captured
+      - '"s/^L(.+);$/$1/g"'
+  - meta: 𝑒-frame-consumer
+    function: sed
+    args:
+      - 𝑒-consumer
+      - '"s/^L(.+);$/$1/g"'

--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-predicate-frame.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-predicate-frame.phr
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The stateful counterpart of `506-distill-predicate-frame` (#794), for a filter
+# guard that has been fused into a STATEFUL distill — one whose wrapper (512)
+# owns the per-call counter at local 3 (#805).
+#
+# 304 leaves a `Φ.hone.frame-item` marker at its keep-label. In a stateless
+# distill-lambda `506-distill-predicate-frame` claims it and names the survivor
+# through the predicate's own parameter; in a stateful one nothing did, and the
+# marker fell all the way to `503-distill-state-frame`, which writes the frame
+# from `bridge-input`. That is the map-retype defect of #794 all over again, just
+# on the branch where a stateful operator is riding the same pipeline: for
+# `Stream.of("a", "bb").map(s -> new Pair(1L, s)).filter(p -> p.key() > 0L)
+# .distinct().count()` the distill receives a java/lang/String, the head
+# `lambda$main$0:(Ljava/lang/String;)Lprobe/Pair;` retypes it, and the frame
+# promises a String over a Pair: "java.lang.VerifyError: Inconsistent stackmap
+# frames at branch target 14 ... Type 'probe/Pair' (current frame, stack[0]) is
+# not assignable to 'java/lang/String' (stack map, stack[0])".
+#
+# The survivor at the keep-label is the value the guard's `dup` copied, which is
+# the value handed to the predicate, so the predicate's parameter names it — in
+# a fused body and in an unfused one alike, where the parameter and bridge-input
+# coincide. The frame written here is FULL rather than same-locals-1 for the
+# reason 504 gives: a same-locals frame would drop the counter 512 keeps at slot
+# 3 and the next guard's `iload 3` would read an undefined local. The local at
+# slot 1 stays on `bridge-input`, as everywhere in this family.
+#
+# It is the twin of 504, which does the same for the object filters 305 lowers
+# with a frame already on them: 504 promotes that frame and keeps its item, this
+# rule fills in the one 304 leaves open. Fires only for a single object
+# parameter (`(L<type>;)Z`); a primitive predicate keeps falling through to 503
+# and its bridge-input, which is right for it, and a captured predicate — whose
+# call takes the captured values as well as the item — is skipped.
+#
+# Ordering: shares 503's number, since no integer is free between 502 and 503,
+# and relies on `503-distill-predicate-frame` < `503-distill-state-frame`
+# alphabetically, so the fallback is left only the markers nobody could name.
+# Scoped to a distill-lambda WITH `captured`, so stateless filter keep-labels
+# stay with 506/507.
+name: distill-predicate-frame
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ 𝑒-static,
+    bridge-input ↦ 𝑒-bridge-input,
+    consumer ↦ 𝑒-consumer,
+    target-method ↦ 𝑒-target-method,
+    captured ↦ 𝑒-captured,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-predicate ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokestatic,
+        i2 ↦ 𝑒-predicate-class,
+        i3 ↦ 𝑒-predicate-method,
+        i4 ↦ 𝑒-predicate-signature,
+        i5 ↦ 𝑒-predicate-is-interface
+      ⟧,
+      𝜏-ifne ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ 𝑒-ifne-target ⟧,
+      𝜏-return ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      𝜏-keep-label ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-keep-label ⟧,
+      𝜏-frame ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ 𝑒-static,
+    bridge-input ↦ 𝑒-bridge-input,
+    consumer ↦ 𝑒-consumer,
+    target-method ↦ 𝑒-target-method,
+    captured ↦ 𝑒-captured,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-predicate ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokestatic,
+        i2 ↦ 𝑒-predicate-class,
+        i3 ↦ 𝑒-predicate-method,
+        i4 ↦ 𝑒-predicate-signature,
+        i5 ↦ 𝑒-predicate-is-interface
+      ⟧,
+      𝜏-ifne ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ 𝑒-ifne-target ⟧,
+      𝜏-return ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      𝜏-keep-label ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-keep-label ⟧,
+      𝜏-frame ↦ ⟦
+        φ ↦ Φ.jeo.frame,
+        type ↦ 0,
+        locals ↦ ⟦
+          φ ↦ Φ.jeo.seq.of4,
+          x0 ↦ 𝑒-frame-captured,
+          x1 ↦ 𝑒-frame-input,
+          x2 ↦ 𝑒-frame-consumer,
+          x3 ↦ "integer"
+        ⟧,
+        stack ↦ ⟦
+          φ ↦ Φ.jeo.seq.of1,
+          x0 ↦ 𝑒-frame-item
+        ⟧
+      ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+when:
+  and:
+    - matches:
+        - '^\(L[^;]+;\)Z$'
+        - 𝑒-predicate-signature
+where:
+  - meta: 𝑒-frame-item
+    function: sed
+    args:
+      - 𝑒-predicate-signature
+      - '"s/^\\(L(.+);\\)Z$/$1/g"'
+  - meta: 𝑒-frame-input
+    function: sed
+    args:
+      - 𝑒-bridge-input
+      - '"s/^B$/byte/g"'
+      - '"s/^C$/char/g"'
+      - '"s/^D$/double/g"'
+      - '"s/^F$/float/g"'
+      - '"s/^I$/integer/g"'
+      - '"s/^J$/long/g"'
+      - '"s/^S$/short/g"'
+      - '"s/^Z$/boolean/g"'
+      - '"s/^L(.+);$/$1/g"'
+  - meta: 𝑒-frame-captured
+    function: sed
+    args:
+      - 𝑒-captured
+      - '"s/^L(.+);$/$1/g"'
+  - meta: 𝑒-frame-consumer
+    function: sed
+    args:
+      - 𝑒-consumer
+      - '"s/^L(.+);$/$1/g"'

--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-skip-frame-peeked.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-skip-frame-peeked.phr
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The skip() twin of `503-distill-distinct-frame-peeked` — read its header for
+# the reasoning; only the guard shape differs (#805).
+#
+# A peek is the one relay that leaves no stackmap frame for
+# `510-distill-skip-frame-relayed` to read: 309 shapes its body as `dup` + a
+# call to the desugared consumer, so 308's `Φ.hone.fetch` marker follows an
+# invokestatic that returns nothing, and `503-distill-skip-frame` — which fires
+# only for an object return — hands the marker to `503-distill-state-frame` and
+# its `bridge-input`. A peek does not change the item, so that is wrong:
+# `Stream.of("a", "bb").map(s -> new Pair(1L, s)).peek(p -> SUM[0] += p.key())
+# .skip(1L).count()` dies with "Type 'probe/Pair' (current frame, stack[0]) is
+# not assignable to 'java/lang/String' (stack map, stack[0])".
+#
+# The item the guard keeps is the value the peek's `dup` copied, which is the
+# value handed to the consumer, so the consumer's own parameter names it — the
+# way dropWhile's predicate does in `503-distill-dropwhile-frame`. Reading it
+# there covers a RUN of peeks with no extra rule: the last one is the one in
+# front of the fetch, and every peek in the run names the same item.
+#
+# It fires only for a single object parameter, and not for Ljava/lang/Object;:
+# the parameter is an upper bound of the survivor rather than its exact type,
+# and a frame that widens the item is safe at the branch but starves a narrower
+# consumer further down the fused body, where 505 only splices a `checkcast` for
+# the Object bridge-input of a distinct/skip-led pipeline.
+#
+# Ordering: shares 503's number, since no integer is free between 502 and 503,
+# and needs only to sort in front of the `503-distill-state-frame` fallback,
+# which it does — `503-distill-skip-frame-peeked` < `503-distill-state-frame`.
+# Where it lands relative to `503-distill-skip-frame` does not matter: a void
+# return and an object one are disjoint, so at most one of the two can claim a
+# marker. Scoped to a distill-lambda WITH `captured`, like 503 itself.
+name: distill-skip-frame-peeked
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ 𝑒-static,
+    bridge-input ↦ 𝑒-bridge-input,
+    consumer ↦ 𝑒-consumer,
+    target-method ↦ 𝑒-target-method,
+    captured ↦ 𝑒-captured,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-head ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokestatic,
+        i2 ↦ 𝑒-head-class,
+        i3 ↦ 𝑒-head-method,
+        i4 ↦ 𝑒-head-signature,
+        i5 ↦ 𝑒-head-is-interface
+      ⟧,
+      𝜏-fetch ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ 𝑒-fetch-type ⟧,
+      𝜏-index ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+      𝜏-dup-slot ↦ ⟦ φ ↦ Φ.jeo.opcode.dup2 ⟧,
+      𝜏-load-count ↦ ⟦ φ ↦ Φ.jeo.opcode.laload ⟧,
+      𝜏-dup-count ↦ ⟦ φ ↦ Φ.jeo.opcode.dup2_x2 ⟧,
+      𝜏-one ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_1 ⟧,
+      𝜏-decrement ↦ ⟦ φ ↦ Φ.jeo.opcode.lsub ⟧,
+      𝜏-store-count ↦ ⟦ φ ↦ Φ.jeo.opcode.lastore ⟧,
+      𝜏-zero ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_0 ⟧,
+      𝜏-compare ↦ ⟦ φ ↦ Φ.jeo.opcode.lcmp ⟧,
+      𝜏-ifle ↦ ⟦ φ ↦ Φ.jeo.opcode.ifle, i2 ↦ 𝑒-ifle-target ⟧,
+      𝜏-pop ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+      𝜏-return ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      𝜏-keep-label ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-keep-label ⟧,
+      𝜏-frame ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ 𝑒-static,
+    bridge-input ↦ 𝑒-bridge-input,
+    consumer ↦ 𝑒-consumer,
+    target-method ↦ 𝑒-target-method,
+    captured ↦ 𝑒-captured,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-head ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokestatic,
+        i2 ↦ 𝑒-head-class,
+        i3 ↦ 𝑒-head-method,
+        i4 ↦ 𝑒-head-signature,
+        i5 ↦ 𝑒-head-is-interface
+      ⟧,
+      𝜏-fetch ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ 𝑒-fetch-type ⟧,
+      𝜏-index ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+      𝜏-dup-slot ↦ ⟦ φ ↦ Φ.jeo.opcode.dup2 ⟧,
+      𝜏-load-count ↦ ⟦ φ ↦ Φ.jeo.opcode.laload ⟧,
+      𝜏-dup-count ↦ ⟦ φ ↦ Φ.jeo.opcode.dup2_x2 ⟧,
+      𝜏-one ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_1 ⟧,
+      𝜏-decrement ↦ ⟦ φ ↦ Φ.jeo.opcode.lsub ⟧,
+      𝜏-store-count ↦ ⟦ φ ↦ Φ.jeo.opcode.lastore ⟧,
+      𝜏-zero ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_0 ⟧,
+      𝜏-compare ↦ ⟦ φ ↦ Φ.jeo.opcode.lcmp ⟧,
+      𝜏-ifle ↦ ⟦ φ ↦ Φ.jeo.opcode.ifle, i2 ↦ 𝑒-ifle-target ⟧,
+      𝜏-pop ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+      𝜏-return ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      𝜏-keep-label ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-keep-label ⟧,
+      𝜏-frame ↦ ⟦
+        φ ↦ Φ.jeo.frame,
+        type ↦ 0,
+        locals ↦ ⟦
+          φ ↦ Φ.jeo.seq.of4,
+          x0 ↦ 𝑒-frame-captured,
+          x1 ↦ 𝑒-frame-input,
+          x2 ↦ 𝑒-frame-consumer,
+          x3 ↦ "integer"
+        ⟧,
+        stack ↦ ⟦
+          φ ↦ Φ.jeo.seq.of1,
+          x0 ↦ 𝑒-frame-item
+        ⟧
+      ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+when:
+  and:
+    - matches:
+        - '^\(L[^;]+;\)V$'
+        - 𝑒-head-signature
+    - not:
+        matches:
+          - '^\(Ljava/lang/Object;\)V$'
+          - 𝑒-head-signature
+where:
+  - meta: 𝑒-frame-item
+    function: sed
+    args:
+      - 𝑒-head-signature
+      - '"s/^\\(L(.+);\\)V$/$1/g"'
+  - meta: 𝑒-frame-input
+    function: sed
+    args:
+      - 𝑒-bridge-input
+      - '"s/^B$/byte/g"'
+      - '"s/^C$/char/g"'
+      - '"s/^D$/double/g"'
+      - '"s/^F$/float/g"'
+      - '"s/^I$/integer/g"'
+      - '"s/^J$/long/g"'
+      - '"s/^S$/short/g"'
+      - '"s/^Z$/boolean/g"'
+      - '"s/^L(.+);$/$1/g"'
+  - meta: 𝑒-frame-captured
+    function: sed
+    args:
+      - 𝑒-captured
+      - '"s/^L(.+);$/$1/g"'
+  - meta: 𝑒-frame-consumer
+    function: sed
+    args:
+      - 𝑒-consumer
+      - '"s/^L(.+);$/$1/g"'

--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/510-distill-distinct-frame-relayed.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/510-distill-distinct-frame-relayed.phr
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Re-derives a distinct() keep-frame from the keep-frame of the operator fused
+# in AHEAD of it, when that operator relays the item instead of producing one
+# (#805).
+#
+# `503-distill-distinct-frame` reads the survivor off an invokestatic required
+# to sit IMMEDIATELY in front of 307's `Φ.hone.fetch` marker, and #798's fix
+# stops there. A filter, a dropWhile, a skip or another distinct fused in
+# between produces no value of its own: each ends its segment at a keep-label
+# with a stackmap frame on it, so what the fetch follows is that frame, the
+# adjacency fails, and `503-distill-state-frame` writes the frame from
+# `bridge-input` again — the very defect #798 closed, re-opened by anything at
+# all standing between the retyping map and the guard.
+# `Stream.of(1, 2).map(n -> n.toString()).distinct().distinct().count()` dies
+# with "Type 'java/lang/String' (current frame, stack[0]) is not assignable to
+# 'java/lang/Integer' (stack map, stack[0])", and so does the same pipeline with
+# a filter or a dropWhile in the middle.
+#
+# A relay does not retype the item, so the frame it left already names the
+# survivor — that is what a keep-frame's single stack slot IS. This rule copies
+# that slot into the frame of the guard behind it and leaves everything else,
+# the local at slot 1 included, exactly as it was.
+#
+# It runs as a CORRECTION, after the whole 503 family has resolved every
+# `Φ.hone.frame-item`, rather than as one more rule racing them for the marker.
+# The 503 rules are tried in one fixed alphabetical order while a chain of
+# relays has to be walked in BODY order, and the two do not agree: for
+# `map(...).skip(1L).distinct()` the fallback claims the distinct marker in the
+# same pass in which `503-distill-skip-frame` resolves the skip one, long before
+# any rule reading the skip's finished frame could get a turn. Correcting the
+# written frame instead makes the order irrelevant — every relay chain converges
+# because each application feeds the next, phino applying a rule to a fixpoint
+# before it moves to the next rule, and a frame that already agrees with its
+# neighbour rewrites to itself and stops.
+#
+# By 510 every keep-frame in a stateful distill-lambda is a FULL frame: 503 and
+# its family write one, and 504 has promoted the same-locals-1 frame 305 leaves
+# on an object filter. Nothing can wedge itself between the neighbour's frame
+# and this guard's fetch either — 505 / 508 / 509 splice their `checkcast` in
+# front of an invokestatic, a dup or 310's latch prologue, never in front of a
+# fetch — so the frame this rule reads is the item as the verifier sees it at
+# the branch. It runs before 512 wraps the lambda into a method (510 < 512).
+#
+# The one relay that leaves no frame is peek(), whose body 309 shapes as `dup` +
+# a void call; `503-distill-distinct-frame-peeked` names the survivor from that
+# call's own parameter instead, with no frame to read and no ordering to respect.
+name: distill-distinct-frame-relayed
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ 𝑒-static,
+    bridge-input ↦ 𝑒-bridge-input,
+    consumer ↦ 𝑒-consumer,
+    target-method ↦ 𝑒-target-method,
+    captured ↦ 𝑒-captured,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-relay ↦ ⟦
+        φ ↦ Φ.jeo.frame,
+        type ↦ 0,
+        locals ↦ ⟦
+          φ ↦ Φ.jeo.seq.of4,
+          x0 ↦ 𝑒-relay-captured,
+          x1 ↦ 𝑒-relay-input,
+          x2 ↦ 𝑒-relay-consumer,
+          x3 ↦ 𝑒-relay-counter
+        ⟧,
+        stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, x0 ↦ 𝑒-survivor ⟧
+      ⟧,
+      𝜏-fetch ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ 𝑒-fetch-type ⟧,
+      𝜏-swap ↦ ⟦ φ ↦ Φ.jeo.opcode.swap ⟧,
+      𝜏-dup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup_x1 ⟧,
+      𝜏-add ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokevirtual,
+        i1 ↦ 𝑒-add-class,
+        i2 ↦ 𝑒-add-method,
+        i3 ↦ 𝑒-add-signature,
+        i4 ↦ 𝑒-add-is-interface
+      ⟧,
+      𝜏-ifne ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ 𝑒-ifne-target ⟧,
+      𝜏-pop ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+      𝜏-return ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      𝜏-keep-label ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-keep-label ⟧,
+      𝜏-frame ↦ ⟦
+        φ ↦ Φ.jeo.frame,
+        type ↦ 0,
+        locals ↦ ⟦
+          φ ↦ Φ.jeo.seq.of4,
+          x0 ↦ 𝑒-frame-captured,
+          x1 ↦ 𝑒-frame-input,
+          x2 ↦ 𝑒-frame-consumer,
+          x3 ↦ 𝑒-frame-counter
+        ⟧,
+        stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, x0 ↦ 𝑒-stale ⟧
+      ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ 𝑒-static,
+    bridge-input ↦ 𝑒-bridge-input,
+    consumer ↦ 𝑒-consumer,
+    target-method ↦ 𝑒-target-method,
+    captured ↦ 𝑒-captured,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-relay ↦ ⟦
+        φ ↦ Φ.jeo.frame,
+        type ↦ 0,
+        locals ↦ ⟦
+          φ ↦ Φ.jeo.seq.of4,
+          x0 ↦ 𝑒-relay-captured,
+          x1 ↦ 𝑒-relay-input,
+          x2 ↦ 𝑒-relay-consumer,
+          x3 ↦ 𝑒-relay-counter
+        ⟧,
+        stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, x0 ↦ 𝑒-survivor ⟧
+      ⟧,
+      𝜏-fetch ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ 𝑒-fetch-type ⟧,
+      𝜏-swap ↦ ⟦ φ ↦ Φ.jeo.opcode.swap ⟧,
+      𝜏-dup ↦ ⟦ φ ↦ Φ.jeo.opcode.dup_x1 ⟧,
+      𝜏-add ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokevirtual,
+        i1 ↦ 𝑒-add-class,
+        i2 ↦ 𝑒-add-method,
+        i3 ↦ 𝑒-add-signature,
+        i4 ↦ 𝑒-add-is-interface
+      ⟧,
+      𝜏-ifne ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ 𝑒-ifne-target ⟧,
+      𝜏-pop ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+      𝜏-return ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      𝜏-keep-label ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-keep-label ⟧,
+      𝜏-frame ↦ ⟦
+        φ ↦ Φ.jeo.frame,
+        type ↦ 0,
+        locals ↦ ⟦
+          φ ↦ Φ.jeo.seq.of4,
+          x0 ↦ 𝑒-frame-captured,
+          x1 ↦ 𝑒-frame-input,
+          x2 ↦ 𝑒-frame-consumer,
+          x3 ↦ 𝑒-frame-counter
+        ⟧,
+        stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, x0 ↦ 𝑒-survivor ⟧
+      ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧

--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/510-distill-skip-frame-relayed.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/510-distill-skip-frame-relayed.phr
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The skip() twin of `510-distill-distinct-frame-relayed` — read its header for
+# the reasoning; only the guard shape differs (#805).
+#
+# `503-distill-skip-frame` insists that the invokestatic that produced the
+# survivor sit immediately in front of 308's `Φ.hone.fetch` marker. A filter, a
+# dropWhile, a distinct or another skip fused in between produces no value of
+# its own and ends at a keep-label with a stackmap frame on it, so the adjacency
+# breaks and `503-distill-state-frame` writes the frame from `bridge-input`
+# again: `Stream.of("a", "bb").map(s -> new Pair(1L, s))
+# .filter(p -> p.key() > 0L).skip(1L).count()` dies with "Type 'probe/Pair'
+# (current frame, stack[0]) is not assignable to 'java/lang/String' (stack map,
+# stack[0])".
+#
+# The frame such a relay leaves already names the survivor, so this rule copies
+# its single stack slot into the frame of the skip behind it, leaving the local
+# at slot 1 — the bridge method's declared parameter — untouched. Like its twin
+# it runs as a CORRECTION at 510, after the 503 family has resolved every
+# `Φ.hone.frame-item`: a chain of relays has to be walked in body order, which
+# no fixed alphabetical rule order can follow, and correcting a written frame
+# converges from any starting point, a frame that already agrees with its
+# neighbour rewriting to itself and stopping.
+#
+# The one relay that leaves no frame is peek(); `503-distill-skip-frame-peeked`
+# names the survivor from the peek's own consumer parameter instead.
+name: distill-skip-frame-relayed
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ 𝑒-static,
+    bridge-input ↦ 𝑒-bridge-input,
+    consumer ↦ 𝑒-consumer,
+    target-method ↦ 𝑒-target-method,
+    captured ↦ 𝑒-captured,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-relay ↦ ⟦
+        φ ↦ Φ.jeo.frame,
+        type ↦ 0,
+        locals ↦ ⟦
+          φ ↦ Φ.jeo.seq.of4,
+          x0 ↦ 𝑒-relay-captured,
+          x1 ↦ 𝑒-relay-input,
+          x2 ↦ 𝑒-relay-consumer,
+          x3 ↦ 𝑒-relay-counter
+        ⟧,
+        stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, x0 ↦ 𝑒-survivor ⟧
+      ⟧,
+      𝜏-fetch ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ 𝑒-fetch-type ⟧,
+      𝜏-index ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+      𝜏-dup-slot ↦ ⟦ φ ↦ Φ.jeo.opcode.dup2 ⟧,
+      𝜏-load-count ↦ ⟦ φ ↦ Φ.jeo.opcode.laload ⟧,
+      𝜏-dup-count ↦ ⟦ φ ↦ Φ.jeo.opcode.dup2_x2 ⟧,
+      𝜏-one ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_1 ⟧,
+      𝜏-decrement ↦ ⟦ φ ↦ Φ.jeo.opcode.lsub ⟧,
+      𝜏-store-count ↦ ⟦ φ ↦ Φ.jeo.opcode.lastore ⟧,
+      𝜏-zero ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_0 ⟧,
+      𝜏-compare ↦ ⟦ φ ↦ Φ.jeo.opcode.lcmp ⟧,
+      𝜏-ifle ↦ ⟦ φ ↦ Φ.jeo.opcode.ifle, i2 ↦ 𝑒-ifle-target ⟧,
+      𝜏-pop ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+      𝜏-return ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      𝜏-keep-label ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-keep-label ⟧,
+      𝜏-frame ↦ ⟦
+        φ ↦ Φ.jeo.frame,
+        type ↦ 0,
+        locals ↦ ⟦
+          φ ↦ Φ.jeo.seq.of4,
+          x0 ↦ 𝑒-frame-captured,
+          x1 ↦ 𝑒-frame-input,
+          x2 ↦ 𝑒-frame-consumer,
+          x3 ↦ 𝑒-frame-counter
+        ⟧,
+        stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, x0 ↦ 𝑒-stale ⟧
+      ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ 𝑒-static,
+    bridge-input ↦ 𝑒-bridge-input,
+    consumer ↦ 𝑒-consumer,
+    target-method ↦ 𝑒-target-method,
+    captured ↦ 𝑒-captured,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-relay ↦ ⟦
+        φ ↦ Φ.jeo.frame,
+        type ↦ 0,
+        locals ↦ ⟦
+          φ ↦ Φ.jeo.seq.of4,
+          x0 ↦ 𝑒-relay-captured,
+          x1 ↦ 𝑒-relay-input,
+          x2 ↦ 𝑒-relay-consumer,
+          x3 ↦ 𝑒-relay-counter
+        ⟧,
+        stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, x0 ↦ 𝑒-survivor ⟧
+      ⟧,
+      𝜏-fetch ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ 𝑒-fetch-type ⟧,
+      𝜏-index ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+      𝜏-dup-slot ↦ ⟦ φ ↦ Φ.jeo.opcode.dup2 ⟧,
+      𝜏-load-count ↦ ⟦ φ ↦ Φ.jeo.opcode.laload ⟧,
+      𝜏-dup-count ↦ ⟦ φ ↦ Φ.jeo.opcode.dup2_x2 ⟧,
+      𝜏-one ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_1 ⟧,
+      𝜏-decrement ↦ ⟦ φ ↦ Φ.jeo.opcode.lsub ⟧,
+      𝜏-store-count ↦ ⟦ φ ↦ Φ.jeo.opcode.lastore ⟧,
+      𝜏-zero ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_0 ⟧,
+      𝜏-compare ↦ ⟦ φ ↦ Φ.jeo.opcode.lcmp ⟧,
+      𝜏-ifle ↦ ⟦ φ ↦ Φ.jeo.opcode.ifle, i2 ↦ 𝑒-ifle-target ⟧,
+      𝜏-pop ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+      𝜏-return ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      𝜏-keep-label ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ 𝑒-keep-label ⟧,
+      𝜏-frame ↦ ⟦
+        φ ↦ Φ.jeo.frame,
+        type ↦ 0,
+        locals ↦ ⟦
+          φ ↦ Φ.jeo.seq.of4,
+          x0 ↦ 𝑒-frame-captured,
+          x1 ↦ 𝑒-frame-input,
+          x2 ↦ 𝑒-frame-consumer,
+          x3 ↦ 𝑒-frame-counter
+        ⟧,
+        stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, x0 ↦ 𝑒-survivor ⟧
+      ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧

--- a/src/test/java/org/eolang/hone/RandomPipeline.java
+++ b/src/test/java/org/eolang/hone/RandomPipeline.java
@@ -34,14 +34,13 @@ import java.util.Random;
  * the API allows to skip the traversal altogether.</p>
  *
  * <p>The grammar does not step around the operations that the rewrite has been
- * known to break — every shape behind #787, #788, #790, #794, #798 and #799 is
- * still reachable, since a generator that avoids the defects we already know
- * about would only prove that we know about them, and nothing about a
- * regression. Two shapes are quarantined all the same, in
- * {@code quarantined()}: they break the rewrite today, they are filed as #804
- * and #805, and a suite that fails on them every night reports nothing new.
- * Each is named by its issue, so closing the issue widens the walk by deleting
- * one clause.</p>
+ * known to break — every shape behind #787, #788, #790, #794, #798, #799 and
+ * #805 is still reachable, since a generator that avoids the defects we already
+ * know about would only prove that we know about them, and nothing about a
+ * regression. One shape is quarantined all the same, in
+ * {@code quarantined()}: it breaks the rewrite today, it is filed as #804, and
+ * a suite that fails on it every night reports nothing new. It is named by its
+ * issue, so closing the issue widens the walk by deleting one clause.</p>
  *
  * @since 0.30.0
  * @todo #791:60min Reach the last corners of the API. There is no
@@ -416,30 +415,6 @@ final class RandomPipeline {
     );
 
     /**
-     * The domains whose elements are references, where {@code distinct} and
-     * {@code skip} erase the element type down to {@code Object}.
-     */
-    private static final List<String> OBJECTS = Arrays.asList(
-        "boxed", "ibox", "pairs", "words"
-    );
-
-    /**
-     * The operations that carry a decision from one element to the next, which
-     * the rewrite fuses into a wrapper with a latch or a counter in it.
-     */
-    private static final List<String> GUARDS = Arrays.asList(
-        "distinct", "dropWhile", "skip"
-    );
-
-    /**
-     * The operations no fused run reaches across, either because the API cannot
-     * express them in one pass or because the rewrite leaves them alone.
-     */
-    private static final List<String> BARRIERS = Arrays.asList(
-        "flatMap", "limit", "sorted", "takeWhile"
-    );
-
-    /**
      * The largest number of intermediate operations in one pipeline.
      */
     private static final int STAGES = 7;
@@ -574,20 +549,19 @@ final class RandomPipeline {
     /**
      * The issue that quarantines this walk, if one does.
      *
-     * <p>Two shapes break the rewrite today, both emitting a class the verifier
-     * rejects, and both are reported upstream. A walk that reaches one of them
-     * is re-rolled from a derived seed instead of being generated, so the suite
-     * stays a net for regressions rather than a standing failure. Delete a
-     * clause here the day its issue closes, and the walk widens again.</p>
+     * <p>One shape breaks the rewrite today, emitting a class the verifier
+     * rejects, and it is reported upstream. A walk that reaches it is re-rolled
+     * from a derived seed instead of being generated, so the suite stays a net
+     * for regressions rather than a standing failure. Delete a clause here the
+     * day its issue closes, and the walk widens again.</p>
      *
-     * <p>Each clause is as narrow as the shape it owns. #805 wants three things
-     * at once: a conversion into an object domain, so the type the guard's frame
-     * is derived from is no longer the type the fused body was handed; a
-     * stateful guard after it; and something between the two that produces no
-     * value — a {@code peek}, a {@code filter}, or another guard. A {@code map}
-     * in between is fine, since the guard then reads its type off that map, and
-     * a barrier in between is fine too, since the run is fused again behind
-     * it.</p>
+     * <p>The clause is as narrow as the shape it owns: a {@code filter} behind
+     * a {@code dropWhile}, which loses the copy of the item its predicate eats.
+     * #805 owned a second one — a conversion into an object domain with a
+     * {@code peek}, a {@code filter} or another guard between it and a stateful
+     * guard — until the keep-frame of such a guard stopped being read off
+     * whatever opcode happens to sit in front of it, and that shape is
+     * reachable again.</p>
      *
      * @param walk The lines the walk picked
      * @return The issue that owns the shape, or an empty string
@@ -596,8 +570,6 @@ final class RandomPipeline {
         String issue = "";
         if (RandomPipeline.dropsThenFilters(walk)) {
             issue = "#804";
-        } else if (RandomPipeline.retypesThenGuards(walk)) {
-            issue = "#805";
         }
         return issue;
     }
@@ -617,78 +589,6 @@ final class RandomPipeline {
                 break;
             }
             dropped = dropped || code.startsWith("dropWhile(");
-        }
-        return found;
-    }
-
-    /**
-     * Does a stateful guard sit behind a conversion into an object domain with
-     * nothing that produces a value between the two?
-     * @param walk The lines the walk picked
-     * @return TRUE if the walk reaches the shape of #805
-     */
-    private static boolean retypesThenGuards(final List<String> walk) {
-        boolean found = false;
-        boolean retyped = false;
-        boolean opaque = false;
-        for (final String line : walk) {
-            final String code = RandomPipeline.code(line);
-            if (retyped && opaque && RandomPipeline.starts(code, RandomPipeline.GUARDS)) {
-                found = true;
-                break;
-            }
-            if (RandomPipeline.starts(code, RandomPipeline.BARRIERS)) {
-                retyped = false;
-                opaque = false;
-            } else if ("turn".equals(line.split("\\|", 3)[1])) {
-                retyped = RandomPipeline.OBJECTS.contains(RandomPipeline.landing(line));
-                opaque = false;
-            } else {
-                opaque = RandomPipeline.relays(code);
-            }
-        }
-        return found;
-    }
-
-    /**
-     * Does this step hand the element on without producing a new one, so that
-     * the type a guard behind it reads is not the type of its survivor?
-     * @param code The Java code of one step of a pipeline
-     * @return TRUE if the step produces no value of its own
-     */
-    private static boolean relays(final String code) {
-        return RandomPipeline.starts(code, RandomPipeline.GUARDS)
-            || code.startsWith("peek(")
-            || code.startsWith("filter(");
-    }
-
-    /**
-     * The element domain one line of a walk leaves behind it.
-     * @param line The line, as {@code domain|role|fragment}
-     * @return The domain a turn lands in, or the one the step was already in
-     */
-    private static String landing(final String line) {
-        final String[] parts = line.split("\\|", 3);
-        final int lands = parts[2].lastIndexOf('|');
-        final String domain;
-        if (lands >= 0) {
-            domain = parts[2].substring(lands + 1);
-        } else {
-            domain = parts[0];
-        }
-        return domain;
-    }
-
-    /**
-     * Does this fragment call one of these operations?
-     * @param code The Java code of one step of a pipeline
-     * @param names The names of the operations to look for
-     * @return TRUE if the step is a call to one of them
-     */
-    private static boolean starts(final String code, final List<String> names) {
-        boolean found = false;
-        for (final String name : names) {
-            found = found || code.startsWith(String.format("%s(", name));
         }
         return found;
     }

--- a/src/test/phino/503-distill-distinct-frame-peeked.yml
+++ b/src/test/phino/503-distill-distinct-frame-peeked.yml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Reproduction of #805 at the rule level, on the peek() relay: a type-changing
+# object map fused in AHEAD of a distinct() guard with a peek BETWEEN the two.
+# The wrapper receives a java/lang/String (bridge-input), the head
+# `lambda$main$0:(Ljava/lang/String;)Lprobe/Pair;` retypes it, and 309's `dup` +
+# void call hands that Pair to the consumer without changing it, so the value the
+# guard's dup_x1 leaves alive at the keep-label is a Pair. What the fetch marker
+# follows is the void call, not an object-returning invokestatic, so
+# `503-distill-distinct-frame` cannot read the survivor and before the fix 503
+# filled the stack item from bridge-input, promising a String over a Pair. The
+# consumer's own parameter names the survivor instead. The local at slot 1 must
+# still be the String: it is the bridge method's declared parameter, loaded by
+# 512's `aload 1`. 503 is listed here too, to prove the alphabetical order leaves
+# it nothing to fall back on.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-distinct-frame-peeked.phr
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-distinct-frame.phr
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-state-frame.phr
+input: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ "true",
+    bridge-input ↦ "Ljava/lang/String;",
+    consumer ↦ "Ljava/util/function/Consumer;",
+    target-method ↦ "distill_1",
+    captured ↦ "Ljava/util/List;",
+    body ↦ ⟦
+      i1 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$0", i4 ↦ "(Ljava/lang/String;)Lprobe/Pair;", i5 ↦ Φ.false ⟧,
+      i2 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+      i3 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$1", i4 ↦ "(Lprobe/Pair;)V", i5 ↦ Φ.false ⟧,
+      i4 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/util/concurrent/ConcurrentHashMap$KeySetView" ⟧,
+      i5 ↦ ⟦ φ ↦ Φ.jeo.opcode.swap ⟧,
+      i6 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup_x1 ⟧,
+      i7 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, i1 ↦ "java/util/concurrent/ConcurrentHashMap$KeySetView", i2 ↦ "add", i3 ↦ "(Ljava/lang/Object;)Z", i4 ↦ Φ.false ⟧,
+      i8 ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L1" ⟧ ⟧,
+      i9 ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+      i10 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      i11 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L1" ⟧,
+      i12 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+expected:
+  - ⟦ φ ↦ Φ.jeo.frame, type ↦ 0, 𝐵-e ⟧
+  - ⟦ φ ↦ Φ.jeo.seq.of1, x0 ↦ "probe/Pair" ⟧
+  - ⟦ φ ↦ Φ.jeo.seq.of4, x0 ↦ "java/util/List", x1 ↦ "java/lang/String", x2 ↦ "java/util/function/Consumer", x3 ↦ "integer" ⟧

--- a/src/test/phino/503-distill-predicate-frame.yml
+++ b/src/test/phino/503-distill-predicate-frame.yml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The stateful half of #794, found again by #805: a type-changing object map
+# fused in AHEAD of a filter that is riding a STATEFUL pipeline, so the whole run
+# has been lowered into a distill-lambda WITH `captured`. 304 leaves a
+# `Φ.hone.frame-item` at the filter's keep-label; in a stateless wrapper
+# `506-distill-predicate-frame` claims it, but in this one nothing did and
+# `503-distill-state-frame` wrote the frame from `bridge-input` — a
+# java/lang/String over the java/lang/Long the head
+# `lambda$main$0:(Ljava/lang/String;)Ljava/lang/Long;` has already produced. The
+# predicate the guard tests the item with names the survivor. The frame has to be
+# FULL rather than same-locals-1, or the counter 512 keeps at slot 3 is dropped
+# and the next guard's `iload 3` reads an undefined local. 503 is listed here
+# too, to prove the alphabetical order leaves it nothing to fall back on.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-predicate-frame.phr
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-state-frame.phr
+input: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ "true",
+    bridge-input ↦ "Ljava/lang/String;",
+    consumer ↦ "Ljava/util/function/Consumer;",
+    target-method ↦ "distill_1",
+    captured ↦ "Ljava/util/List;",
+    body ↦ ⟦
+      i1 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$0", i4 ↦ "(Ljava/lang/String;)Ljava/lang/Long;", i5 ↦ Φ.false ⟧,
+      i2 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+      i3 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$1", i4 ↦ "(Ljava/lang/Long;)Z", i5 ↦ Φ.false ⟧,
+      i4 ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L1" ⟧ ⟧,
+      i5 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      i6 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L1" ⟧,
+      i7 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+expected:
+  - ⟦ φ ↦ Φ.jeo.frame, type ↦ 0, 𝐵-e ⟧
+  - ⟦ φ ↦ Φ.jeo.seq.of1, x0 ↦ "java/lang/Long" ⟧
+  - ⟦ φ ↦ Φ.jeo.seq.of4, x0 ↦ "java/util/List", x1 ↦ "java/lang/String", x2 ↦ "java/util/function/Consumer", x3 ↦ "integer" ⟧

--- a/src/test/phino/503-distill-skip-frame-peeked.yml
+++ b/src/test/phino/503-distill-skip-frame-peeked.yml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The skip() twin of `503-distill-distinct-frame-peeked` (#805): a type-changing
+# object map fused in AHEAD of 308's countdown guard, with a peek BETWEEN the
+# two. The wrapper receives a java/lang/String, the head
+# `lambda$main$0:(Ljava/lang/String;)Lprobe/Pair;` retypes it, and 309's `dup` +
+# void call relays the Pair on unchanged, so the survivor waiting at the
+# keep-label is that Pair while `503-distill-skip-frame` — which needs an
+# object-returning invokestatic right in front of the fetch — cannot see it. The
+# peek's consumer parameter names it. The local at slot 1 stays the String.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-skip-frame-peeked.phr
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-skip-frame.phr
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-state-frame.phr
+input: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ "true",
+    bridge-input ↦ "Ljava/lang/String;",
+    consumer ↦ "Ljava/util/function/Consumer;",
+    target-method ↦ "distill_1",
+    captured ↦ "Ljava/util/List;",
+    body ↦ ⟦
+      i1 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$0", i4 ↦ "(Ljava/lang/String;)Lprobe/Pair;", i5 ↦ Φ.false ⟧,
+      i2 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+      i3 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$1", i4 ↦ "(Lprobe/Pair;)V", i5 ↦ Φ.false ⟧,
+      i4 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "[J" ⟧,
+      i5 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+      i6 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup2 ⟧,
+      i7 ↦ ⟦ φ ↦ Φ.jeo.opcode.laload ⟧,
+      i8 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup2_x2 ⟧,
+      i9 ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_1 ⟧,
+      i10 ↦ ⟦ φ ↦ Φ.jeo.opcode.lsub ⟧,
+      i11 ↦ ⟦ φ ↦ Φ.jeo.opcode.lastore ⟧,
+      i12 ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_0 ⟧,
+      i13 ↦ ⟦ φ ↦ Φ.jeo.opcode.lcmp ⟧,
+      i14 ↦ ⟦ φ ↦ Φ.jeo.opcode.ifle, i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L1" ⟧ ⟧,
+      i15 ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+      i16 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      i17 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L1" ⟧,
+      i18 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+expected:
+  - ⟦ φ ↦ Φ.jeo.frame, type ↦ 0, 𝐵-e ⟧
+  - ⟦ φ ↦ Φ.jeo.seq.of1, x0 ↦ "probe/Pair" ⟧
+  - ⟦ φ ↦ Φ.jeo.seq.of4, x0 ↦ "java/util/List", x1 ↦ "java/lang/String", x2 ↦ "java/util/function/Consumer", x3 ↦ "integer" ⟧

--- a/src/test/phino/510-distill-distinct-frame-relayed.yml
+++ b/src/test/phino/510-distill-distinct-frame-relayed.yml
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Reproduction of #805 on a guard relaying into a guard: a type-changing object
+# map, then 308's countdown guard, then 307's seen-set guard. The wrapper
+# receives a java/lang/String (bridge-input), the head
+# `lambda$main$0:(Ljava/lang/String;)Lprobe/Pair;` retypes it, and a skip keeps
+# the item it was given, so the survivor at BOTH keep-labels is a Pair.
+#
+# `503-distill-skip-frame` reads the survivor for the first one off the
+# invokestatic in front of it. Nothing could read it for the second: what its
+# fetch marker follows is the skip's keep-frame, not a producer, and no rule
+# ordering fixes that — the 503 rules are tried in one fixed alphabetical order
+# while the chain has to be walked in body order, so the fallback claims the
+# distinct marker in the same pass in which `503-distill-skip-frame` resolves the
+# skip one. 510 therefore corrects the written frame instead of racing for the
+# marker, copying the neighbour's single stack slot into it.
+#
+# The two `expected` patterns pin the frames by the label in front of them, since
+# both end up naming the same type and a bare stack pattern would match either.
+# "L0" is the skip's, already right before this rule; "L1" is the distinct's, the
+# one the fallback wrote as a java/lang/String. The local at slot 1 stays the
+# String in both: it is the bridge method's declared parameter.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-skip-frame.phr
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-state-frame.phr
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/510-distill-distinct-frame-relayed.phr
+input: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ "true",
+    bridge-input ↦ "Ljava/lang/String;",
+    consumer ↦ "Ljava/util/function/Consumer;",
+    target-method ↦ "distill_1",
+    captured ↦ "Ljava/util/List;",
+    body ↦ ⟦
+      i1 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$0", i4 ↦ "(Ljava/lang/String;)Lprobe/Pair;", i5 ↦ Φ.false ⟧,
+      s1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "[J" ⟧,
+      s2 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+      s3 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup2 ⟧,
+      s4 ↦ ⟦ φ ↦ Φ.jeo.opcode.laload ⟧,
+      s5 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup2_x2 ⟧,
+      s6 ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_1 ⟧,
+      s7 ↦ ⟦ φ ↦ Φ.jeo.opcode.lsub ⟧,
+      s8 ↦ ⟦ φ ↦ Φ.jeo.opcode.lastore ⟧,
+      s9 ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_0 ⟧,
+      s10 ↦ ⟦ φ ↦ Φ.jeo.opcode.lcmp ⟧,
+      s11 ↦ ⟦ φ ↦ Φ.jeo.opcode.ifle, i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L0" ⟧ ⟧,
+      s12 ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+      s13 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      s14 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L0" ⟧,
+      s15 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+      d1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/util/concurrent/ConcurrentHashMap$KeySetView" ⟧,
+      d2 ↦ ⟦ φ ↦ Φ.jeo.opcode.swap ⟧,
+      d3 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup_x1 ⟧,
+      d4 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, i1 ↦ "java/util/concurrent/ConcurrentHashMap$KeySetView", i2 ↦ "add", i3 ↦ "(Ljava/lang/Object;)Z", i4 ↦ Φ.false ⟧,
+      d5 ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L1" ⟧ ⟧,
+      d6 ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+      d7 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      d8 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L1" ⟧,
+      d9 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+expected:
+  - ⟦ 𝐵-before, 𝜏-label ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L0" ⟧, 𝜏-frame ↦ ⟦ φ ↦ Φ.jeo.frame, type ↦ 0, locals ↦ ⟦ φ ↦ Φ.jeo.seq.of4, x0 ↦ "java/util/List", x1 ↦ "java/lang/String", x2 ↦ "java/util/function/Consumer", x3 ↦ "integer" ⟧, stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, x0 ↦ "probe/Pair" ⟧ ⟧, 𝐵-after ⟧
+  - ⟦ 𝐵-before, 𝜏-label ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L1" ⟧, 𝜏-frame ↦ ⟦ φ ↦ Φ.jeo.frame, type ↦ 0, locals ↦ ⟦ φ ↦ Φ.jeo.seq.of4, x0 ↦ "java/util/List", x1 ↦ "java/lang/String", x2 ↦ "java/util/function/Consumer", x3 ↦ "integer" ⟧, stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, x0 ↦ "probe/Pair" ⟧ ⟧, 𝐵-after ⟧

--- a/src/test/phino/510-distill-skip-frame-relayed.yml
+++ b/src/test/phino/510-distill-skip-frame-relayed.yml
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The skip() twin of `510-distill-distinct-frame-relayed` (#805): a
+# type-changing object map, then 307's seen-set guard, then 308's countdown
+# guard. distinct keeps the item it was given, so the survivor at BOTH
+# keep-labels is the Pair the head `lambda$main$0:(Ljava/lang/String;)
+# Lprobe/Pair;` produced, while the distill still receives a java/lang/String.
+#
+# `503-distill-distinct-frame` reads the survivor for the first guard off the
+# invokestatic in front of it; the second one has the first's keep-frame in front
+# of it instead, which no rule of the 503 family can read in time, so
+# `503-distill-state-frame` wrote it from `bridge-input`. 510 copies the
+# neighbour's stack slot into it afterwards.
+#
+# The two `expected` patterns pin the frames by the label in front of them, since
+# both end up naming the same type. "L0" is the distinct's, already right before
+# this rule; "L1" is the skip's, the one the fallback wrote as a
+# java/lang/String.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-distinct-frame.phr
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-state-frame.phr
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/510-distill-skip-frame-relayed.phr
+input: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ "true",
+    bridge-input ↦ "Ljava/lang/String;",
+    consumer ↦ "Ljava/util/function/Consumer;",
+    target-method ↦ "distill_1",
+    captured ↦ "Ljava/util/List;",
+    body ↦ ⟦
+      i1 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, i2 ↦ "Foo", i3 ↦ "lambda$main$0", i4 ↦ "(Ljava/lang/String;)Lprobe/Pair;", i5 ↦ Φ.false ⟧,
+      d1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/util/concurrent/ConcurrentHashMap$KeySetView" ⟧,
+      d2 ↦ ⟦ φ ↦ Φ.jeo.opcode.swap ⟧,
+      d3 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup_x1 ⟧,
+      d4 ↦ ⟦ φ ↦ Φ.jeo.opcode.invokevirtual, i1 ↦ "java/util/concurrent/ConcurrentHashMap$KeySetView", i2 ↦ "add", i3 ↦ "(Ljava/lang/Object;)Z", i4 ↦ Φ.false ⟧,
+      d5 ↦ ⟦ φ ↦ Φ.jeo.opcode.ifne, i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L0" ⟧ ⟧,
+      d6 ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+      d7 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      d8 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L0" ⟧,
+      d9 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+      s1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "[J" ⟧,
+      s2 ↦ ⟦ φ ↦ Φ.jeo.opcode.iconst_0 ⟧,
+      s3 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup2 ⟧,
+      s4 ↦ ⟦ φ ↦ Φ.jeo.opcode.laload ⟧,
+      s5 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup2_x2 ⟧,
+      s6 ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_1 ⟧,
+      s7 ↦ ⟦ φ ↦ Φ.jeo.opcode.lsub ⟧,
+      s8 ↦ ⟦ φ ↦ Φ.jeo.opcode.lastore ⟧,
+      s9 ↦ ⟦ φ ↦ Φ.jeo.opcode.lconst_0 ⟧,
+      s10 ↦ ⟦ φ ↦ Φ.jeo.opcode.lcmp ⟧,
+      s11 ↦ ⟦ φ ↦ Φ.jeo.opcode.ifle, i2 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L1" ⟧ ⟧,
+      s12 ↦ ⟦ φ ↦ Φ.jeo.opcode.pop ⟧,
+      s13 ↦ ⟦ φ ↦ Φ.jeo.opcode.return ⟧,
+      s14 ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L1" ⟧,
+      s15 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+expected:
+  - ⟦ 𝐵-before, 𝜏-label ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L0" ⟧, 𝜏-frame ↦ ⟦ φ ↦ Φ.jeo.frame, type ↦ 0, locals ↦ ⟦ φ ↦ Φ.jeo.seq.of4, x0 ↦ "java/util/List", x1 ↦ "java/lang/String", x2 ↦ "java/util/function/Consumer", x3 ↦ "integer" ⟧, stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, x0 ↦ "probe/Pair" ⟧ ⟧, 𝐵-after ⟧
+  - ⟦ 𝐵-before, 𝜏-label ↦ ⟦ φ ↦ Φ.jeo.label, i1 ↦ "L1" ⟧, 𝜏-frame ↦ ⟦ φ ↦ Φ.jeo.frame, type ↦ 0, locals ↦ ⟦ φ ↦ Φ.jeo.seq.of4, x0 ↦ "java/util/List", x1 ↦ "java/lang/String", x2 ↦ "java/util/function/Consumer", x3 ↦ "integer" ⟧, stack ↦ ⟦ φ ↦ Φ.jeo.seq.of1, x0 ↦ "probe/Pair" ⟧ ⟧, 𝐵-after ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/map-retype-relayed.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/map-retype-relayed.yml
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# Reproduction of #805: the #798 shape with something standing BETWEEN the
+# retyping map and the stateful guard. `map-retype-stateful.yml` keeps the two
+# adjacent, which is the only arrangement 503's keep-frame rules could read: they
+# take the survivor off an invokestatic required to sit immediately in front of
+# the guard's `Φ.hone.fetch` marker. Fuse a peek, a filter or a second guard in
+# between and that adjacency is gone — a relay produces no value of its own, so
+# what the fetch follows is a void call or a keep-label's frame — the marker falls
+# through to `503-distill-state-frame`, and the frame is written from
+# `bridge-input` again: "java.lang.VerifyError: Inconsistent stackmap frames ...
+# Type 'mapretyperelayed/X$Pair' (current frame, stack[0]) is not assignable to
+# 'java/lang/String' (stack map, stack[0])".
+#
+# One pipeline per relay, each one retyping first so that bridge-input and the
+# survivor differ:
+#   * peek between map and skip — the relay that leaves no frame at all, since
+#     309 shapes a peek as `dup` + a void call.
+#     `503-distill-skip-frame-peeked` names the survivor through that call's own
+#     parameter. Lengths {1, 2, 3}, one skipped, count = 2.
+#   * filter between map and distinct — TWO wrong frames in one pipeline: 304
+#     leaves a marker at the filter's own keep-label, which in a stateful wrapper
+#     nothing but the fallback claimed (`503-distill-predicate-frame` now names it
+#     from the predicate, the way 506 does for a stateless one), and then the
+#     distinct behind it reads the filter's frame through
+#     `510-distill-distinct-frame-relayed`. Lengths {1, 2, 2, 3}, the 1 filtered
+#     out, three distinct pairs left.
+#   * dropWhile between map and distinct — 310's latch guard names its own
+#     survivor, so its frame was right all along; the distinct behind it is the
+#     one that was not. "1" and "2" dropped, "3" and "4" kept, count = 2.
+#   * distinct between map and distinct — a guard relaying into a guard, the
+#     chain `510` walks one link at a time. {"1", "2", "2", "3"} has three
+#     distinct elements and staying distinct keeps three.
+#   * distinct between map and skip — the same for `510-distill-skip-frame-relayed`.
+#     Lengths {1, 2, 3, 4}, all distinct, one skipped, count = 3.
+#
+# `SUM` is written by the peek but not printed: `count()` is allowed to skip the
+# traversal altogether on a SIZED pipeline, so what the peek accumulates differs
+# between the two runs by the API's own contract, and only the counts are an
+# oracle here. Every pipeline collapses its map + operators into one
+# Stream.mapMulti: invokedynamic drops 8 -> 5, the five captured java/util/List
+# holders push new from 3 to 8, and the two skip countdowns plus the dropWhile
+# latch push newarray from 1 to 4. The printed line asserts end to end that the
+# optimized class VERIFIES and still computes the right answers.
+java: |
+  package mapretyperelayed;
+  import java.util.stream.Stream;
+  public class X {
+    private static final long[] SUM = new long[1];
+    public static void main(String[] a) {
+      long peeked = Stream.of("a", "bb", "ccc")
+        .map(s -> new Pair((long) s.length(), s))
+        .peek(p -> SUM[0] += p.key())
+        .skip(1L)
+        .count();
+      long picked = Stream.of("a", "bb", "cc", "ddd")
+        .map(s -> new Pair((long) s.length(), s))
+        .filter(p -> p.key() > 1L)
+        .distinct()
+        .count();
+      long dropped = Stream.of(1, 2, 3, 4)
+        .map(n -> n.toString())
+        .dropWhile(s -> s.compareTo("3") < 0)
+        .distinct()
+        .count();
+      long twice = Stream.of(1, 2, 2, 3)
+        .map(n -> n.toString())
+        .distinct()
+        .distinct()
+        .count();
+      long tailed = Stream.of("a", "bb", "ccc", "dddd")
+        .map(s -> new Pair((long) s.length(), s))
+        .distinct()
+        .skip(1L)
+        .count();
+      System.out.printf("The result is %d/%d/%d/%d/%d\n", peeked, picked, dropped, twice, tailed);
+    }
+    static final class Pair {
+      private final long num;
+      private final String word;
+      Pair(final long key, final String text) {
+        this.num = key;
+        this.word = text;
+      }
+      long key() {
+        return this.num;
+      }
+      @Override
+      public boolean equals(final Object other) {
+        return other instanceof Pair && ((Pair) other).num == this.num
+          && ((Pair) other).word.equals(this.word);
+      }
+      @Override
+      public int hashCode() {
+        return (int) this.num * 31 + this.word.hashCode();
+      }
+    }
+  }
+log:
+  - "Modified 2/2 X.phi"
+  - "Finished rewriting 2 file"
+  - "BUILD SUCCESS"
+  - "The result is 2/3/2/3/3"
+before:
+  invokedynamic: 8
+  invokeinterface: 20
+  invokestatic: 18
+  invokevirtual: 9
+  new: 3
+  newarray: 1
+  checkcast: 0
+after:
+  invokedynamic: 5
+  invokeinterface: 31
+  invokestatic: 31
+  invokevirtual: 14
+  new: 8
+  newarray: 4
+  checkcast: 8


### PR DESCRIPTION
Closes #805.

## The defect

The #798 fix only reached the guard sitting **directly** behind the retyping map. `503-distill-distinct-frame` and `503-distill-skip-frame` read the survivor off an `invokestatic` required to sit *immediately* in front of the guard's `Φ.hone.fetch` marker. Fuse anything that relays the item — a `peek`, a `filter`, another guard — in between and that adjacency is gone: a relay produces no value of its own, so what the fetch follows is a void call or a keep-label's frame. The marker fell through to `503-distill-state-frame`, the frame was written from `bridge-input` again, and the class failed verification with the very same message.

All four pipelines from the issue now run. The `map(...).filter(...).distinct()` one was failing for **two** reasons, not one: the filter's own keep-frame was wrong as well, because 304's marker had no rule of its own inside a stateful wrapper (506 is scoped to the stateless branch) and also fell to the fallback.

## What changed

Three ways of naming the survivor, none of which needs an adjacent producer:

| Rule | Relay it covers | Where the type comes from |
| --- | --- | --- |
| `503-distill-distinct-frame-peeked`, `503-distill-skip-frame-peeked` | a `peek`, the one relay that leaves no frame (309 shapes it as `dup` + a void call) | the peek's own consumer parameter, the way `503-distill-dropwhile-frame` uses its predicate |
| `503-distill-predicate-frame` | a `filter` fused into a **stateful** distill | the predicate's parameter — the stateful twin of `506-distill-predicate-frame` (#794) |
| `510-distill-distinct-frame-relayed`, `510-distill-skip-frame-relayed` | every other relay: a filter, a dropWhile, a skip or a distinct in front of the guard | the single stack slot of the keep-frame that relay already left |

The two `510` rules **correct a written frame** instead of racing the 503 family for the marker. The 503 rules are tried in one fixed alphabetical order while a chain of relays has to be walked in body order, and the two do not agree — for `map(...).skip(1L).distinct()` the fallback claims the distinct marker in the same pass in which `503-distill-skip-frame` resolves the skip one, long before any rule reading the skip's finished frame could get a turn. Correcting converges from any starting point (phino applies a rule to a fixpoint before moving to the next), and a frame that already agrees with its neighbour rewrites to itself and stops. A correction can only ever replace what the fallback guessed: when a frame sits in front of the fetch, neither the base rule nor the peeked one could have fired.

The peeked rules skip a `(Ljava/lang/Object;)V` consumer. The parameter is an upper bound of the survivor rather than its exact type, and widening the item is safe at the branch but starves a narrower consumer further down the body, where 505 only splices a `checkcast` for the Object `bridge-input` of a distinct/skip-led pipeline.

## Tests

- `src/test/resources/org/eolang/hone/optimize/streams/map-retype-relayed.yml` — five pipelines, one per relay, each retyping first so `bridge-input` and the survivor differ. Verified end to end: it fails with `VerifyError: Inconsistent stackmap frames ... Type 'mapretyperelayed/X$Pair' ... is not assignable to 'java/lang/String'` on the rules as they stand on `master`, and prints `2/3/2/3/3` — the same as before optimization — with this change.
- Five `src/test/phino/` packs, one per new rule. The two `510` packs pin the corrected frame by the label in front of it, since both frames in the chain end up naming the same type and a bare stack pattern would match either.
- `RandomPipeline.quarantined()` loses its `#805` clause, so the differential walk reaches the shape again.

Run against a locally built `phino` 0.0.106: all 80 phino packs pass, `mvn test` is green, `-Pqulice` is green, and the differential walk agrees before and after on seeds 0–119 (all 120 rewritten, none broken).

## One thing this does not fix

Widening the walk past 120 seeds surfaces `P0334`, a `peek → map → sorted → peek → flatMapToLong → filter → filter → boxed` pipeline that optimizes into a `VerifyError: Operand stack underflow`. It has no stateful guard in it at all, and it fails identically with these five rules removed, so it is a pre-existing defect rather than fallout from this change — and it is outside the 120 seeds the suite walks by default. Worth its own issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B6nroCkygRAPmkcGK5x6Md)_