### PR TITLE
fix(#821): dup the item for a filter behind a capturing map

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/2xx/283-insert-dup-before-filter-after-stateful.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/2xx/283-insert-dup-before-filter-after-stateful.phr
@@ -7,11 +7,11 @@
 # Φ.hone.dup when the filter follows a map or another filter, but its
 # pattern is shaped for the map/filter pragma (opcode + target bindings)
 # and so never matches a stateful predecessor. A filter that follows a
-# distinct, skip or dropWhile — a stateful guard that leaves a single
-# (un-duplicated) item — would therefore be left without its dup, its
+# distinct, skip, dropWhile or capturing map — a stateful pragma that leaves a
+# single (un-duplicated) item — would therefore be left without its dup, its
 # predicate would eat the only item, and the keep-label frame would find an
 # empty stack. This rule plugs that gap: when 𝜏-first is one of those
-# stateful guards and 𝜏-second is a filter, it splices the same Φ.hone.dup
+# stateful pragmas and 𝜏-second is a filter, it splices the same Φ.hone.dup
 # between them. After
 # insertion the two are no longer adjacent, so it fires once per site.
 #
@@ -26,6 +26,25 @@
 # "Inconsistent stackmap frames" (#804). 𝐵-first-head absorbs whatever the
 # guard puts between `φ` and `class` — none of it is anything this rule reads
 # — so the ordering a fourth guard picks will not matter either.
+#
+# The capturing map is the fourth (#821). A `c-map` is pointwise, so 281 is
+# where it would belong by nature, but 112 gives it `state-acc`, `body-acc`
+# and `captures` ahead of `class` and no `opcode` at all, and 281 spells its
+# predecessor out binding for binding — so a plain filter behind a capturing
+# map reached 4xx with no guard, 401 fused it into a distill, the predicate
+# ate the only copy of the mapped item, and 503's keep-frame promised an
+# element the stack no longer had. It is stateful in the sense that matters
+# here — 316 folds it into a stateful distill, and its bindings are exactly
+# the ones this rule's 𝐵-first-head was written to absorb. `map(p -> new
+# Pair(p.key() + by, p.text())).filter(p -> p.key() > 1L)`, with `by`
+# captured, is the shape; streams/closure-map-filter.yml runs it.
+#
+# A c-map cannot reach the other two rules of this family. 241-243 pin
+# Φ.hone.map literally, so no `type` or `transform` is ever spliced behind a
+# capturing map and 282 has nothing to say about one; and 112 only lifts a
+# Stream.map, whose element stays a reference, so the filter that follows is
+# always an o-filter over one stack slot — the `dup` this rule reads off the
+# filter's `bridge-input`, never a `dup2`.
 name: insert-dup-before-filter-after-stateful
 pattern: |
   ⟦
@@ -82,6 +101,7 @@ when:
         - eq: [𝜏-one, 'distinct']
         - eq: [𝜏-one, 'skip']
         - eq: [𝜏-one, 'dropWhile']
+        - eq: [𝜏-one, 'c-map']
     - or:
         - eq: [𝜏-two, 'o-filter']
         - eq: [𝜏-two, 'p-filter']

--- a/src/test/phino/283-insert-dup-before-filter-after-capturing-map.yml
+++ b/src/test/phino/283-insert-dup-before-filter-after-capturing-map.yml
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The capturing half of #821: a plain filter behind the Φ.hone.c-map that 112
+# lifts and 114 gathers. The pragma is pointwise, so 281 is where it looks
+# like it belongs, but it carries `state-acc`, `body-acc` and `captures` ahead
+# of `class` and no `opcode` at all, and 281 spells its predecessor out
+# binding for binding — so the site was left without a dup, the predicate ate
+# the only copy of the mapped item and the keep label met an empty stack. 283's
+# 𝐵-first-head absorbs the three accumulators, which is why the fix is one
+# more name in its alternation and nothing else.
+#
+# The c-map here is a drained one — `captures` empty, both accumulators
+# already holding the unit 114 peeled — because that is the state the pragma
+# is in by the time the 2xx rules see it. The dup opcode is read off the
+# filter's `bridge-input`, an Object, so it is the one-slot `dup`; a c-map is
+# type-preserving over a reference element, so it is never a `dup2`.
+rules:
+  - src/main/resources/org/eolang/hone/rules/streams/2xx/283-insert-dup-before-filter-after-stateful.phr
+input: |
+  ⟦
+    body ↦ ⟦
+      op1 ↦ ⟦
+        φ ↦ Φ.hone.c-map,
+        state-acc ↦ ⟦
+          s1 ↦ ⟦ φ ↦ Φ.jeo.opcode.dup ⟧,
+          ρ ↦ ∅
+        ⟧,
+        body-acc ↦ ⟦
+          b1 ↦ ⟦ φ ↦ Φ.hone.cap-fetch, code ↦ "J" ⟧,
+          ρ ↦ ∅
+        ⟧,
+        captures ↦ "",
+        class ↦ "cap/X",
+        bridge-input ↦ "Lcap/X$Pair;",
+        bridge-output ↦ "Lcap/X$Pair;",
+        accepted ↦ "Lcap/X$Pair;",
+        returned ↦ "Lcap/X$Pair;",
+        static ↦ "true",
+        target ↦ ⟦
+          handle ↦ 6,
+          class ↦ "cap/X",
+          method ↦ "lambda$run$0",
+          signature ↦ "(JLcap/X$Pair;)Lcap/X$Pair;",
+          is-interface ↦ Φ.false
+        ⟧
+      ⟧,
+      op2 ↦ ⟦
+        φ ↦ Φ.hone.o-filter,
+        opcode ↦ "invokestatic",
+        class ↦ "cap/X",
+        bridge-input ↦ "Ljava/lang/Object;",
+        bridge-output ↦ "Ljava/lang/Object;",
+        accepted ↦ "Lcap/X$Pair;",
+        returned ↦ "Ljava/lang/Object;",
+        static ↦ "true",
+        target ↦ ⟦
+          handle ↦ 6,
+          class ↦ "cap/X",
+          method ↦ "lambda$run$1",
+          signature ↦ "(Lcap/X$Pair;)Z",
+          is-interface ↦ Φ.false
+        ⟧
+      ⟧,
+      ρ ↦ ∅
+    ⟧
+  ⟧
+expected:
+  - ⟦ 𝐵-head, 𝜏-cmap ↦ ⟦ φ ↦ Φ.hone.c-map, 𝐵-cmap ⟧, 𝜏-dup ↦ ⟦ φ ↦ Φ.hone.dup, opcode ↦ "dup", class ↦ "cap/X" ⟧, 𝜏-filter ↦ ⟦ φ ↦ Φ.hone.o-filter, 𝐵-filter ⟧, 𝐵-tail ⟧

--- a/src/test/resources/org/eolang/hone/optimize/streams/closure-map-filter.yml
+++ b/src/test/resources/org/eolang/hone/optimize/streams/closure-map-filter.yml
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A plain filter behind a CAPTURING map — the shape #821 reports. A filter
+# guard spends the item on its predicate, so it needs a throwaway copy
+# duplicated in front of it. 281 splices that Φ.hone.dup when a map, a filter
+# or a peek leads, and 283 when a stateful guard does, but a capturing map is
+# neither as far as their patterns go: 112 lifts it to a Φ.hone.c-map carrying
+# `state-acc`, `body-acc` and `captures` ahead of `class` and no `opcode` at
+# all, while 281 spells its predecessor out binding for binding. So no dup was
+# spliced, 401 fused the pair into one distill anyway, the predicate ate the
+# only copy of the mapped Pair, and 503 framed the keep label with a
+# `stack [Pair]` the stack no longer had: the class died at load with
+# "java.lang.VerifyError: Inconsistent stackmap frames at branch target".
+# It is the failure family of #790 and #804, one producer further along, and
+# the fix is one more name in 283's alternation — the 𝐵-first-head that #804
+# gave it already absorbs the three accumulator bindings.
+#
+# Three pipelines, one class, all three capturing the method argument `by` in
+# their map so 112 lifts it (a non-capturing map goes to 202 and was never
+# affected):
+#   * kept  — the reported reproduction: keys 0, 1, 2 shift to 1, 2, 3 and
+#     filter(key > 1) keeps two of them.
+#   * shown — the same pair with a forEach behind it, and the pipeline the
+#     verifier rejected first: its distill wrapper reached the `ifne` with
+#     only the predicate's own int on the stack, against a frame promising a
+#     Pair at the keep label. The printed text is also the proof that what
+#     survives the guard is the MAPPED item and not the original: "2:b 3:c",
+#     never "1:b 2:c".
+#   * twice — TWO filters behind the capturing map, so 283 has to leave the
+#     second pair for 281 to dup: filter(key > 1) keeps 2 and 3, filter
+#     (key < 3) keeps 2 -> count 1.
+# Nothing in the nested Pair mentions a stream method, so the default grep-in
+# skips its .xmir and only CMapFilter.phi is rewritten — 2 files walked, 1
+# modified.
+#
+# invokedynamic drops from 8 — three capturing maps, four predicates and the
+# forEach consumer — to 4: one Stream.mapMulti dispatch per pipeline, each
+# holding a map fused with the filters behind it, plus the forEach consumer,
+# which is a capturing Consumer and stays native. The four `ifne` are the four
+# guards, now lowered into the distill bodies where the spliced dup feeds them
+# their copy. What the fix is really about, though, is that the class LOADS at
+# all: the printed line is the end-to-end assertion, and without the dup there
+# is no line to read, only a VerifyError.
+java: |
+  package closure;
+  import java.util.List;
+  public class CMapFilter {
+    private static final List<Pair> PAIRS =
+      List.of(new Pair(0L, "a"), new Pair(1L, "b"), new Pair(2L, "c"));
+    static long kept(final long by) {
+      return PAIRS.stream()
+        .map(p -> new Pair(p.key() + by, p.text()))
+        .filter(p -> p.key() > 1L)
+        .count();
+    }
+    static String shown(final long by) {
+      final StringBuilder out = new StringBuilder();
+      PAIRS.stream()
+        .map(p -> new Pair(p.key() + by, p.text()))
+        .filter(p -> p.key() > 1L)
+        .forEach(p -> out.append(p.key()).append(':').append(p.text()).append(' '));
+      return out.toString().trim();
+    }
+    static long twice(final long by) {
+      return PAIRS.stream()
+        .map(p -> new Pair(p.key() + by, p.text()))
+        .filter(p -> p.key() > 1L)
+        .filter(p -> p.key() < 3L)
+        .count();
+    }
+    public static void main(final String... args) {
+      System.out.printf("The result is %d/%s/%d%n", kept(1L), shown(1L), twice(1L));
+    }
+    static final class Pair {
+      private final long num;
+      private final String word;
+      Pair(final long key, final String text) {
+        this.num = key;
+        this.word = text;
+      }
+      long key() {
+        return this.num;
+      }
+      String text() {
+        return this.word;
+      }
+    }
+  }
+log:
+  - "No grep-in match for 1/2 CMapFilter$Pair.xmir"
+  - "Modified 2/2 CMapFilter.phi"
+  - "Finished rewriting 2 file"
+  - "BUILD SUCCESS"
+  - "The result is 2/2:b 3:c/1"
+before:
+  invokedynamic: 8
+  ifne: 0
+after:
+  invokedynamic: 4
+  ifne: 4


### PR DESCRIPTION
Closes #821.

## What was wrong

A filter guard spends the item on its predicate, so it needs a throwaway copy in front of it. `281` splices that `Φ.hone.dup` when a `map`, an `o-filter`/`p-filter` or a `peek` leads, `283` when a stateful guard does — but a **capturing** map is neither as far as their patterns go. `112` lifts it to a `Φ.hone.c-map` carrying `state-acc`, `body-acc` and `captures` ahead of `class` and no `opcode` at all, while `281` spells its predecessor out binding for binding, so a plain filter behind one reached `4xx` with no guard. `401` fused the pair into a distill anyway, the predicate ate the only copy of the mapped item, and `503` framed the keep label with an element the stack no longer had.

Reproduced exactly as reported, down to the branch target:

```
Caused by: java.lang.VerifyError: Inconsistent stackmap frames at branch target 31
  Location: closure/CMapFilter.distill_5021652(Ljava/util/List;Lclosure/CMapFilter$Pair;Ljava/util/function/Consumer;)V @27: ifne
  Reason:   Current frame's stack size doesn't match stackmap.
  Current Frame:  stack: { integer }
  Stackmap Frame: stack: { 'closure/CMapFilter$Pair' }
```

## The fix

One more name in `283`'s alternation:

```yaml
- eq: [𝜏-one, 'c-map']
```

The issue suggests giving `281` a `𝐵-` wildcard or writing a sibling rule; `283` is already that sibling. The `𝐵-first-head` that #804 gave it to reach a `dropWhile` absorbs the c-map's three accumulator bindings unchanged, and a capturing map is stateful in the sense that matters here — `316` folds it into a stateful distill. Its `dup` opcode comes off the filter's `bridge-input`, which is what a c-map wants too: `112` only lifts a `Stream.map` whose element stays a reference, so the follower is always a one-slot `o-filter`, never a `dup2`. The header paragraph records that, and why a c-map cannot reach `281` or `282` (`241`-`243` pin `Φ.hone.map` literally, so no `type`/`transform` is ever spliced behind a capturing map).

No double dup: after insertion the two are no longer adjacent, and the fused run's `start` becomes `dup`, so `413` still declines it.

## Tests

* `src/test/phino/283-insert-dup-before-filter-after-capturing-map.yml` — a drained c-map (empty `captures`, both accumulators holding the peeled unit) ahead of an `o-filter`; asserts the spliced `Φ.hone.dup` with `opcode ↦ "dup"`. Before the fix the same input comes out with no dup at all.
* `src/test/resources/org/eolang/hone/optimize/streams/closure-map-filter.yml` — the reported shape end to end: a `long` captured in the map, a small value class as the element, three pipelines (the plain pair, the same pair behind a `forEach`, and a two-filter variant so `283` has to leave the second pair for `281`). `invokedynamic` 8 → 4, four `ifne` guards, and the printed line proves the mapped item — not the original — is what survives the guard.

## Verification

* `mvn -Pdeep test`: **153 run, 0 failures, 17 skipped** (the skipped ones are Docker-gated). All 83 single-rule packs pass against phino 0.0.106 on the host.
* All **55** `optimize/**.yml` fixtures compiled into one project and optimized in a single build: every class prints byte-identical output before and after optimization. With the c-map clause removed the run is identical except for the new fixture, which fails with the `VerifyError` above — so the change is inert on every shape the suite already covered.
* **360 random pipelines** (`RandomPipeline`, seeds 0-359), same before/after oracle: 359 identical.

Two notes on the reproduction, since the issue attributes it to the random walk:

* `RandomPipeline`'s grammar has no capturing lambdas — every lambda in it reads statics or its own parameter, so no factory descriptor carries a capture. `0` of the 720 rewritten `.phi` files in the 360-seed run contain a `c-map`, and seed 224 on `f0d4e47` walks to `INTEGERS.stream().map(Integer::doubleValue).peek(…).dropWhile(…).peek(…).peek(…).map(…).map(…).collect(teeing(…))`, which has no filter in it and passes. The new fixture is therefore hand-written to the shape the issue describes rather than lifted from a seed.
* One seed does still fail, `P0235` — `Stream.of(1.5, 2.25, 1.5, 8.125).distinct().mapToInt(Double::intValue).filter(n -> n > 2).asDoubleStream().average()`. It is **not** this defect and **not** a regression: rewriting its `.phi` with and without the c-map clause gives byte-identical output, its guard *is* dupped (the pragma run after `2xx` is `distinct, map, dup, p-filter, unbox`), and the keep frame disagrees with the stack about the element's *type* rather than its presence (`stack: { integer }` against `Object`). That looks like the boxed-primitive relay family of #811, and probably wants an issue of its own.


---
_Generated by [Claude Code](https://claude.ai/code/session_012zpUE19ynLwsbMxw5ijyq8)_