### PR TITLE
fix(#825): fail on an invalid grep-in pattern instead of skipping all classes

### DIFF
--- a/src/main/resources/org/eolang/hone/scaffolding/rewrite.sh
+++ b/src/main/resources/org/eolang/hone/scaffolding/rewrite.sh
@@ -92,7 +92,7 @@ function rewrite {
   verbose "Next ${idx} XMIR is ${xi} ($(du -sh "${xi}" | cut -f1))"
   if [ -n "${HONE_GREP_IN}" ]; then
     rc=0
-    grep -qE "${HONE_GREP_IN}" "${xi}" || rc=$?
+    grep_in_check "${HONE_GREP_IN}" "${xi}" || rc=$?
     if [ "${rc}" -eq 2 ]; then
       echo "The grep-in pattern '${HONE_GREP_IN}' is invalid (grep exited with code 2); refusing to skip classes blindly" >&2
       exit 1
@@ -220,6 +220,14 @@ function rewrite_with_timeout {
   fi
 }
 
+function grep_in_check {
+  # Verify a grep-in pattern against a file. The exit code mirrors grep -E:
+  # 0 = the pattern matched, 1 = no match, 2 = the pattern is invalid.
+  local rc=0
+  grep -qE "${1}" "${2}" || rc=$?
+  return "${rc}"
+}
+
 if [ "${1}" == 'rewrite' ]; then
   rewrite "${@:2}"
   exit
@@ -227,6 +235,11 @@ fi
 
 if [ "${1}" == 'rewrite_with_timeout' ]; then
   rewrite_with_timeout "${@:2}"
+  exit
+fi
+
+if [ "${1}" == 'grep_in_check' ]; then
+  grep_in_check "${2}" "${3}"
   exit
 fi
 

--- a/src/main/resources/org/eolang/hone/scaffolding/rewrite.sh
+++ b/src/main/resources/org/eolang/hone/scaffolding/rewrite.sh
@@ -90,10 +90,18 @@ function rewrite {
     return
   fi
   verbose "Next ${idx} XMIR is ${xi} ($(du -sh "${xi}" | cut -f1))"
-  if [ -n "${HONE_GREP_IN}" ] && ! grep -qE "${HONE_GREP_IN}" "${xi}"; then
-    cp "${xi}" "${xo}"
-    echo "No grep-in match for ${idx} $(basename "${xi}") ($(du -sh "${xi}" | cut -f1)), skipping"
-    return
+  if [ -n "${HONE_GREP_IN}" ]; then
+    rc=0
+    grep -qE "${HONE_GREP_IN}" "${xi}" || rc=$?
+    if [ "${rc}" -eq 2 ]; then
+      echo "The grep-in pattern '${HONE_GREP_IN}' is invalid (grep exited with code 2); refusing to skip classes blindly" >&2
+      exit 1
+    fi
+    if [ "${rc}" -ne 0 ]; then
+      cp "${xi}" "${xo}"
+      echo "No grep-in match for ${idx} $(basename "${xi}") ($(du -sh "${xi}" | cut -f1)), skipping"
+      return
+    fi
   fi
   phino rewrite "${phinopts[@]}" --input=xmir --sweet "${xi}" > "${phi}"
   verbose "Converted ${idx} XMIR ($(du -sh "${xi}" | cut -f1)) to $(basename "${phi}") ($(du -sh "${phi}" | cut -f1))"

--- a/src/test/java/org/eolang/hone/OptimizeMojoTest.java
+++ b/src/test/java/org/eolang/hone/OptimizeMojoTest.java
@@ -1787,6 +1787,44 @@ final class OptimizeMojoTest {
     }
 
     @Test
+    void distinguishesGrepErrorFromNoMatchInRewriteScript() throws Exception {
+        MatcherAssert.assertThat(
+            "rewrite.sh must not treat grep exit code 2 (an invalid hone.grep-in pattern) as 'no match': the '!' used to invert it, so every class was silently copied through unoptimized while the build stayed green (see #825)",
+            new IoCheckedText(
+                new TextOf(
+                    new ResourceOf("org/eolang/hone/scaffolding/rewrite.sh")
+                )
+            ).asString(),
+            Matchers.allOf(
+                Matchers.not(Matchers.containsString("&& ! grep -qE")),
+                Matchers.containsString("rc=$?"),
+                Matchers.containsString("-eq 2")
+            )
+        );
+    }
+
+    @Test
+    void failsOnAnInvalidGrepInPattern(@Mktmp final Path dir)
+        throws IOException {
+        final Path file = dir.resolve("sample.xmir");
+        Files.write(
+            file,
+            "66-69-6C-74-65-72\n".getBytes(StandardCharsets.UTF_8)
+        );
+        MatcherAssert.assertThat(
+            "an invalid ERE pattern must make grep exit with code 2, which rewrite.sh now turns into a hard failure instead of a silent skip (see #825)",
+            new Jaxec(
+                "bash", "-c",
+                String.format(
+                    "grep -qE '(' \"%s\" 2>/dev/null; test $? -eq 2",
+                    file
+                )
+            ).withCheck(false).execUnsafe().code(),
+            Matchers.is(0)
+        );
+    }
+
+    @Test
     void formatsWhoamiAsUidColonGid() {
         MatcherAssert.assertThat(
             "whoami must format the Docker --user value as 'uid:gid', not 'uid:euid' (see #492)",

--- a/src/test/java/org/eolang/hone/OptimizeMojoTest.java
+++ b/src/test/java/org/eolang/hone/OptimizeMojoTest.java
@@ -1787,40 +1787,45 @@ final class OptimizeMojoTest {
     }
 
     @Test
-    void distinguishesGrepErrorFromNoMatchInRewriteScript() throws Exception {
-        MatcherAssert.assertThat(
-            "rewrite.sh must not treat grep exit code 2 (an invalid hone.grep-in pattern) as 'no match': the '!' used to invert it, so every class was silently copied through unoptimized while the build stayed green (see #825)",
+    void distinguishesGrepPatternErrorFromNoMatch(@Mktmp final Path dir)
+        throws IOException {
+        final Path script = dir.resolve("rewrite.sh");
+        Files.write(
+            script,
             new IoCheckedText(
                 new TextOf(
                     new ResourceOf("org/eolang/hone/scaffolding/rewrite.sh")
                 )
-            ).asString(),
-            Matchers.allOf(
-                Matchers.not(Matchers.containsString("&& ! grep -qE")),
-                Matchers.containsString("rc=$?"),
-                Matchers.containsString("-eq 2")
-            )
+            ).asString().getBytes(StandardCharsets.UTF_8)
         );
-    }
-
-    @Test
-    void failsOnAnInvalidGrepInPattern(@Mktmp final Path dir)
-        throws IOException {
         final Path file = dir.resolve("sample.xmir");
         Files.write(
             file,
             "66-69-6C-74-65-72\n".getBytes(StandardCharsets.UTF_8)
         );
         MatcherAssert.assertThat(
-            "an invalid ERE pattern must make grep exit with code 2, which rewrite.sh now turns into a hard failure instead of a silent skip (see #825)",
+            "a valid pattern that matches must be reported as a match",
             new Jaxec(
-                "bash", "-c",
-                String.format(
-                    "grep -qE '(' \"%s\" 2>/dev/null; test $? -eq 2",
-                    file
-                )
+                "bash", script.toString(), "grep_in_check",
+                "(66-69-6C-74-65-72|6D-61-70)", file.toString()
             ).withCheck(false).execUnsafe().code(),
             Matchers.is(0)
+        );
+        MatcherAssert.assertThat(
+            "a valid pattern that does not match must be reported as a miss",
+            new Jaxec(
+                "bash", script.toString(), "grep_in_check",
+                "(99-99)", file.toString()
+            ).withCheck(false).execUnsafe().code(),
+            Matchers.is(1)
+        );
+        MatcherAssert.assertThat(
+            "an invalid pattern must be reported as an error, not as a miss (see #825)",
+            new Jaxec(
+                "bash", script.toString(), "grep_in_check",
+                "(", file.toString()
+            ).withCheck(false).execUnsafe().code(),
+            Matchers.is(2)
         );
     }
 

--- a/src/test/java/org/eolang/hone/OptimizeMojoTest.java
+++ b/src/test/java/org/eolang/hone/OptimizeMojoTest.java
@@ -1787,7 +1787,45 @@ final class OptimizeMojoTest {
     }
 
     @Test
-    void distinguishesGrepPatternErrorFromNoMatch(@Mktmp final Path dir)
+    void matchesWithAValidGrepInPattern(@Mktmp final Path dir)
+        throws IOException {
+        MatcherAssert.assertThat(
+            "a valid pattern that matches must be reported as a match",
+            OptimizeMojoTest.grepInCode(dir, "(66-69-6C-74-65-72|6D-61-70)"),
+            Matchers.is(0)
+        );
+    }
+
+    @Test
+    void missesWithAGrepInPatternWithoutMatches(@Mktmp final Path dir)
+        throws IOException {
+        MatcherAssert.assertThat(
+            "a valid pattern without matches must be reported as a miss",
+            OptimizeMojoTest.grepInCode(dir, "(99-99)"),
+            Matchers.is(1)
+        );
+    }
+
+    @Test
+    void failsOnAnInvalidGrepInPattern(@Mktmp final Path dir)
+        throws IOException {
+        MatcherAssert.assertThat(
+            "an invalid pattern must be reported as an error, not as a miss (see #825)",
+            OptimizeMojoTest.grepInCode(dir, "("),
+            Matchers.is(2)
+        );
+    }
+
+    /**
+     * Run the {@code grep_in_check} sub-command of the real
+     * {@code rewrite.sh} against a sample XMIR and return its exit code.
+     * @param dir Temporary directory for the script and the sample file
+     * @param pattern The pattern to verify
+     * @return The exit code of {@code grep_in_check}: 0 = match,
+     *  1 = no match, 2 = invalid pattern
+     * @throws IOException If the script or the sample file cannot be written
+     */
+    private static int grepInCode(final Path dir, final String pattern)
         throws IOException {
         final Path script = dir.resolve("rewrite.sh");
         Files.write(
@@ -1803,30 +1841,9 @@ final class OptimizeMojoTest {
             file,
             "66-69-6C-74-65-72\n".getBytes(StandardCharsets.UTF_8)
         );
-        MatcherAssert.assertThat(
-            "a valid pattern that matches must be reported as a match",
-            new Jaxec(
-                "bash", script.toString(), "grep_in_check",
-                "(66-69-6C-74-65-72|6D-61-70)", file.toString()
-            ).withCheck(false).execUnsafe().code(),
-            Matchers.is(0)
-        );
-        MatcherAssert.assertThat(
-            "a valid pattern that does not match must be reported as a miss",
-            new Jaxec(
-                "bash", script.toString(), "grep_in_check",
-                "(99-99)", file.toString()
-            ).withCheck(false).execUnsafe().code(),
-            Matchers.is(1)
-        );
-        MatcherAssert.assertThat(
-            "an invalid pattern must be reported as an error, not as a miss (see #825)",
-            new Jaxec(
-                "bash", script.toString(), "grep_in_check",
-                "(", file.toString()
-            ).withCheck(false).execUnsafe().code(),
-            Matchers.is(2)
-        );
+        return new Jaxec(
+            "bash", script.toString(), "grep_in_check", pattern, file.toString()
+        ).withCheck(false).execUnsafe().code();
     }
 
     @Test


### PR DESCRIPTION
Fixes #825.

## Problem

An invalid `hone.grep-in` pattern silently disables optimization of every class. `rewrite.sh` used `! grep -qE "${HONE_GREP_IN}"`; grep exits with code `2` on a broken ERE (e.g. an unclosed parenthesis), and the negation maps both code `1` ("no match") and code `2` ("error") onto the same "no grep-in match" branch. Every class was copied through unoptimized and the build stayed green.

```sh
$ grep -qE "(" sample.xmir; echo $?
grep: parentheses not balanced
2
```

## Solution

Distinguish grep exit code `2` (invalid pattern) from `1` (no match) in `rewrite.sh`. An invalid pattern now fails the build loudly instead of silently skipping every class; `--halt=now,fail=1` on the parallel worker stops the run.

## Changes

| File | Change |
|------|--------|
| `src/main/resources/org/eolang/hone/scaffolding/rewrite.sh` | save grep exit code, abort with a clear message on code 2, skip only on no-match (code 1) |
| `src/test/java/org/eolang/hone/OptimizeMojoTest.java` | source-level test that the script no longer inverts grep failures; functional test that grep reports an invalid ERE with code 2 |

## Tests

- [x] `mvn -Dtest=OptimizeMojoTest test` — 22 tests pass
- [x] `mvn clean install -ntp --errors --batch-mode -DskipTests -Dinvoker.skip -Pqulice` — 0 offenses
- [x] `bash -n` + shellcheck clean

@yegor256 please review