### PR TITLE
fix(#813): re-measure the stale after-counts, and give the deep runner a Maven

### DIFF
--- a/.github/workflows/deep.yml
+++ b/.github/workflows/deep.yml
@@ -40,6 +40,25 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 21
+      # The EC2 AMI carries no Maven and actions/setup-java installs only a
+      # JDK, so without this step every "mvn" below dies with "command not
+      # found" and the whole job is red in under a second (see #813).
+      - name: install-maven
+        env:
+          MAVEN_VERSION: 3.9.11
+        run: |
+          if command -v mvn > /dev/null; then
+            mvn --version
+            exit 0
+          fi
+          curl --silent --show-error --fail --location \
+            --output /tmp/maven.tgz \
+            "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz"
+          mkdir -p "${HOME}/maven"
+          tar xzf /tmp/maven.tgz --strip-components=1 --directory "${HOME}/maven"
+          rm /tmp/maven.tgz
+          echo "${HOME}/maven/bin" >> "${GITHUB_PATH}"
+          "${HOME}/maven/bin/mvn" --version
       - uses: actions/cache@v6
         with:
           path: ~/.m2/repository

--- a/.github/workflows/deep.yml
+++ b/.github/workflows/deep.yml
@@ -46,6 +46,10 @@ jobs:
       - name: install-maven
         env:
           MAVEN_VERSION: 3.9.11
+          # The SHA-512 Apache publishes next to the archive, pinned here so
+          # that the digest is reviewed in this repo instead of fetched from
+          # the same host that serves the bytes it vouches for.
+          MAVEN_SHA512: bcfe4fe305c962ace56ac7b5fc7a08b87d5abd8b7e89027ab251069faebee516b0ded8961445d6d91ec1985dfe30f8153268843c89aa392733d1a3ec956c9978
         run: |
           if command -v mvn > /dev/null; then
             mvn --version
@@ -54,6 +58,7 @@ jobs:
           curl --silent --show-error --fail --location \
             --output /tmp/maven.tgz \
             "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz"
+          echo "${MAVEN_SHA512}  /tmp/maven.tgz" | sha512sum --check --strict
           mkdir -p "${HOME}/maven"
           tar xzf /tmp/maven.tgz --strip-components=1 --directory "${HOME}/maven"
           rm /tmp/maven.tgz

--- a/src/test/resources/org/eolang/hone/optimize/streams/all-ops.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/all-ops.yml
@@ -1,6 +1,15 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
+# Every intermediate operator the Stream API offers, in one pipeline, as a
+# smoke test that the whole rule set survives them together. The `after`
+# counts are a tally, not a design: they move whenever a rule starts
+# recognising one more operator or emits one more call, so they need
+# re-measuring rather than defending. Two such moves are already baked in
+# (see #813): 208/310 folding dropWhile into a stateful distill (#718), and
+# the try-with-resources that 455-458 wrap around the inner stream of each
+# flatMap variant — its four Throwable.addSuppressed calls, one per flatMap
+# below, are four of the 18 invokevirtual.
 java: |
   package allops;
   import java.util.*;
@@ -52,8 +61,8 @@ before:
   invokedynamic: 17
   return: 7
 after:
-  invokespecial: 2
-  invokestatic: 31
-  invokevirtual: 14
+  invokespecial: 3
+  invokestatic: 32
+  invokevirtual: 18
   invokedynamic: 14
-  return: 17
+  return: 19

--- a/src/test/resources/org/eolang/hone/optimize/streams/stateful-ops.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/stateful-ops.yml
@@ -17,10 +17,11 @@
 #
 #   dropWhile (208 -> 310 -> 502): captures a one-shot sticky latch (#718)
 #     inside its own java/util/List, which is the second `new`. The latch is
-#     an int[1] — hence the 1 `newarray`, and iaload/iastore rather than
-#     baload/bastore. Those two stay 0 and are still worth asserting: they
-#     pin the latch's array type, and the boolean[1] this comment used to
-#     predict would have driven them to 1 each instead.
+#     an int[1]: 1 `newarray` allocates it, and it is read with iaload and
+#     written with iastore. Those two are what pin the array type — since
+#     `newarray` covers every primitive type, it alone proves only that some
+#     primitive array was allocated. baload/bastore stay asserted at 0 to
+#     rule out the boolean[1] this comment used to predict.
 #     input [1, 2, 100, 4, 5, 6, 7] -> [100, 4, 5, 6, 7]; count() = 5
 #
 # takeWhile is NOT recognised, and not for want of a rule: a mapMulti body
@@ -55,10 +56,14 @@ log:
 before:
   new: 0
   newarray: 0
+  iaload: 0
+  iastore: 0
   baload: 0
   bastore: 0
 after:
   new: 2
   newarray: 1
+  iaload: 1
+  iastore: 1
   baload: 0
   bastore: 0

--- a/src/test/resources/org/eolang/hone/optimize/streams/stateful-ops.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/stateful-ops.yml
@@ -1,23 +1,32 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
-# State-carrying intermediate operators. Only distinct is folded into
-# the distill today; it fuses with the preceding .map(n -> n) into one
-# Stream.mapMulti backed by a captured java/util/List that holds the
-# seen-set, so the pinned `new` count proves the List was allocated. The
-# seen-set itself is a ConcurrentHashMap.newKeySet() built by a static
-# factory (thread-safe, so a parallel run cannot race — see #715), which
-# is an invokestatic rather than a `new`.
+# State-carrying intermediate operators. Two of the three are folded into
+# the distill today — distinct and dropWhile — and each fuses with the
+# .map(n -> n) in front of it into one Stream.mapMulti backed by a captured
+# java/util/List that carries its state, so the pinned `new` count is one
+# ArrayList per fused operator.
 #
 #   distinct (216 -> 307 -> 502): captures a newKeySet() seen-set
-#     inside the wrapper's java/util/List
+#     inside the wrapper's java/util/List. The seen-set itself is a
+#     ConcurrentHashMap.newKeySet() built by a static factory (thread-safe,
+#     so a parallel run cannot race — see #715), which is an invokestatic
+#     rather than a `new`.
 #     input [1, 2, 2, 3, 1, 3, 4] -> [1, 2, 3, 4]; count() = 4
 #     emits 1 `new` (the ArrayList) and a KeySetView.add call.
 #
-# takeWhile and dropWhile are NOT recognised yet — no rule folds them —
-# so they survive as their original lambdas and allocate no state cell
-# (hence baload == bastore == 0). When they are migrated to the distill
-# they will allocate a boolean[1] guard and these counts will change.
+#   dropWhile (208 -> 310 -> 502): captures a one-shot sticky latch (#718)
+#     inside its own java/util/List, which is the second `new`. The latch is
+#     an int[1] — hence the 1 `newarray`, and iaload/iastore rather than
+#     baload/bastore. Those two stay 0 and are still worth asserting: they
+#     pin the latch's array type, and the boolean[1] this comment used to
+#     predict would have driven them to 1 each instead.
+#     input [1, 2, 100, 4, 5, 6, 7] -> [100, 4, 5, 6, 7]; count() = 5
+#
+# takeWhile is NOT recognised, and not for want of a rule: a mapMulti body
+# cannot cancel upstream traversal, so the short-circuiting operators stay
+# fusion barriers on purpose (README explains the decision). It survives as
+# its original lambda and allocates no state cell.
 #
 # The .map(n -> n) before each operator also keeps the class inside the
 # default grep-in scope (which targets bodies containing any fusable Stream
@@ -45,9 +54,11 @@ log:
   - "The result is 4 3 5"
 before:
   new: 0
+  newarray: 0
   baload: 0
   bastore: 0
 after:
-  new: 1
+  new: 2
+  newarray: 1
   baload: 0
   bastore: 0


### PR DESCRIPTION
Closes #813.

## What was wrong

`mvn -Pdeep test -Dtest='OptimizeMojoTest#optimizesAsSpecifiedInYamlPack'` was **49 run / 2 failures** — reproduced here exactly as the issue describes, and both failures are `after`-stage opcode tallies, not miscompiles. The `log:` assertions run before `assertOpcodes` and pass in both packs, so the optimized classes verify and still print the right answer; only the numbers of record had drifted.

Measured `after` tallies, straight from the failure output:

| pack | asserted | measured |
| --- | --- | --- |
| `all-ops` | invokespecial 2, invokestatic 31, invokevirtual 14, invokedynamic 14, return 17 | invokespecial **3**, invokestatic **32**, invokevirtual **18**, invokedynamic 14, return **19** |
| `stateful-ops` | new 1, baload 0, bastore 0 | new **2**, baload 0, bastore 0 (`newarray` 1) |

Attribution matches the issue's rule-selection experiment: `208`/`310` (dropWhile recognition, #718) accounts for `stateful-ops` entirely and for invokespecial/invokestatic/return in `all-ops`; `455`–`458` account for the remaining invokevirtual 14 → 18, four `Throwable.addSuppressed` calls — one per flatMap variant — from the try-with-resources that each generated `mapMulti` body wraps around its inner stream (documented in `455`'s own header, the `L_h2` block).

## Changes

**`all-ops.yml`** — `after` block re-measured. Added a short header saying what the tally is and which two rule-set moves are baked into it, so the next drift is diagnosed rather than defended.

**`stateful-ops.yml`** — `after` block re-measured, and the stale paragraph rewritten. It still read:

> takeWhile and dropWhile are NOT recognised yet — no rule folds them […] When they are migrated to the distill they will allocate a `boolean[1]` guard and these counts will change.

dropWhile has been migrated. The prediction was half right: the latch is an `int[1]` in its own captured `ArrayList` (that `ArrayList` is the second `new`), so `baload`/`bastore` correctly stayed 0. The rewrite describes what `208`/`310` actually do to this pipeline and adds `newarray` (0 → 1) so the latch is pinned by an assertion rather than only by prose — `baload`/`bastore` stay asserted, since together with `newarray` they now pin the latch's *array type*. takeWhile's paragraph now says it is a deliberate fusion barrier, not a gap awaiting a rule (a `mapMulti` body cannot cancel upstream traversal).

No rule changed. Nothing here suggested the optimized bytecode was wrong.

**`.github/workflows/deep.yml`** — every visible run of this workflow died on its first step in under a second with `mvn: command not found` (exit 127): `actions/setup-java` puts a JDK on the EC2 runner, but the AMI carries no Maven. Added a step that unpacks Apache Maven 3.9.11 into `$HOME/maven` (no sudo needed) and appends it to `$GITHUB_PATH` before the cache and build steps, skipping the download if the AMI ever gains an `mvn`.

## Verification

phino `0.0.106` on the host (matching `default-phino-version.txt`, so the plugin skips Docker), JDK 21, GNU `parallel` installed.

- Full pack sweep before the change: `Tests run: 49, Failures: 2` — the two packs above, everything else green.
- Both packs after the change: `Tests run: 2, Failures: 0, Errors: 0` (`BUILD SUCCESS`).
- `before`-stage `newarray: 0` confirmed independently by `javac` + `javap` on the pack's own source, so the new `before` assertion is measured too.
- `yamllint -c .yamllint.yml` clean on all three files; the `install-maven` script is shellcheck-clean.

## One thing worth a look on the AMI side

Maven alone gets `deep` to green, but it may not get these packs *executed*: `optimizesAsSpecifiedInYamlPack` is `@DisabledWithoutDocker` and `appliesPhinoRulesAsSpecifiedInYamlPack` is `@DisabledWithoutPhino`, and both **skip silently**. So unless the AMI carries Docker — and, for the single-rule packs, `phino` — the job will pass while checking nothing. Worth confirming on the image; it is out of scope for this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rpv3eLTaATpDwMxFCxdY13)_