### PR TITLE
fix(#834): run the real rule pipeline in the make CI workflow

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -24,4 +24,4 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install libxml2-utils
           ./.github/install-phino.sh
-      - run: make -C src/test/resources/org/eolang/hone/rules/streams env test
+      - run: make -C src/test/resources/org/eolang/hone/rules/streams all

--- a/src/test/resources/org/eolang/hone/rules/streams/Makefile
+++ b/src/test/resources/org/eolang/hone/rules/streams/Makefile
@@ -5,7 +5,7 @@
 .SHELLFLAGS := -e -o pipefail -c
 SHELL := bash
 .SECONDARY:
-.PHONY: all clean test env diff jeo-test run
+.PHONY: all clean env diff jeo-test run
 
 ROOT=../../../../../../../..
 RULES_DIR=$(ROOT)/src/main/resources/org/eolang/hone/rules/streams
@@ -17,7 +17,7 @@ RULE_NAMES=$(subst .phr,,$(RULES))
 
 JEO_VERSION=$(shell cat "$(ROOT)/src/main/resources/org/eolang/hone/default-jeo-version.txt" | xargs)
 
-all: env test jeo-test run
+all: env jeo-test run
 
 env:
 	phino --version


### PR DESCRIPTION
Fixes #834.

## Problem

`make.yml:30` invoked `make ... env test`, but `test` was a phony target with **no recipe and no prerequisites** (`Makefile:8`), so GNU make printed `Nothing to be done` and exited 0. The only CI workflow that pins the exact phino version did nothing but `phino --version` (the `env` target). The real rule pipeline — javac, jeo disassemble/assemble, applying every `.phr` rule, and diffing before/after output — never ran.

## Solution

Remove the phantom `test` target and run the meaningful chain instead:

- `Makefile`: drop `test` from `.PHONY` and from `all`; `all` now chains `env jeo-test run`.
- `make.yml`: call `make ... all` instead of `make ... env test`.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/make.yml` | `make ... env test` → `make ... all` |
| `src/test/resources/org/eolang/hone/rules/streams/Makefile` | remove the recipe-less `test` from `.PHONY` and `all` |

## Tests

- `make -C ... test` now fails with `No rule to make target test` (was: silent success)
- `make -C ... -n all` plans the full pipeline: `phino --version`, `javac`, jeo `disassemble`/`assemble`, `phino rewrite` for every rule, `diff` of before/after output, `javap`