### PR TITLE
fix(#835): install the pinned phino in the deep workflow

### DIFF
--- a/.github/workflows/deep.yml
+++ b/.github/workflows/deep.yml
@@ -64,6 +64,18 @@ jobs:
           rm /tmp/maven.tgz
           echo "${HOME}/maven/bin" >> "${GITHUB_PATH}"
           "${HOME}/maven/bin/mvn" --version
+      # The @DisabledWithoutPhino tests (82 phino rule packs and friends)
+      # require phino of exactly the pinned version; without it they are
+      # silently skipped and never run anywhere in CI (see #835). The EC2
+      # AMI is not guaranteed to carry it, so install it here explicitly.
+      - name: install-phino
+        run: |
+          version=$(xargs < src/main/resources/org/eolang/hone/default-phino-version.txt)
+          if ! phino --pin="${version}" --version > /dev/null 2>&1; then
+            sudo wget -q -O /usr/bin/phino "http://phino.objectionary.com/releases/ubuntu-24.04/phino-${version}"
+            sudo chmod +x /usr/bin/phino
+          fi
+          phino --pin="${version}" --version
       - uses: actions/cache@v6
         with:
           path: ~/.m2/repository


### PR DESCRIPTION
Fixes #835.

## Problem

The 82 phino rule packs in `src/test/phino/*.yml` are guarded by `@DisabledWithoutPhino`, which enables them only when phino of **exactly the pinned version** (`default-phino-version.txt`) is on the PATH. `deep.yml` — the only workflow that runs `-Pdeep` — never installs phino, so the packs run only if the undocumented EC2 AMI happens to carry the right binary. Meanwhile `mvn.yml` downloads `phino-latest` and does not run `-Pdeep` at all. Net result: the packs are never executed anywhere in CI.

## Solution

Add an `install-phino` step to `deep.yml`, right after the Maven install, mirroring the pinned-download pattern already used in `make.yml`:

```sh
version=$(xargs < src/main/resources/org/eolang/hone/default-phino-version.txt)
if ! phino --pin="${version}" --version > /dev/null 2>&1; then
  sudo wget -q -O /usr/bin/phino "http://phino.objectionary.com/releases/ubuntu-24.04/phino-${version}"
  sudo chmod +x /usr/bin/phino
fi
phino --pin="${version}" --version
```

The `if !` guard makes the step idempotent on AMIs that already carry phino.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/deep.yml` | add `install-phino` step before the `-Pdeep` run |

## Tests

- `deep.yml` is only triggered on push to `master`, not on PRs, so the real verification (the packs actually executing on the EC2 runner) happens after merge. The workflow file itself is validated by `actionlint`/`yamllint` in this PR