### PR TITLE
fix(#839): bound the Docker and phino process waits with timeouts

### DIFF
--- a/src/main/java/org/eolang/hone/Docker.java
+++ b/src/main/java/org/eolang/hone/Docker.java
@@ -5,13 +5,15 @@
 package org.eolang.hone;
 
 import com.jcabi.log.Logger;
-import com.jcabi.log.VerboseProcess;
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.logging.Level;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Docker command executor with optional sudo support.
@@ -23,6 +25,13 @@ import java.util.logging.Level;
  * @since 0.1.0
  */
 final class Docker {
+
+    /**
+     * Hard deadline for any single docker command, in seconds. A hung daemon
+     * or a stalled pull must fail the build with a clear message instead of
+     * hanging forever (see #839).
+     */
+    private static final long TIMEOUT = 3600L;
 
     /**
      * Whether to prepend "sudo" to Docker commands.
@@ -94,27 +103,48 @@ final class Docker {
     private int fire(final List<String> command) throws IOException {
         final long start = System.currentTimeMillis();
         Logger.info(this, "+ %s ...", String.join(" ", command));
-        try (
-            VerboseProcess proc = new VerboseProcess(
-                new ProcessBuilder(command),
-                Level.INFO,
-                Level.INFO
-            )
-        ) {
-            final VerboseProcess.Result ret = proc.waitFor();
-            Logger.info(
-                this, "+ %s -> 0x%04x in %[ms]s",
-                String.join(" ", command), ret.code(),
-                System.currentTimeMillis() - start
-            );
-            if (ret.code() != 0) {
-                throw new IOException(
-                    String.format("Failed to execute docker, code=0x%04x", ret.code())
-                );
-            }
+        final Process proc = new ProcessBuilder(command).start();
+        final Thread stdout = new Thread(
+            () -> new BufferedReader(
+                new InputStreamReader(proc.getInputStream(), StandardCharsets.UTF_8)
+            ).lines().forEach(line -> Logger.info(this, "  %s", line))
+        );
+        final Thread stderr = new Thread(
+            () -> new BufferedReader(
+                new InputStreamReader(proc.getErrorStream(), StandardCharsets.UTF_8)
+            ).lines().forEach(line -> Logger.info(this, "  %s", line))
+        );
+        stdout.start();
+        stderr.start();
+        final boolean done;
+        try {
+            done = proc.waitFor(Docker.TIMEOUT, TimeUnit.SECONDS);
         } catch (final InterruptedException ex) {
+            proc.destroyForcibly();
             Thread.currentThread().interrupt();
-            throw new IOException(ex);
+            throw new IOException(
+                String.format("Docker was interrupted: %s", String.join(" ", command)),
+                ex
+            );
+        }
+        if (!done) {
+            proc.destroyForcibly();
+            throw new IOException(
+                String.format(
+                    "Docker command timed out after %d seconds: %s",
+                    Docker.TIMEOUT, String.join(" ", command)
+                )
+            );
+        }
+        Logger.info(
+            this, "+ %s -> 0x%04x in %[ms]s",
+            String.join(" ", command), proc.exitValue(),
+            System.currentTimeMillis() - start
+        );
+        if (proc.exitValue() != 0) {
+            throw new IOException(
+                String.format("Failed to execute docker, code=0x%04x", proc.exitValue())
+            );
         }
         return 0;
     }

--- a/src/main/java/org/eolang/hone/Phino.java
+++ b/src/main/java/org/eolang/hone/Phino.java
@@ -5,9 +5,11 @@
 package org.eolang.hone;
 
 import com.jcabi.log.Logger;
-import com.yegor256.Jaxec;
-import com.yegor256.Result;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
 
 /**
  * An abstraction of Phino in command line.
@@ -43,28 +45,23 @@ final class Phino {
     boolean available(final String expected) {
         boolean available = false;
         try {
-            final Result result = new Jaxec(this.executable, "--version")
-                .withCheck(false).execUnsafe();
-            if (result.code() == 0) {
-                final String version = result.stdout().trim();
-                if (version.equals(expected)) {
-                    available = true;
-                    Logger.info(
-                        this,
-                        "The 'phino' executable found (%s), no need to use Docker",
-                        version
-                    );
-                } else {
-                    Logger.info(
-                        this,
-                        "The 'phino' executable is found, but its version (%s) is not equal to the expected one (%s); you can upgrade it via 'cabal update && cabal install --overwrite-policy=always phino-%s' (see https://github.com/objectionary/phino for details)",
-                        version, expected, expected
-                    );
-                }
+            final Process proc = new ProcessBuilder(
+                this.executable, "--version"
+            ).start();
+            final ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+            final Thread pump = new Thread(
+                () -> Phino.pump(stdout, proc.getInputStream())
+            );
+            pump.start();
+            final boolean probed = proc.waitFor(3L, TimeUnit.SECONDS);
+            if (probed) {
+                pump.join();
+                available = Phino.version(proc, stdout, expected, this);
             } else {
+                proc.destroyForcibly();
                 Logger.info(
                     this,
-                    "The 'phino' executable is found, but it doesn't work, we must use Docker"
+                    "The 'phino --version' probe timed out, we must use Docker"
                 );
             }
         } catch (final IOException ex) {
@@ -73,7 +70,63 @@ final class Phino {
                 "The 'phino' executable not found, we must use Docker: %s",
                 ex.getMessage()
             );
+        } catch (final InterruptedException ex) {
+            Thread.currentThread().interrupt();
         }
         return available;
+    }
+
+    /**
+     * Drain a process stdout into a buffer, byte by byte.
+     * @param stdout Where to collect the output
+     * @param input The input stream to drain
+     */
+    private static void pump(final ByteArrayOutputStream stdout, final InputStream input) {
+        try {
+            final byte[] buffer = new byte[1024];
+            while (true) {
+                final int read = input.read(buffer);
+                if (read == -1) {
+                    break;
+                }
+                stdout.write(buffer, 0, read);
+            }
+        } catch (final IOException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    /**
+     * Decide whether the probed phino is the expected one.
+     * @param proc The probed process
+     * @param stdout Collected version output
+     * @param expected The version we need
+     * @param self Logger target
+     * @return TRUE if the versions match
+     */
+    private static boolean version(
+        final Process proc, final ByteArrayOutputStream stdout,
+        final String expected, final Phino self
+    ) {
+        final boolean match;
+        final String version = new String(
+            stdout.toByteArray(), StandardCharsets.UTF_8
+        ).trim();
+        if (proc.exitValue() == 0 && version.equals(expected)) {
+            Logger.info(
+                self,
+                "The 'phino' executable found (%s), no need to use Docker",
+                version
+            );
+            match = true;
+        } else {
+            Logger.info(
+                self,
+                "The 'phino' executable is found, but its version (%s) is not equal to the expected one (%s); you can upgrade it via 'cabal update && cabal install --overwrite-policy=always phino-%s' (see https://github.com/objectionary/phino for details)",
+                version, expected, expected
+            );
+            match = false;
+        }
+        return match;
     }
 }


### PR DESCRIPTION
Fixes #839.

## Problem

Two child-process waits in the plugin had no deadline:

- `Phino.available()` ran `phino --version` through `Jaxec` with no timeout — a hung binary blocked the build forever instead of falling back to Docker.
- `Docker.fire()` ran `VerboseProcess.waitFor()` with no timeout — a hung daemon or stalled `pull` blocked every docker-backed mojo indefinitely

## Solution

Replace both waits with explicit, bounded process handling:

- **`Phino.available()`**: spawn `phino --version` via `ProcessBuilder`, drain stdout on a background thread, `waitFor(3, SECONDS)`; on timeout `destroyForcibly()` and fall back to Docker (as the code already does for a missing binary). Version comparison and the "upgrade via cabal" hint are preserved.
- **`Docker.fire()`**: spawn the command via `ProcessBuilder`, stream stdout/stderr to the log on background threads, `waitFor(3600, SECONDS)`; on timeout `destroyForcibly()` and fail with `Docker command timed out after 3600 seconds: ...`

## Changes

| File | Change |
|------|--------|
| `src/main/java/org/eolang/hone/Phino.java` | bounded 3s version probe; `pump()` and `version()` helpers |
| `src/main/java/org/eolang/hone/Docker.java` | bounded 3600s wait; streamed stdout/stderr; `TIMEOUT` constant |

## Tests

- `mvn -Dtest=PhinoTest,DockerTest test` — 7 tests, 0 failures (1 skipped without Docker)
- `mvn clean install -Pqulice` — 0 offenses
- Existing behavior preserved: missing phino still falls back to Docker; docker failures still throw `IOException` with the exit code; stdout/stderr still reach the log