### PR TITLE
fix(#816): guard the lifted short-circuits too

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,18 @@ Because a `mapMulti` cannot honour cancellation, the cure mirrors the
   native call whenever the same method body reaches a `limit`, `takeWhile`,
   `findFirst`, `findAny`, `anyMatch`, `allMatch`, or `noneMatch` downstream of
   it, so those `flatMap`s stay unfused.
+Covering those seven names takes two rules, because by the time the 4xx pass
+  runs they no longer share a shape (#816):
+  `limit`, `findFirst` and `findAny` take no lambda and are still plain opcodes,
+  while `takeWhile`, `anyMatch`, `allMatch` and `noneMatch` each take one and
+  have therefore been folded into a `Φ.hone.lambda` by
+  `111-invokedynamic-to-lambda`.
+`454-flatMap-revert-on-short-circuit` matches the opcode shape and its sibling
+  `454-flatMap-revert-on-lifted-short-circuit` the folded one, with the same
+  guard and the same seven-name list in both;
+  until the second one existed the four lambda-taking names went unguarded, the
+  `flatMap` was fused anyway, and the hang above stayed reachable through
+  `.takeWhile(i -> i < 5)`.
 
 ## Why `skip` Is Only Fused on Sequential Pipelines
 

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/454-flatMap-revert-on-lifted-short-circuit.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/454-flatMap-revert-on-lifted-short-circuit.phr
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The lifted half of the guard `454-flatMap-revert-on-short-circuit` opens; it
+# shares that rule's number and sorts ahead of it (`-lifted-` < `-short-`),
+# both ahead of 455. Read the sibling's header first: everything it says about
+# WHY a flatMap has to stay native once a short-circuiting operator is
+# reachable downstream of it (#736), about the dual positive route, and about
+# the `reverted ↦ Φ.true` marker that keeps the 111 → 454 → 701 cycle from
+# spinning, holds here word for word. Exactly one binding differs — the shape
+# the downstream short-circuit is matched in.
+#
+# The sibling binds that short-circuit as a raw `Φ.jeo.opcode.invokeinterface`
+# or `invokevirtual` and tests its method operand against the seven names. In
+# practice that reaches only the three which take no lambda — `limit`,
+# `findFirst`, `findAny`. The other four all take one, so by the time the 4xx
+# pass runs `111-invokedynamic-to-lambda` has folded each of their
+# invokedynamic + invokeinterface pairs into a single `Φ.hone.lambda` and there
+# is no opcode left for the sibling's pattern to see: `takeWhile`, `anyMatch`,
+# `allMatch` and `noneMatch` went unguarded, 455-458 converted the flatMap
+# anyway, and the traversal contract broke — a `.takeWhile(...)` pipeline
+# counted more peeks after optimization than before, and the hang #736 was
+# filed for stayed reachable through
+# `Stream.of(1L).flatMap(x -> Stream.iterate(x, i -> i + 1)).takeWhile(i -> i < 5)`
+# (#816).
+#
+# Matching the lifted form here closes that half: `𝜏-short` is bound as a
+# `Φ.hone.lambda` and the `method` of its `stream` block is tested against the
+# same seven names. Nothing between 111 and 701 claims those four operators —
+# no 2xx rule recognises them, so no distill ever swallows them — which is why
+# the lambda is still intact at this point and one pattern suffices. The name
+# list is kept character-identical in both rules rather than split three/four,
+# so the pair reads as one guard and neither drifts: `limit` cannot appear in
+# this form (it takes a `long`, not a functional interface) and the two
+# lambda-free terminals cannot either, so the extra names simply never match.
+# A capturing short-circuit — `takeWhile(n -> n < bound)` — is not lifted by
+# `111` either (its pattern requires a non-capturing `()...` interface), so it
+# arrives as the raw opcode the sibling already handles.
+name: flatMap-revert-on-lifted-short-circuit
+pattern: |
+  ⟦
+    𝐵-before,
+    𝜏-flatmap ↦ ⟦
+      φ ↦ Φ.hone.lambda,
+      class ↦ 𝑒-class,
+      method ↦ 𝑒-method,
+      interface ↦ 𝑒-interface,
+      lambda-signature ↦ 𝑒-lambda-signature,
+      bridge-signature ↦ 𝑒-bridge-signature,
+      static ↦ "true",
+      opcode ↦ 𝑒-opcode,
+      target ↦ ⟦
+        handle ↦ 𝑒-target-handle,
+        class ↦ 𝑒-target-class,
+        method ↦ 𝑒-target-method,
+        signature ↦ 𝑒-target-signature,
+        is-interface ↦ 𝑒-target-is-interface
+      ⟧,
+      stream ↦ ⟦
+        class ↦ 𝑒-stream-class,
+        method ↦ 𝑒-stream-method,
+        signature ↦ 𝑒-stream-signature
+      ⟧
+    ⟧,
+    𝐵-between,
+    𝜏-short ↦ ⟦
+      φ ↦ Φ.hone.lambda,
+      class ↦ 𝑒-sclass,
+      method ↦ 𝑒-smethod,
+      interface ↦ 𝑒-sinterface,
+      lambda-signature ↦ 𝑒-slambda-signature,
+      bridge-signature ↦ 𝑒-sbridge-signature,
+      static ↦ 𝑒-sstatic,
+      opcode ↦ 𝑒-sopcode,
+      target ↦ 𝑒-starget,
+      stream ↦ ⟦
+        class ↦ 𝑒-sstream-class,
+        method ↦ 𝑒-sstream-method,
+        signature ↦ 𝑒-sstream-signature
+      ⟧
+    ⟧,
+    𝐵-after
+  ⟧
+result: |
+  ⟦
+    𝐵-before,
+    𝜏-invokedynamic ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokedynamic,
+      i2 ↦ 𝑒-method,
+      i3 ↦ 𝑒-interface,
+      i4 ↦ ⟦
+        φ ↦ Φ.jeo.handle,
+        i1 ↦ 6,
+        i2 ↦ "java/lang/invoke/LambdaMetafactory",
+        i3 ↦ "metafactory",
+        i4 ↦ "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+        i5 ↦ Φ.false
+      ⟧,
+      i5 ↦ ⟦
+        φ ↦ Φ.jeo.type,
+        i1 ↦ 𝑒-lambda-signature
+      ⟧,
+      i6 ↦ ⟦
+        φ ↦ Φ.jeo.handle,
+        i1 ↦ 𝑒-target-handle,
+        i2 ↦ 𝑒-target-class,
+        i3 ↦ 𝑒-target-method,
+        i4 ↦ 𝑒-target-signature,
+        i5 ↦ 𝑒-target-is-interface
+      ⟧,
+      i7 ↦ ⟦
+        φ ↦ Φ.jeo.type,
+        i1 ↦ 𝑒-bridge-signature
+      ⟧
+    ⟧,
+    𝜏-invokeinterface ↦ ⟦
+      φ ↦ Φ.jeo.opcode.invokeinterface,
+      i2 ↦ 𝑒-stream-class,
+      i3 ↦ 𝑒-stream-method,
+      i4 ↦ 𝑒-stream-signature,
+      i5 ↦ Φ.true,
+      reverted ↦ Φ.true
+    ⟧,
+    𝐵-between,
+    𝜏-short ↦ ⟦
+      φ ↦ Φ.hone.lambda,
+      class ↦ 𝑒-sclass,
+      method ↦ 𝑒-smethod,
+      interface ↦ 𝑒-sinterface,
+      lambda-signature ↦ 𝑒-slambda-signature,
+      bridge-signature ↦ 𝑒-sbridge-signature,
+      static ↦ 𝑒-sstatic,
+      opcode ↦ 𝑒-sopcode,
+      target ↦ 𝑒-starget,
+      stream ↦ ⟦
+        class ↦ 𝑒-sstream-class,
+        method ↦ 𝑒-sstream-method,
+        signature ↦ 𝑒-sstream-signature
+      ⟧
+    ⟧,
+    𝐵-after
+  ⟧
+when:
+  and:
+    - matches: ['^flatMap(ToInt|ToLong|ToDouble)?$', 𝑒-stream-method]
+    - matches: ['^(limit|takeWhile|findFirst|findAny|anyMatch|allMatch|noneMatch)$', 𝑒-sstream-method]
+where:
+  - meta: 𝜏-invokedynamic
+    function: random-tau
+  - meta: 𝜏-invokeinterface
+    function: random-tau

--- a/src/main/resources/org/eolang/hone/rules/streams/4xx/454-flatMap-revert-on-short-circuit.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/4xx/454-flatMap-revert-on-short-circuit.phr
@@ -38,6 +38,17 @@
 # ignores the extra binding when assembling, so the bytecode is an ordinary
 # flatMap call.
 #
+# The short-circuit is bound below as a raw opcode, which reaches only the
+# three of the seven names that take no lambda: `limit`, `findFirst` and
+# `findAny`. The other four take one, so `111` has already folded them into a
+# `Φ.hone.lambda` and there is no opcode here to see — the sibling
+# `454-flatMap-revert-on-lifted-short-circuit` (which sorts just ahead of this
+# file) carries the identical guard with `𝜏-short` bound in that lifted shape
+# instead, and between the two every one of the seven is covered (#816). Keep
+# the name list in the two `when` blocks character-identical: a name that
+# cannot occur in one shape simply never matches there, and splitting the list
+# three/four would let the halves drift apart.
+#
 # Detection is intentionally over-broad: any matching short-circuit anywhere
 # after the flatMap in the method reverts it, even one on an unrelated,
 # locally-consumed stream. Over-reverting only forfeits the mapMulti fusion on
@@ -45,7 +56,7 @@
 # pass sound. Binding groups are order-preserving, and a short-circuit BEFORE
 # the flatMap is upstream of it — not reachable downstream — so a single
 # pattern with the flatMap ahead of the call is exactly the case to guard; the
-# mirror layout needs no sibling.
+# mirror layout needs no rule of its own.
 name: flatMap-revert-on-short-circuit
 pattern: |
   ⟦

--- a/src/test/phino/454-flatMap-revert-on-lifted-short-circuit.yml
+++ b/src/test/phino/454-flatMap-revert-on-lifted-short-circuit.yml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The lifted half of the 454 guard (#816). `takeWhile` takes a lambda, so by
+# the time the 4xx pass runs it is no longer an opcode at all — 111 has folded
+# its invokedynamic + invokeinterface pair into a Φ.hone.lambda, which is why
+# the sibling pack's raw-opcode pattern cannot see it. Here the flatMap lambda
+# is still reverted to its native invokedynamic + invokeinterface pair, with
+# the `reverted ↦ Φ.true` guard that stops 111 re-lifting it, so 455-458 never
+# fuse a flatMap whose mapMulti adapter could not honour cancellation (#736).
+# The downstream takeWhile lambda is left exactly as it was, for 701 to lower.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/4xx/454-flatMap-revert-on-lifted-short-circuit.phr
+input: |
+  ⟦
+    φ ↦ Φ.jeo.class,
+    name ↦ "Foo",
+    jm$main ↦ ⟦
+      φ ↦ Φ.jeo.method,
+      name ↦ "main",
+      body ↦ ⟦
+        φ ↦ Φ.jeo.seq.of,
+        op0 ↦ ⟦
+          φ ↦ Φ.hone.lambda,
+          class ↦ "Foo",
+          method ↦ "apply",
+          interface ↦ "()Ljava/util/function/Function;",
+          lambda-signature ↦ "(Ljava/lang/Object;)Ljava/lang/Object;",
+          bridge-signature ↦ "(Ljava/lang/Long;)Ljava/util/stream/Stream;",
+          static ↦ "true",
+          opcode ↦ "invokestatic",
+          target ↦ ⟦ handle ↦ 6, class ↦ "Foo", method ↦ "lambda$main$0", signature ↦ "(Ljava/lang/Long;)Ljava/util/stream/Stream;", is-interface ↦ Φ.false ⟧,
+          stream ↦ ⟦ class ↦ "java/util/stream/Stream", method ↦ "flatMap", signature ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;" ⟧
+        ⟧,
+        op1 ↦ ⟦
+          φ ↦ Φ.hone.lambda,
+          class ↦ "Foo",
+          method ↦ "test",
+          interface ↦ "()Ljava/util/function/Predicate;",
+          lambda-signature ↦ "(Ljava/lang/Object;)Z",
+          bridge-signature ↦ "(Ljava/lang/Long;)Z",
+          static ↦ "true",
+          opcode ↦ "invokestatic",
+          target ↦ ⟦ handle ↦ 6, class ↦ "Foo", method ↦ "lambda$main$1", signature ↦ "(Ljava/lang/Long;)Z", is-interface ↦ Φ.false ⟧,
+          stream ↦ ⟦ class ↦ "java/util/stream/Stream", method ↦ "takeWhile", signature ↦ "(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;" ⟧
+        ⟧,
+        ρ ↦ ∅
+      ⟧
+    ⟧,
+    ρ ↦ ∅
+  ⟧
+expected:
+  - ⟦ φ ↦ Φ.jeo.opcode.invokedynamic, i2 ↦ "apply", i3 ↦ "()Ljava/util/function/Function;", 𝐵-rest ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.invokeinterface, i2 ↦ "java/util/stream/Stream", i3 ↦ "flatMap", i4 ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;", i5 ↦ Φ.true, reverted ↦ Φ.true ⟧
+  - ⟦ φ ↦ Φ.hone.lambda, class ↦ "Foo", method ↦ "test", 𝐵-rest ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/flatmap-lifted-any-match.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/flatmap-lifted-any-match.yml
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# The traversal-contract half of #816, on a finite source, where the symptom is
+# wasted work rather than a hang. `anyMatch` takes a lambda, so — exactly like
+# `takeWhile` in flatmap-lifted-short-circuit.yml — 111 folds it into a
+# Φ.hone.lambda long before the 4xx pass, and the raw-opcode pattern of
+# 454-flatMap-revert-on-short-circuit could not see it. 455 converted the
+# flatMap into a mapMulti whose `result.sequential().forEach(c)` cannot be
+# cancelled, so the optimized class kept pulling elements after the match had
+# already been found.
+#
+# The peek here counts every element that reaches it, and the count is printed
+# next to the answer, which makes the traversal contract observable rather than
+# merely argued. The inner streams have three elements each and the match lands
+# on the FIRST of one of them, which is what makes the difference visible: the
+# native flatMap stops mid-inner-stream as soon as anyMatch is satisfied and
+# reaches the peek 13 times, while a mapMulti adapter has to finish the inner
+# stream it is draining — its `result.sequential().forEach(c)` cannot be
+# cancelled — and reaches it 15. (Cancellation between OUTER elements works
+# either way, so a match on the last element of an inner stream would hide the
+# defect; that is why the order inside `Stream.of` is not the obvious one.)
+# The lifted sibling reverts the flatMap, so both runs print the same line;
+# without it the optimized run printed `after 15`.
+#
+# Counts: the flatMap goes back to native form while the peek/map pair behind
+# it still fuses, so the optimized class holds exactly four call sites —
+# List.stream, the native Stream.flatMap, one Stream.mapMulti in place of
+# Stream.peek and Stream.map, and Stream.anyMatch. invokedynamic falls from 4 to
+# 3: the peek and map lambdas are replaced by the single BiConsumer the fused
+# adapter is handed. invokeinterface stays at 5 because the slot the collapsed
+# peek/map pair frees is taken by the adapter body's own
+# Consumer.accept call. What matters is what is NOT in the tally: no
+# flatMap-to-mapMulti conversion, so the native Stream.flatMap survives.
+java: |
+  package flatmapliftedanymatch;
+  import java.util.List;
+  import java.util.stream.Stream;
+  public class X {
+    private static final List<Long> LIST = List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L);
+    private static final long[] SEEN = {0L};
+    public static void main(String[] a) {
+      boolean found = LIST.stream()
+        .flatMap(n -> Stream.of(n + 2L, n, n + 1L))
+        .peek(n -> SEEN[0] += 1L)
+        .map(n -> n * 2L)
+        .anyMatch(n -> n > 12L);
+      System.out.printf("The result is %b after %d\n", found, SEEN[0]);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is true after 13"
+before:
+  invokedynamic: 4
+  invokeinterface: 5
+after:
+  invokedynamic: 3
+  invokeinterface: 5

--- a/src/test/resources/org/eolang/hone/optimize/streams/flatmap-lifted-short-circuit.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/flatmap-lifted-short-circuit.yml
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# The same unbounded flatMap as flatmap-short-circuit.yml, ending in the
+# short-circuit that takes a lambda instead of the one that takes a long
+# (issue #816). `Stream.of(1L).flatMap(x -> Stream.iterate(x, i -> i + 1))
+# .takeWhile(i -> i < 5)` yields 1+2+3+4 = 10 natively, because
+# ReferencePipeline.flatMap forwards cancellation and stops pulling from the
+# unbounded Stream.iterate once takeWhile has said no. A mapMulti adapter
+# cannot honour that cancellation, so fusing this flatMap (455) loops forever
+# — the very hang #736 was filed for.
+#
+# 454-flatMap-revert-on-short-circuit was supposed to prevent that, but it
+# binds the downstream short-circuit as a raw opcode, and `takeWhile` takes a
+# lambda: by the time the 4xx pass runs, 111 has already folded its
+# invokedynamic + invokeinterface pair into a Φ.hone.lambda, so there was no
+# opcode left to match and the guard silently covered only `limit`,
+# `findFirst` and `findAny`. This build therefore hung. Its lifted sibling
+# 454-flatMap-revert-on-lifted-short-circuit matches the folded form and
+# reverts the flatMap the same way, so the build finishes and prints 10.
+#
+# Counts: the guard reverts the flatMap to byte-identical native form and
+# nothing else in the chain fuses (takeWhile and reduce are not fusable, and
+# Stream.iterate's i -> i + 1 lambda is an argument to a static factory, not a
+# pipeline stage), so both opcode tallies are unchanged. invokedynamic stays at
+# 4 (the flatMap mapper, the iterate UnaryOperator, the takeWhile Predicate and
+# the Long::sum reduce accumulator). invokeinterface stays at 3
+# (Stream.flatMap, Stream.takeWhile, Stream.reduce); Stream.of and
+# Stream.iterate are static. Crucially there is no Stream.mapMulti call site —
+# the flatMap was left native rather than converted.
+java: |
+  package flatmapliftedshortcircuit;
+  import java.util.stream.Stream;
+  public class X {
+    public static void main(String[] a) {
+      long n = Stream.of(1L)
+        .flatMap(x -> Stream.iterate(x, i -> i + 1))
+        .takeWhile(i -> i < 5)
+        .reduce(0L, Long::sum);
+      System.out.printf("The result is %d\n", n);
+    }
+  }
+log:
+  - "Modified 1/1 X.phi"
+  - "Finished rewriting 1 file"
+  - "BUILD SUCCESS"
+  - "The result is 10"
+before:
+  invokedynamic: 4
+  invokeinterface: 3
+after:
+  invokedynamic: 4
+  invokeinterface: 3


### PR DESCRIPTION
Closes #816.

## The defect

`454-flatMap-revert-on-short-circuit.phr` binds the downstream short-circuit as a raw opcode — `𝜏-op` must be `invokeinterface` or `invokevirtual` — and then tests its method operand against `^(limit|takeWhile|findFirst|findAny|anyMatch|allMatch|noneMatch)$`. By the time the 4xx pass runs, `111-invokedynamic-to-lambda` has folded every stream call that takes a lambda into a `Φ.hone.lambda`, so `takeWhile`, `anyMatch`, `allMatch` and `noneMatch` are no longer opcodes at all and that pattern never reaches them. Only the three lambda-free names were actually guarded, `455`–`458` converted the `flatMap` anyway, and the traversal contract broke.

## The fix

A sibling rule, `454-flatMap-revert-on-lifted-short-circuit.phr`, carrying the identical guard with `𝜏-short` bound as a `Φ.hone.lambda` whose `stream` block holds the operator name. Nothing between `111` and `701` claims those four operators, so the lambda is still intact at 454 and one pattern covers them. Both files keep the same seven-name list rather than splitting it three/four, so neither half can drift; a name that cannot occur in one shape simply never matches there. The pair sorts ahead of `455` (`-lifted-` < `-short-` < `.phr`), and the reverted `invokeinterface` carries the same `reverted ↦ Φ.true` marker, so the `111 → 454 → 701` cycle still cannot spin.

Headers in the existing `454` and the README section that claimed all seven names were covered are corrected to describe the pair.

## Tests

- `src/test/phino/454-flatMap-revert-on-lifted-short-circuit.yml` — single-rule pack: a `flatMap` lambda followed by a lifted `takeWhile` reverts to the native pair, and the `takeWhile` lambda is left untouched for `701`.
- `flatmap-lifted-short-circuit.yml` — the `limit` fixture's `takeWhile` twin on an unbounded `Stream.iterate`. **Without the new rule this hangs**, timing out at 180s: the #736 hang, still reachable through a lambda-taking short-circuit.
- `flatmap-lifted-any-match.yml` — a finite source where the symptom is wasted work. The inner streams hold three elements and the match lands on the *first* of one of them, which is what makes the difference visible; cancellation between outer elements works either way, so a match on an inner stream's last element would hide the defect. **Without the new rule the optimized run prints `after 15` instead of `after 13`** — the `mapMulti` adapter finishing an inner stream after `anyMatch` was already satisfied.

Both fixtures' `after` tallies were measured from the optimized bytecode, not predicted: in the `anyMatch` case `invokedynamic` falls 4 → 3 (the peek and map lambdas become the fused adapter's single `BiConsumer`) while `invokeinterface` stays at 5 (`Stream.peek` + `Stream.map` collapse into one `Stream.mapMulti`, and the adapter body's own `Consumer.accept` takes the freed slot), and the class keeps its native `Stream.flatMap` call site beside the fused `Stream.mapMulti`.

Verified against the real `phino` 0.0.106 on the host: 82/82 single-rule packs pass, and both new fixtures pass with the rule and fail without it as described above.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MqnMxs1pLym2wm2oLSpYq9)_