### PR TITLE
fix(#817): take the item from the descriptor, not from its last L

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/509-distill-state-item-cast-parked.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/509-distill-state-item-cast-parked.phr
@@ -118,12 +118,20 @@ when:
 where:
   - meta: 𝜏-cast
     function: random-tau
-  # The rightmost reference of the parameter list, which is the item: the
-  # greedy prefix walks past every capture to the last "L…;" that still ends at
-  # the closing parenthesis, so a capture whose own class name sits earlier in
-  # the descriptor cannot be picked by mistake.
+  # The LAST parameter of the descriptor, which is the item. The walk is over
+  # the descriptor's own delimiters, never over its letters: isolate the
+  # parameter list, drop its final ";", cut everything through the last ";" that
+  # is left (which ends the second-to-last reference capture, if any), and strip
+  # the primitive captures and the "L" off what remains. Searching for the last
+  # "L" instead would find one INSIDE a class name — "Ljava/util/List;" and
+  # "LA$Level;" each carry one — and name the suffix after it instead of the
+  # class, splicing a checkcast onto a type that does not exist.
   - meta: 𝑒-cast-class
     function: sed
     args:
       - 𝑒-invoke-signature
-      - '"s/.*L([^;]*);\\).*/$1/g"'
+      - '"s/^[(]//"'
+      - '"s/[)].*$//"'
+      - '"s/;$//"'
+      - '"s/^.*;//"'
+      - '"s/^[IJD]*L//"'

--- a/src/test/phino/509-distill-state-item-cast-parked.yml
+++ b/src/test/phino/509-distill-state-item-cast-parked.yml
@@ -7,17 +7,24 @@
 # stateful guard left it: it parks the item in local 1, pushes the captured
 # values back out of the shared state List (one `fetch` each, plus an unboxing
 # call for a primitive capture), reloads the item on top with `aload 1`, and only
-# then calls the desugared lambda$. So the body below reads frame → astore 1 →
-# fetch → longValue → aload 1 → invokestatic, and 505 (frame → invokestatic),
-# 508 (frame → dup → invokestatic) and 509 (frame → latch → dup →
-# invokestatic) all decline it. The item is still the erased Ljava/lang/Object; a
-# distinct/skip-led distill carries, while the desugared map takes
-# "(JLA$Pair;)LA$Pair;" — the captured long first, the item last — so without a
-# cast the class fails verification with "Bad type on operand stack". This rule
-# anchors on the RELOAD and splices `checkcast A$Pair` between it and the call,
-# taking the class from the RIGHTMOST reference of the descriptor's parameter
-# list (the item), not the first one (a capture). The frame is untouched: the
-# cast runs long after it, so it still rightly declares Object.
+# then calls the desugared lambda$. So the bodies below read frame → astore 1 →
+# fetch → … → aload 1 → invokestatic, and 505 (frame → invokestatic), 508 (frame
+# → dup → invokestatic) and 509 (frame → latch → dup → invokestatic) all decline
+# them. The item is still the erased Ljava/lang/Object; a distinct/skip-led
+# distill carries, while the desugared map takes the captures first and the item
+# LAST, so without a cast the class fails verification with "Bad type on operand
+# stack". This rule anchors on the RELOAD and splices the `checkcast` between it
+# and the call. The frame is untouched: the cast runs long after it, so it still
+# rightly declares Object.
+#
+# `op1` is the one-capture shape #817 reports, "(JLA$Pair;)LA$Pair;". `op2` is
+# there for the extraction: the class to cast to is the descriptor's LAST
+# parameter, and reading it as "the last L in the string" is wrong the moment a
+# class name carries an L of its own — "Ljava/util/LinkedList;" and "LA$Level;"
+# each do, and such a read names the suffix after that inner L instead of the
+# class, a type that does not exist. So `op2` captures a LinkedList and carries
+# an A$Level item, and the expected pattern pins the cast to A$Level; a
+# regression in the walk cannot pass it.
 rules:
   - src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-state-frame.phr
   - src/main/resources/org/eolang/hone/rules/streams/5xx/509-distill-state-item-cast-parked.phr
@@ -54,6 +61,37 @@ input: |
           ρ ↦ ∅
         ⟧
       ⟧,
+      op2 ↦ ⟦
+        φ ↦ Φ.hone.distill-lambda,
+        static ↦ "true",
+        bridge-input ↦ "Ljava/lang/Object;",
+        consumer ↦ "Ljava/util/function/Consumer;",
+        target-method ↦ "distill_1",
+        captured ↦ "Ljava/util/List;",
+        body ↦ ⟦
+          h1 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/util/HashSet" ⟧,
+          h2 ↦ ⟦ φ ↦ Φ.hone.frame-item ⟧,
+          h3 ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, i1 ↦ 1 ⟧,
+          h4 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/lang/Long" ⟧,
+          h5 ↦ ⟦
+            φ ↦ Φ.jeo.opcode.invokevirtual,
+            i1 ↦ "java/lang/Long",
+            i2 ↦ "longValue",
+            i3 ↦ "()J",
+            i4 ↦ Φ.false
+          ⟧,
+          h6 ↦ ⟦ φ ↦ Φ.hone.fetch, type ↦ "java/util/LinkedList" ⟧,
+          h7 ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧,
+          h8 ↦ ⟦
+            φ ↦ Φ.jeo.opcode.invokestatic,
+            i1 ↦ "A",
+            i2 ↦ "lambda$main$1",
+            i3 ↦ "(JLjava/util/LinkedList;LA$Level;)LA$Level;",
+            i4 ↦ Φ.false
+          ⟧,
+          ρ ↦ ∅
+        ⟧
+      ⟧,
       ρ ↦ ∅
     ⟧
   ⟧
@@ -61,3 +99,5 @@ expected:
   - ⟦ φ ↦ Φ.jeo.opcode.checkcast, i1 ↦ "A$Pair" ⟧
   - ⟦ 𝐵-p, 𝜏-r ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧, 𝜏-c ↦ ⟦ φ ↦ Φ.jeo.opcode.checkcast, i1 ↦ "A$Pair" ⟧, 𝜏-i ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, 𝐵-x, i2 ↦ "lambda$main$0", 𝐵-y ⟧, 𝐵-q ⟧
   - ⟦ 𝐵-b, 𝜏-f ↦ ⟦ φ ↦ Φ.jeo.frame, 𝐵-fr ⟧, 𝜏-p ↦ ⟦ φ ↦ Φ.jeo.opcode.astore, i1 ↦ 1 ⟧, 𝐵-a ⟧
+  - ⟦ φ ↦ Φ.jeo.opcode.checkcast, i1 ↦ "A$Level" ⟧
+  - ⟦ 𝐵-s, 𝜏-rr ↦ ⟦ φ ↦ Φ.jeo.opcode.aload, i1 ↦ 1 ⟧, 𝜏-cc ↦ ⟦ φ ↦ Φ.jeo.opcode.checkcast, i1 ↦ "A$Level" ⟧, 𝜏-ii ↦ ⟦ φ ↦ Φ.jeo.opcode.invokestatic, 𝐵-u, i2 ↦ "lambda$main$1", 𝐵-v ⟧, 𝐵-t ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/stateful-closure-boxed.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/stateful-closure-boxed.yml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The companion of stateful-closure-tail.yml, and the one that pins WHICH class
+# 509-parked casts to. The rule takes the item from the LAST parameter of the
+# desugared lambda's descriptor, because 316 pushes the captures first and
+# reloads the item on top of them. Reading that as "the last L in the
+# descriptor" is wrong the moment the element's own internal name carries an L:
+# for the "(JLjava/lang/Long;)Ljava/lang/Long;" this pack produces, such a read
+# lands on the L of Long itself and casts to the three-letter suffix behind it,
+# a class that does not exist. The optimized class then dies at initialization
+# with NoClassDefFoundError instead of a VerifyError — a different failure from
+# the one #817 reports, out of the same rule. Long is not special: every element
+# whose name carries an L (List, ArrayList, LinkedList, a value class of one's
+# own) reaches it, while Integer, Double and String happen not to and hide it.
+#
+# So this is ordinary code, not an exotic shape: distinct() erases the element
+# type, the capturing map behind it takes the captured long first and the Long
+# item last, and the whole thing must simply run. The tally pins three
+# `checkcast` opcodes in the optimized class — the guard's KeySetView, the
+# capture's Long, and the item's Long — against none in what javac emits.
+#
+# LIST is {4, 8, 8, 15}, distinct leaves {4, 8, 15}, by=3 lifts them to
+# {7, 11, 18}, and forEach sums: 36.
+java: |
+  package statefulclosureboxed;
+  import java.util.List;
+  public class X {
+    private static final List<Long> LIST = List.of(4L, 8L, 8L, 15L);
+    static long shifted(long by) {
+      long[] sum = new long[1];
+      LIST.stream()
+        .distinct()
+        .map(n -> n + by)
+        .forEach(n -> sum[0] += n);
+      return sum[0];
+    }
+    public static void main(String[] args) {
+      System.out.printf("The result is %d%n", shifted(3L));
+    }
+  }
+before:
+  invokedynamic: 2
+  checkcast: 0
+after:
+  invokedynamic: 2
+  checkcast: 3
+log:
+  - "BUILD SUCCESS"
+  - "The result is 36"


### PR DESCRIPTION
Follow-up to #818, which merged before this could be pushed. Copilot's review
on that PR was right, and the defect is worse than the comment suggests.

## What is broken on master

`509-distill-state-item-cast-parked.phr` reads the class to cast to with

```
s/.*L([^;]*);\).*/$1/
```

which finds the **last `L` in the descriptor**, not the `L` that opens its last
parameter. Any element whose internal name carries an `L` of its own is read
from that inner letter. Ordinary code:

```java
private static final List<Long> LIST = List.of(4L, 8L, 8L, 15L);
LIST.stream().distinct().map(n -> n + by).forEach(n -> sum[0] += n);
```

desugars to `(JLjava/lang/Long;)Ljava/lang/Long;`, the walk lands on the `L` of
`Long`, and the optimized class carries

```
44: checkcast  #150   // class ong
47: invokestatic #152 // Method lambda$shifted$0:(JLjava/lang/Long;)Ljava/lang/Long;
```

and dies at initialization with `java.lang.NoClassDefFoundError: ong` —
measured through the plugin against master's rule, then again with this fix,
where the same site becomes `checkcast java/lang/Long` and the class prints
`shifted=36`.

`Long` is not special. `List` yields a three-letter suffix, `ArrayList` and
`LinkedList` the same, and so does any value class holding an `L`. `Integer`,
`Double` and `String` happen to carry no `L`, which is exactly why the pack and
the fixture added in #818 passed — every type in them was L-free.

## The fix

Walk the descriptor's **delimiters**, never its letters: isolate the parameter
list, drop its final `;`, cut everything through the last `;` that is left
(which ends the second-to-last reference capture, if any), and strip the
primitive captures and the `L` off what remains.

```yaml
- meta: 𝑒-cast-class
  function: sed
  args:
    - 𝑒-invoke-signature
    - '"s/^[(]//"'
    - '"s/[)].*$//"'
    - '"s/;$//"'
    - '"s/^.*;//"'
    - '"s/^[IJD]*L//"'
```

## Tests

The gap that let this through was that no committed test used an L-bearing type,
so both new tests do.

* `src/test/phino/509-distill-state-item-cast-parked.yml` gains a second
  distill-lambda (`op2`) whose descriptor is
  `(JLjava/util/LinkedList;LA$Level;)LA$Level;` — an L-bearing capture and an
  L-bearing item. The expected pattern pins the cast to `A$Level`; the old walk
  produced the suffix of `Level` and cannot pass it.
* `src/test/resources/org/eolang/hone/optimize/streams/stateful-closure-boxed.yml`
  runs the `List<Long>` pipeline above end to end: `checkcast` 0 → 3 (the
  guard's `KeySetView`, the capture's `Long`, the item's `Long`) and
  `The result is 36`.

Verified against the real `phino` 0.0.106 on the host:

* A 16-case table over the guard and the extraction — L-bearing items
  (`java/lang/Long`, `java/util/List`, `java/util/LinkedList`, `A$Level`),
  L-bearing captures, primitive-capture prefixes, a class name beginning with a
  primitive letter (`LJar;`), and the declined shapes (`Object` item, no
  reference item, array parameter, non-`Object` bridge-input) — all extract the
  correct class. Four of the sixteen fail on master.
* Both fixtures and the pack pass, and the nine capturing shapes from #818's
  verification still print identically before and after optimization.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMBVSsm14kUEpARD63MKdF)_