### PR TITLE
fix(#449): add dropWhile to the default grep-in pre-filter

### DIFF
--- a/src/main/java/org/eolang/hone/OptimizeMojo.java
+++ b/src/main/java/org/eolang/hone/OptimizeMojo.java
@@ -97,6 +97,7 @@ public final class OptimizeMojo extends AbstractMojo {
         "peek",
         "distinct",
         "skip",
+        "dropWhile",
         "flatMap",
         "flatMapToInt",
         "flatMapToLong",

--- a/src/test/java/org/eolang/hone/OptimizeMojoTest.java
+++ b/src/test/java/org/eolang/hone/OptimizeMojoTest.java
@@ -1681,6 +1681,18 @@ final class OptimizeMojoTest {
     }
 
     @Test
+    void matchesStandaloneDropWhileByteSequenceInDefaultGrepIn(@Mktmp final Path dir)
+        throws IOException {
+        MatcherAssert.assertThat(
+            "default grep-in must match a standalone 'dropWhile' byte sequence, since the method is fused by the pipeline but absent from the default pre-filter (see #449)",
+            OptimizeMojoTest.grepInMatches(
+                dir, "<o as=\"data\">64-72-6F-70-57-68-69-6C-65</o>"
+            ),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
     void matchesStandaloneFlatMapByteSequenceInDefaultGrepIn(@Mktmp final Path dir)
         throws IOException {
         MatcherAssert.assertThat(


### PR DESCRIPTION
Fixes #449.

## Problem

`dropWhile` is fused by the pipeline (see `2xx/208-lambda-to-dropwhile.phr`, `3xx/310-dropwhile-to-distill.phr` and the `dropwhile.yml` fixtures), but it is missing from `DEFAULT_GREP_IN`. A class whose only stream operation is `.dropWhile(...)` is filtered out by the default pre-filter and silently left unoptimized. Commit `d363de8` (#705) claimed "all fusable Stream methods" but `dropWhile` was not added.

## Solution

Add `"dropWhile"` to the `Greppable` list in `OptimizeMojo.DEFAULT_GREP_IN`, so a `dropWhile` byte sequence matches and the class goes through the optimizer.

## Changes

| File | Change |
|------|--------|
| `src/main/java/org/eolang/hone/OptimizeMojo.java` | add `"dropWhile"` to `DEFAULT_GREP_IN` |
| `src/test/java/org/eolang/hone/OptimizeMojoTest.java` | test that the default grep-in matches the standalone `dropWhile` byte sequence (`64-72-6F-70-57-68-69-6C-65`) |

## Tests

- [x] `mvn -Dtest=OptimizeMojoTest test` — 29 tests pass
- [x] `mvn clean install -ntp --errors --batch-mode -DskipTests -Dinvoker.skip -Pqulice` — 0 offenses

@yegor256 please review