### PR TITLE
#836: do nothing when there is no XMIR to rewrite

### DIFF
--- a/src/main/resources/org/eolang/hone/scaffolding/rewrite.sh
+++ b/src/main/resources/org/eolang/hone/scaffolding/rewrite.sh
@@ -291,6 +291,10 @@ if [ -n "${HONE_GREP_IN}" ]; then
 fi
 
 files=$(find "$("${RP}" "${HONE_XMIR_IN}")" -name '*.xmir' -type f -exec "${RP}" --relative-to="${HONE_XMIR_IN}" {} \; | LC_ALL=C sort)
+if [ -z "${files}" ]; then
+  echo "No XMIR files to process"
+  exit 0
+fi
 total=$(echo "${files}" | wc -l | xargs)
 tasks=${TARGET}/hone-tasks.txt
 mkdir -p "$(dirname "${tasks}")"


### PR DESCRIPTION
`echo ""` still prints a newline, so `wc -l` counted one file where there were none, and a here-string built from an empty variable still feeds the loop one empty line. The task list then got an entry for `${HONE_XMIR_IN}/.xmir`, phino failed on the missing file, and `--halt-on-error` took the whole pipeline down.

The script now says so and stops before any of that, which is what the goal should do when `hone.includes` selects nothing or the project is empty.

Closes #836
