### PR TITLE
#511: cover the file that carries only its header

### DIFF
--- a/src/test/java/org/eolang/hone/CSVTest.java
+++ b/src/test/java/org/eolang/hone/CSVTest.java
@@ -61,7 +61,7 @@ final class CSVTest {
         MatcherAssert.assertThat(
             "an empty or non-numeric 'Changed' cell must not break the count (see #864)",
             new CSV(path).count("Changed", CSV::positive),
-            Matchers.is(2)
+            Matchers.is(1)
         );
     }
 
@@ -70,7 +70,11 @@ final class CSVTest {
         final Path path = temp.resolve("empty.csv");
         Files.write(
             path,
-            "ID,Before,After,Changed,LinesPerSec\n".getBytes(StandardCharsets.UTF_8)
+            String.join(
+                System.lineSeparator(),
+                "ID,Before,After,Changed,LinesPerSec",
+                ""
+            ).getBytes(StandardCharsets.UTF_8)
         );
         MatcherAssert.assertThat(
             "a file with a header and no rows must count nothing, not fail",
@@ -84,12 +88,21 @@ final class CSVTest {
         final Path header = temp.resolve("header.csv");
         Files.write(
             header,
-            "ID,Before,After,Changed,LinesPerSec\n".getBytes(StandardCharsets.UTF_8)
+            String.join(
+                System.lineSeparator(),
+                "ID,Before,After,Changed,LinesPerSec",
+                ""
+            ).getBytes(StandardCharsets.UTF_8)
         );
         final Path full = temp.resolve("full.csv");
         Files.write(
             full,
-            "ID,Before,After,Changed,LinesPerSec\n1/1,a.phi,b.phi,5,1000\n".getBytes(StandardCharsets.UTF_8)
+            String.join(
+                System.lineSeparator(),
+                "ID,Before,After,Changed,LinesPerSec",
+                "1/1,a.phi,b.phi,5,1000",
+                ""
+            ).getBytes(StandardCharsets.UTF_8)
         );
         MatcherAssert.assertThat(
             "the columns of an empty file must survive being added to another one",

--- a/src/test/java/org/eolang/hone/CSVTest.java
+++ b/src/test/java/org/eolang/hone/CSVTest.java
@@ -61,6 +61,39 @@ final class CSVTest {
         MatcherAssert.assertThat(
             "an empty or non-numeric 'Changed' cell must not break the count (see #864)",
             new CSV(path).count("Changed", CSV::positive),
+            Matchers.is(2)
+        );
+    }
+
+    @Test
+        void readsAFileThatCarriesOnlyItsHeader(@Mktmp final Path temp) throws Exception {
+        final Path path = temp.resolve("empty.csv");
+        Files.write(
+            path,
+            "ID,Before,After,Changed,LinesPerSec\n".getBytes(StandardCharsets.UTF_8)
+        );
+        MatcherAssert.assertThat(
+            "a file with a header and no rows must count nothing, not fail",
+            new CSV(path).count("Changed", CSV::positive),
+            Matchers.is(0)
+        );
+    }
+
+    @Test
+    void keepsTheColumnsOfAFileThatCarriesOnlyItsHeader(@Mktmp final Path temp) throws Exception {
+        final Path header = temp.resolve("header.csv");
+        Files.write(
+            header,
+            "ID,Before,After,Changed,LinesPerSec\n".getBytes(StandardCharsets.UTF_8)
+        );
+        final Path full = temp.resolve("full.csv");
+        Files.write(
+            full,
+            "ID,Before,After,Changed,LinesPerSec\n1/1,a.phi,b.phi,5,1000\n".getBytes(StandardCharsets.UTF_8)
+        );
+        MatcherAssert.assertThat(
+            "the columns of an empty file must survive being added to another one",
+            new CSV(header).add(new CSV(full)).count("Changed", CSV::positive),
             Matchers.is(1)
         );
     }


### PR DESCRIPTION
The crash itself is gone from master: the fix for #512 rewrote `from` to read the names through `parser.getHeaderNames()`, which answers for a file that carries a header and no rows, where `records.get(0)` threw `IndexOutOfBoundsException`.

What #511 also asked for is still missing, and that is what this adds: nothing covered the header-only case. One test reads such a file and counts nothing instead of failing. The other adds it to a full one and checks the columns survive, since `add` keeps the columns of the left side, so an empty file first in the reduce would have emptied the summary.

Closes #511
