### PR TITLE
#512: add resource management tests for CSV parsing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -407,8 +407,10 @@
             <version>0.30.13</version>
             <configuration>
               <excludes>
-                <!-- Synthetic sample code used as input data for the
-                     "streams" bytecode-rewrite rule test, not real code -->
+                <!--
+                Synthetic sample code used as input data for the
+                "streams" bytecode-rewrite rule test, not real code
+                -->
                 <exclude>checkstyle:.*/src/test/resources/org/eolang/hone/rules/streams/.*</exclude>
                 <exclude>pmd:.*/src/test/resources/org/eolang/hone/rules/streams/.*</exclude>
                 <exclude>errorprone:.*/src/test/resources/org/eolang/hone/rules/streams/.*</exclude>

--- a/src/test/java/org/eolang/hone/CSVTest.java
+++ b/src/test/java/org/eolang/hone/CSVTest.java
@@ -123,8 +123,9 @@ final class CSVTest {
 
     @Test
     void parsesLargeCsvWithoutResourceLeak(@Mktmp final Path temp) throws Exception {
-        final StringBuilder content = new StringBuilder();
-        content.append("ID,Before,After,Changed,LinesPerSec\n");
+        final StringBuilder content = new StringBuilder(8192);
+        content.append("ID,Before,After,Changed,LinesPerSec")
+            .append(System.lineSeparator());
         for (int idx = 0; idx < 200; idx += 1) {
             content.append(
                 String.format(

--- a/src/test/java/org/eolang/hone/CSVTest.java
+++ b/src/test/java/org/eolang/hone/CSVTest.java
@@ -120,4 +120,76 @@ final class CSVTest {
             Matchers.is(0)
         );
     }
+
+    @Test
+    void parsesLargeCsvWithoutResourceLeak(@Mktmp final Path temp) throws Exception {
+        final StringBuilder content = new StringBuilder();
+        content.append("ID,Before,After,Changed,LinesPerSec\n");
+        for (int idx = 0; idx < 200; idx += 1) {
+            content.append(
+                String.format(
+                    "%d/200,src%d.phi,dst%d.phi,%d,%d%n",
+                    idx, idx, idx, idx % 3, idx * 10
+                )
+            );
+        }
+        final Path path = temp.resolve("large.csv");
+        Files.write(path, content.toString().getBytes(StandardCharsets.UTF_8));
+        MatcherAssert.assertThat(
+            "large CSV must parse all 200 rows without resource leak",
+            new CSV(path).size(),
+            Matchers.is(200)
+        );
+    }
+
+    @Test
+    void flushesAndRereadsRoundTrip(@Mktmp final Path temp) throws Exception {
+        final Path source = temp.resolve("input.csv");
+        Files.write(
+            source,
+            String.join(
+                System.lineSeparator(),
+                "ID,Before,After,Changed,LinesPerSec",
+                "1/2,a.phi,b.phi,5,1000",
+                "2/2,c.phi,d.phi,3,800",
+                ""
+            ).getBytes(StandardCharsets.UTF_8)
+        );
+        final Path flushed = temp.resolve("output.csv");
+        new CSV(source).flush(flushed);
+        MatcherAssert.assertThat(
+            "round-trip through flush must preserve row count",
+            new CSV(flushed).size(),
+            Matchers.is(2)
+        );
+    }
+
+    @Test
+    void combinesTwoCsvFiles(@Mktmp final Path temp) throws Exception {
+        final Path first = temp.resolve("first.csv");
+        Files.write(
+            first,
+            String.join(
+                System.lineSeparator(),
+                "ID,Before,After,Changed,LinesPerSec",
+                "1/1,a.phi,b.phi,5,1000",
+                ""
+            ).getBytes(StandardCharsets.UTF_8)
+        );
+        final Path second = temp.resolve("second.csv");
+        Files.write(
+            second,
+            String.join(
+                System.lineSeparator(),
+                "ID,Before,After,Changed,LinesPerSec",
+                "1/1,c.phi,d.phi,3,800",
+                ""
+            ).getBytes(StandardCharsets.UTF_8)
+        );
+        MatcherAssert.assertThat(
+            "combined CSV must contain rows from both files",
+            new CSV(first).add(new CSV(second)).size(),
+            Matchers.is(2)
+        );
+    }
 }


### PR DESCRIPTION
The try-with-resources fix for `CSV.from()` is already in place. This adds test coverage for the resource management paths:

- `parsesLargeCsvWithoutResourceLeak`: parses 200 rows, exercises InputStreamReader/CSVParser cleanup
- `flushesAndRereadsRoundTrip`: writes via `flush()` then re-reads, exercising both try-with-resources blocks
- `combinesTwoCsvFiles`: exercises `add()` with two parsed files

Fixes #512