### PR TITLE
fix(#817): narrow the parked item a capturing operator reloads

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/509-distill-state-item-cast-parked.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/509-distill-state-item-cast-parked.phr
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The fourth member of the 505 family, and the only one that reaches a
+# CAPTURING operator (#817). 505 narrows the erased Object item that a
+# distinct()/skip()-led pipeline carries by splicing a `checkcast` between the
+# stateful guard's keep-frame and the first body opcode that consumes the item
+# as a NARROWER reference; 508 tolerates the one `dup` a filter or a peek puts
+# in that gap (#788) and 509 tolerates 310's sticky-latch prologue (#799). All
+# three anchor on the keep-frame and count opcodes forward from it, which works
+# only because every operator they cover eats the item WHERE THE FRAME LEFT IT,
+# on top of the stack.
+#
+# A capturing map or filter does not. 316 (and 314, its predicate mirror) lowers
+# one to a park/reload body — `astore 1` parks the incoming item in its own
+# now-dead parameter slot, one `fetch` per capture reads the captured values
+# back out of the shared state List, and `aload 1` reloads it on top — so the
+# consuming `invokestatic` sits behind a run whose length is the number of
+# captures, and the reference it eats is the RELOADED copy, not the one the
+# frame declared. `PAIRS.stream().distinct().map(p -> new Pair(p.key() + by,
+# p.text()))`, with `by` a captured long and `Pair` a small value class, is
+# therefore left uncast by all three rules, the erased Object reaches an
+# `invokestatic` typed "(JLPair;)LPair;", and the class dies at initialization
+# with "Bad type on operand stack: Type 'java/lang/Object' is not assignable to
+# 'Pair'" inside the synthesised distill. `skip(1L)` in place of `distinct()`
+# fails identically, and the same map runs clean with no stateful head — the
+# trigger is exactly a stateful head plus a capturing reference operator. 314
+# assembles the very same park/reload body for a capturing FILTER, so the
+# predicate shape is covered here by construction, even though a capturing
+# predicate directly behind a bare distinct()/skip() is left native today and
+# does not reach this rule.
+#
+# So this rule anchors on the RELOAD instead of the frame: an `aload 1`
+# immediately followed by the `invokestatic` onto the desugared `lambda$`, with
+# the cast spliced between them. That narrows exactly the copy the call
+# consumes, one opcode before it is needed, and it is indifferent to whatever
+# lies between the guard and the park — nothing, a `dup` from 283/431, 310's
+# latch prologue, or the whole body of another fused operator — which is why the
+# park/reload shape needs one rule where the frame-anchored shape needed three.
+# The frame is untouched, so it still rightly declares Object (the cast runs far
+# after it) and 503 is left unchanged, exactly as in 505, 508 and 509. Local 1
+# keeps its declared Object type too: the cast narrows the value on the stack
+# after the `aload`, not the slot it came from, so a second reload further down
+# a fused body gets its own cast rather than inheriting this one.
+#
+# The item is the LAST parameter of the target descriptor, because 316 pushes
+# the captures first and reloads the item on top of them. 112 and 113 admit a
+# capture only from the alphabet "[IJD]" and "L…;", so the parameter list is
+# always "([IJD]|L…;)*L…;" and the class to cast to is its RIGHTMOST reference —
+# the same descriptor walking 112 and 113 do with their own alternation. This is
+# also why 505's guard cannot be repaired by widening it to admit a capture
+# prefix: "(JLPair;)LPair;" does fail its `^\(L[^;]+;\)` test, but a guard that
+# admitted the prefix still would not fire, since what 505 anchors on — a frame
+# DIRECTLY followed by the call — never occurs once 316 has parked the item.
+#
+# The `when` guard is otherwise 505's: bridge-input must be Object (the
+# distinct / skip element-erasure signature) and the item parameter must be a
+# non-Object reference, so an Object-accepting body is left alone. The
+# invokestatic is spelled with the "i1 ↦ class … i4 ↦ is-interface" bindings 314
+# and 316 emit, not the "i2 ↦ class … i5 ↦ is-interface" ones the bodies 505
+# matches carry, so this rule sees the park/reload call and nothing else. It
+# runs before 512 (which wraps the distill-lambda body into a method) and 521
+# (which turns each `fetch` into a List.get plus a checkcast), applied at
+# fixpoint: the cast it inserts now sits between the `aload` and the
+# `invokestatic`, so the adjacency does not re-match.
+name: distill-state-item-cast-parked
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ 𝑒-static,
+    bridge-input ↦ "Ljava/lang/Object;",
+    consumer ↦ 𝑒-consumer,
+    target-method ↦ 𝑒-target-method,
+    captured ↦ 𝑒-captured,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-reload ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
+      𝜏-invoke ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokestatic,
+        i1 ↦ 𝑒-invoke-class,
+        i2 ↦ 𝑒-invoke-method,
+        i3 ↦ 𝑒-invoke-signature,
+        i4 ↦ 𝑒-invoke-is-interface
+      ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.distill-lambda,
+    static ↦ 𝑒-static,
+    bridge-input ↦ "Ljava/lang/Object;",
+    consumer ↦ 𝑒-consumer,
+    target-method ↦ 𝑒-target-method,
+    captured ↦ 𝑒-captured,
+    body ↦ ⟦
+      𝐵-before,
+      𝜏-reload ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
+      𝜏-cast ↦ ⟦ φ ↦ Φ.jeo.opcode.checkcast, i1 ↦ 𝑒-cast-class ⟧,
+      𝜏-invoke ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokestatic,
+        i1 ↦ 𝑒-invoke-class,
+        i2 ↦ 𝑒-invoke-method,
+        i3 ↦ 𝑒-invoke-signature,
+        i4 ↦ 𝑒-invoke-is-interface
+      ⟧,
+      𝐵-after,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+when:
+  and:
+    - matches: ['^\(([IJD]|L[^;]+;)*L[^;]+;\)', 𝑒-invoke-signature]
+    - not:
+        matches: ['^\(([IJD]|L[^;]+;)*Ljava/lang/Object;\)', 𝑒-invoke-signature]
+where:
+  - meta: 𝜏-cast
+    function: random-tau
+  # The rightmost reference of the parameter list, which is the item: the
+  # greedy prefix walks past every capture to the last "L…;" that still ends at
+  # the closing parenthesis, so a capture whose own class name sits earlier in
+  # the descriptor cannot be picked by mistake.
+  - meta: 𝑒-cast-class
+    function: sed
+    args:
+      - 𝑒-invoke-signature
+      - '"s/.*L([^;]*);\\).*/$1/g"'

--- a/src/test/phino/509-distill-state-item-cast-parked.yml
+++ b/src/test/phino/509-distill-state-item-cast-parked.yml
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# 509-parked is the member of the 505 family that reaches a CAPTURING operator
+# (#817). 316 does not let the consuming invokestatic eat the item where the
+# stateful guard left it: it parks the item in local 1, pushes the captured
+# values back out of the shared state List (one `fetch` each, plus an unboxing
+# call for a primitive capture), reloads the item on top with `aload 1`, and only
+# then calls the desugared lambda$. So the body below reads frame → astore 1 →
+# fetch → longValue → aload 1 → invokestatic, and 505 (frame → invokestatic),
+# 508 (frame → dup → invokestatic) and 509 (frame → latch → dup →
+# invokestatic) all decline it. The item is still the erased Ljava/lang/Object; a
+# distinct/skip-led distill carries, while the desugared map takes
+# "(JLA$Pair;)LA$Pair;" — the captured long first, the item last — so without a
+# cast the class fails verification with "Bad type on operand stack". This rule
+# anchors on the RELOAD and splices `checkcast A$Pair` between it and the call,
+# taking the class from the RIGHTMOST reference of the descriptor's parameter
+# list (the item), not the first one (a capture). The frame is untouched: the
+# cast runs long after it, so it still rightly declares Object.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-state-frame.phr
+  - src/main/resources/org/eolang/hone/rules/streams/5xx/509-distill-state-item-cast-parked.phr
+input: |
+  ⟦
+    body ↦ ⟦
+      op1 ↦ ⟦
+        φ ↦ Φ.hone.distill-lambda,
+        static ↦ "true",
+        bridge-input ↦ "Ljava/lang/Object;",
+        consumer ↦ "Ljava/util/function/Consumer;",
+        target-method ↦ "distill_0",
+        captured ↦ "Ljava/util/List;",
+        body ↦ ⟦
+          g1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/util/HashSet" ⟧,
+          g2 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+          g3 ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, i1 ↦ 1 ⟧,
+          g4 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Long" ⟧,
+          g5 ↦ ⟦
+            φ ↦ Φ.jeo.opcode.invokevirtual,
+            i1 ↦ "java/lang/Long",
+            i2 ↦ "longValue",
+            i3 ↦ "()J",
+            i4 ↦ Φ.false
+          ⟧,
+          g6 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
+          g7 ↦ ⟦
+            φ ↦ Φ.jeo.opcode.invokestatic,
+            i1 ↦ "A",
+            i2 ↦ "lambda$main$0",
+            i3 ↦ "(JLA$Pair;)LA$Pair;",
+            i4 ↦ Φ.false
+          ⟧,
+          ρ ↦ ∅
+        ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+expected:
+  - ⟦ φ ↦ Φ.jeo.opcode.checkcast, i1 ↦ "A$Pair" ⟧
+  - ⟦ 𝐵-p, 𝜏-r ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧, 𝜏-c ↦ ⟦ φ ↦ Φ.jeo.opcode.checkcast, i1 ↦ "A$Pair" ⟧, 𝜏-i ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, 𝐵-x, i2 ↦ "lambda$main$0", 𝐵-y ⟧, 𝐵-q ⟧
+  - ⟦ 𝐵-b, 𝜏-f ↦ ⟦ φ ↦ Φ.jeo.frame, 𝐵-fr ⟧, 𝜏-p ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, i1 ↦ 1 ⟧, 𝐵-a ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/stateful-closure-tail.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/stateful-closure-tail.yml
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# End-to-end proof that a CAPTURING map riding a distinct()-led pipeline
+# verifies (#817). distinct erases the element type, so the fused stateful
+# distill carries bridge-input ↦ Ljava/lang/Object; and the item the guard hands
+# on is an Object. The map that follows captures a `long` method argument, so
+# javac desugars it to a "(JLPair;)LPair;" static handle and 316 lowers it to a
+# park/reload body: `astore 1` parks the item, one `fetch` reads the captured
+# long back out of the shared state List, `aload 1` reloads the item on top, and
+# the invokestatic consumes both. The 505 family narrows the item by anchoring
+# on the guard's keep-frame — 505 on the frame itself, 508 across a filter's
+# `dup`, 509 across a dropWhile's latch — and NONE of them reaches this shape,
+# because the item the call eats is the reloaded copy and the frame is separated
+# from the call by the whole capture run. So before 509-parked the Object
+# reached an invokestatic typed for Pair and the class died at initialization
+# with "Bad type on operand stack: Type 'java/lang/Object' is not assignable to
+# 'statefulclosuretail/X$Pair'" inside the synthesised distill. The new rule
+# splices the `checkcast` between the reload and the call, where the narrowed
+# item is first needed.
+#
+# The opcode tally is where the cast is pinned. `checkcast` is absent from what
+# javac emits here and the optimized class carries exactly three: the
+# ConcurrentHashMap$KeySetView the distinct guard reads out of the captured
+# List, the java/lang/Long the capture is unboxed from, and the Pair this fix
+# adds — drop the fix and the count is two. The two invokedynamics are
+# unchanged: the capturing map's indy becomes the fused mapMulti's, and forEach
+# keeps its own, so the proof of fusion is the mapMulti dispatch
+# (invokeinterface 4 → 8) rather than a dropped indy.
+#
+# PAIRS is {(2,"two"), (5,"five"), (2,"two")}, distinct leaves {(2,"two"),
+# (5,"five")}, the capturing map adds by=3 to each key, and forEach sums them:
+# 5 + 8 = 13.
+java: |
+  package statefulclosuretail;
+  import java.util.List;
+  public class X {
+    private static final List<Pair> PAIRS =
+      List.of(new Pair(2L, "two"), new Pair(5L, "five"), new Pair(2L, "two"));
+    static long sum(long by) {
+      long[] acc = new long[1];
+      PAIRS.stream()
+        .distinct()
+        .map(p -> new Pair(p.key() + by, p.text()))
+        .forEach(p -> acc[0] += p.key());
+      return acc[0];
+    }
+    public static void main(String[] args) {
+      System.out.printf("The result is %d%n", sum(3L));
+    }
+    static final class Pair {
+      private final long num;
+      private final String word;
+      Pair(long key, String text) {
+        this.num = key;
+        this.word = text;
+      }
+      long key() {
+        return this.num;
+      }
+      String text() {
+        return this.word;
+      }
+      @Override
+      public boolean equals(Object other) {
+        return other instanceof Pair
+          && ((Pair) other).num == this.num
+          && ((Pair) other).word.equals(this.word);
+      }
+      @Override
+      public int hashCode() {
+        return (int) this.num * 31 + this.word.hashCode();
+      }
+    }
+  }
+before:
+  invokedynamic: 2
+  checkcast: 0
+after:
+  invokedynamic: 2
+  checkcast: 3
+log:
+  - "BUILD SUCCESS"
+  - "The result is 13"


### PR DESCRIPTION
Closes #817.

## The defect

Reproduced by hand, since the seed the issue names no longer prints that class
(the grammar in `RandomPipeline` has no capturing production today — see
"Notes" below):

```java
PAIRS.stream()
  .distinct()
  .map(p -> new Pair(p.key() + by, p.text()))   // `by` is a captured long
  .forEach(p -> acc[0] += p.key());
```

dies at initialization with

```
java.lang.VerifyError: Bad type on operand stack
  Location: repro/Repro.distill_5028152(Ljava/util/List;Ljava/lang/Object;Ljava/util/function/Consumer;)V @44
  Reason: Type 'java/lang/Object' (current frame, stack[2]) is not assignable to 'repro/Repro$Pair'
```

`skip(1L)` in place of `distinct()` fails identically; the same map with no
stateful head runs clean.

## Why 505's guard is not the whole story

The issue proposes widening `505-distill-state-item-cast.phr:94` to admit a
capture prefix and taking the rightmost reference in the `𝑒-cast-class` sed.
The descriptor diagnosis is right — `(JLPair;)LPair;` does fail that
`^\(L[^;]+;\)` test — but widening the guard alone would not fire, because
**505 never sees this site at all**.

505, `508` (dup-tolerant) and `509-latch` all anchor on the stateful guard's
keep-frame and count opcodes forward from it. That works only for operators
that eat the item *where the frame left it*, on top of the stack. A capturing
operator does not: `316` (and `314`, its predicate mirror) lowers one to a
park/reload body —

```
frame                       <- what 505/508/509 anchor on
astore 1                    <- park the item in its own now-dead param slot
fetch java/lang/Long        <- one per capture, out of the shared state List
invokevirtual longValue
aload 1                     <- reload the item on top of the captures
invokestatic lambda$…(JLPair;)LPair;
```

so the call is separated from the frame by a run whose length is the number of
captures, and the reference it consumes is the *reloaded* copy. No amount of
gap tolerance in the frame-anchored family reaches it. (Confirmed empirically:
the frame is followed by the `astore`, never by the call.)

## The fix

`509-distill-state-item-cast-parked.phr` — a fourth member of the 505 family
that anchors on the **reload** instead of the frame: an `aload 1` immediately
followed by the `invokestatic`, with the `checkcast` spliced between them. That
narrows exactly the copy the call consumes, one opcode before it is needed, and
it is indifferent to whatever sits between the guard and the park (nothing, a
`dup` from 283/431, 310's latch prologue, another fused operator's body) — which
is why the park/reload shape needs one rule where the frame-anchored shape needed
three. The frame is untouched, so it still rightly declares `Object` and `503`
is left unchanged, exactly as in the three siblings.

The class to cast to is the **rightmost** reference of the descriptor's
parameter list, because `316` pushes the captures first and reloads the item
last. `112`/`113` admit a capture only from the `[IJD]` / `L…;` alphabet, so the
guard mirrors that alternation, declines an `Object` item (nothing to narrow)
and declines an array parameter rather than mis-casting it.

It reuses the `509` prefix and sorts right after `509-latch`; ordering inside
the family is immaterial, since each rule anchors on a different adjacency.

## Verification

Run against the real `phino` 0.0.106 on the host.

* `src/test/phino/509-distill-state-item-cast-parked.yml` — single-rule pack
  over the post-`503` park/reload body; asserts the `checkcast` lands between
  the reload and the call, and that the frame still opens the parked run. All
  three expected patterns match when `phino rewrite` / `phino match` are driven
  by hand.
* `src/test/resources/org/eolang/hone/optimize/streams/stateful-closure-tail.yml`
  — end-to-end. `checkcast` is absent from what `javac` emits and the optimized
  class carries exactly three (the guard's `KeySetView`, the capture's `Long`,
  and the item's `Pair`); drop the fix and the count is two and the class will
  not load. Runtime line `The result is 13` is the real proof.
* `mvn -Pdeep test`: **all 50 `optimize/**.yml` fixtures pass**, including the
  new one, so nothing regressed in the end-to-end suite.
  `preservesWhatRandomPipelinesPrint` reports 1 of 120 — seed 9, the
  pre-existing failure described below.
* By hand, before/after output compared for eight shapes: capturing map after
  `distinct()`, after `skip()`, after `dropWhile()`, a two-capture map
  (`(JLjava/lang/String;LPair;)LPair;`), a `String`-element capturing map, two
  fused capturing maps in a row, `distinct().filter(…).map(capturing)`, and
  capturing filters. All print identically before and after optimization; with
  the new rule excluded via `!streams/5xx/509-distill-state-item-cast-parked*`
  the same build fails to load.
* A ten-case table over the guard and the `sed` extraction (capture prefixes,
  `Object` item, no reference item, array parameter, non-`Object` bridge-input)
  behaves as designed.

## Notes, out of scope

* `RandomPipeline`'s grammar has no capturing production — every lambda in it
  closes over nothing, and `pipe()` takes no arguments — so
  `new RandomPipeline(224L)` prints a non-capturing `dropWhile`/`peek` pipeline,
  not the class in the issue. Nothing is quarantined for #817 and nothing needed
  deleting. Teaching the walk to capture would guard this rule against
  regression, but it widens the grammar well beyond this fix and is likely to
  surface unrelated gaps, so it is left for its own issue.
* `preservesWhatRandomPipelinesPrint` is red on `master` independently of this
  change: seed 9,
  `Arrays.stream(DECIMALS).filter(d -> d > 1.0).boxed().mapToInt(Double::intValue).count()`,
  fails with `VerifyError: Inconsistent stackmap frames at branch target 12` in
  `distill_…(Ljava/lang/Double;Ljava/util/function/IntConsumer;)V` — a
  frame-shape defect with no captures and `bridge-input ↦ Ljava/lang/Double;`,
  so it is out of reach of this rule. It reproduces with this rule excluded, and
  the `deep` workflow has been failing on `master` for several pushes. Not filed;
  happy to open an issue if useful.