### PR TITLE
#840: refuse a rules pattern that matches nothing

### DIFF
--- a/src/main/java/org/eolang/hone/Rules.java
+++ b/src/main/java/org/eolang/hone/Rules.java
@@ -51,6 +51,11 @@ final class Rules {
     private final Map<Pattern, Boolean> patterns;
 
     /**
+     * The patterns as the user wrote them, for the message of an empty match.
+     */
+    private final String text;
+
+    /**
      * Creates a rule manager that includes all rules.
      */
     Rules() {
@@ -64,6 +69,7 @@ final class Rules {
      */
     Rules(final String ptns) {
         this.patterns = Rules.regexs(ptns);
+        this.text = ptns;
     }
 
     @Override
@@ -96,6 +102,14 @@ final class Rules {
             files.add(name);
         }
         Logger.info(this, "Found %d rule(s) by: %s", files.size(), this.patterns);
+        if (files.isEmpty()) {
+            throw new IllegalStateException(
+                String.format(
+                    "No rules matched the hone.rules pattern '%s', while the ones available are: %s",
+                    this.text, Rules.discover()
+                )
+            );
+        }
         return files;
     }
 

--- a/src/main/java/org/eolang/hone/Rules.java
+++ b/src/main/java/org/eolang/hone/Rules.java
@@ -106,7 +106,7 @@ final class Rules {
             throw new IllegalStateException(
                 String.format(
                     "No rules matched the hone.rules pattern '%s', while the ones available are: %s",
-                    this.text, Rules.discover()
+                    this.text, String.join(", ", Rules.discover())
                 )
             );
         }

--- a/src/test/java/org/eolang/hone/RulesTest.java
+++ b/src/test/java/org/eolang/hone/RulesTest.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -69,11 +70,23 @@ final class RulesTest {
     }
 
     @Test
-    void discoversNothingWithSuffix() {
+    void refusesAPatternThatMatchesNothing() {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new Rules("none.yml").yamls(),
+            "A pattern that matches no rule must be refused, not answered with nothing"
+        );
+    }
+
+    @Test
+    void namesThePatternThatMatchedNothing() {
         MatcherAssert.assertThat(
-            "Should NOT discover none.yml from classpath",
-            new Rules("none.yml").yamls(),
-            Matchers.emptyIterable()
+            "The message must quote the pattern the user wrote",
+            Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> new Rules("strrams/*").yamls()
+            ).getMessage(),
+            Matchers.containsString("strrams/*")
         );
     }
 


### PR DESCRIPTION
A pattern that matched no rule left `rulesAsString()` empty, `entry.sh` read
that as "nothing was configured" and put every built-in rule back, including
`33-to-42.yml`, whose own javadoc says the code will be corrupted. A typo in
`hone.rules` therefore turned into a green build with the demo rule applied.

`Rules.yamls()` refuses an empty match now, quoting the pattern and listing
what is available, so the empty value never reaches the script.

`discoversNothingWithSuffix` asserted the old answer, so it now asserts the
refusal under a name that says so, and a second test checks that the message
quotes the pattern.

Closes #840
