### PR TITLE
#850: write the pom comment the way xcop asks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -407,8 +407,10 @@
             <version>0.30.13</version>
             <configuration>
               <excludes>
-                <!-- Synthetic sample code used as input data for the
-                     "streams" bytecode-rewrite rule test, not real code -->
+                <!--
+                Synthetic sample code used as input data for the
+                "streams" bytecode-rewrite rule test, not real code
+                -->
                 <exclude>checkstyle:.*/src/test/resources/org/eolang/hone/rules/streams/.*</exclude>
                 <exclude>pmd:.*/src/test/resources/org/eolang/hone/rules/streams/.*</exclude>
                 <exclude>errorprone:.*/src/test/resources/org/eolang/hone/rules/streams/.*</exclude>


### PR DESCRIPTION
The multi-line comment added in ed5c9ee0 kept its text on the `<!--` line,
which xcop refuses, so the job has been red on every commit since. It now opens
and closes on lines of its own.

`xcop` reports nothing over every XML file in the repository.

Closes #850
