### PR TITLE
fix(#870): correct the stale ordering and predecessor-gate comments

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/103-methodref-to-lambda.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/103-methodref-to-lambda.phr
@@ -17,14 +17,12 @@
 #
 # Two important restrictions keep this from pessimising code:
 #
-#   1. It fires only when the method-ref directly follows a pointwise object
-#      operator (map / filter / peek). Those are exactly the predecessors
-#      451 can fuse a trailing unbox into (an empty-state distill), so the
-#      synthesised wrapper is always consumed by a fusion. A method-ref after
-#      a barrier, a stateful distinct/skip, or a boxed() roundtrip is left
-#      native — desugaring it there would only add a wrapper that never fuses
-#      and reverts (a strict pessimisation), the same "do not pessimise a lone
-#      operator" stance as the 441/442 reverts.
+#   1. It carries no predecessor gate: the pattern binds the body head
+#      directly before the invokedynamic, so it desugars a method-ref wherever
+#      it appears. A wrapper that ends up unfused is reverted to native by the
+#      711/712 revert rules, which is what actually protects a lone or
+#      barrier-separated method-ref from pessimisation, the same "do not
+#      pessimise a lone operator" stance as the 441/442 reverts.
 #
 #   2. It handles only the adaptation-free unbound-instance case: handle 5,
 #      the referenced method takes no arguments (the receiver is the single

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/105-methodref-peek-to-lambda.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/105-methodref-peek-to-lambda.phr
@@ -19,9 +19,10 @@
 # distill is emitted as a standalone mapMulti (501), which a method reference
 # (whose native form synthesises no method) would be pessimised by, and which
 # 711 cannot revert (the folded distill has dropped the SAM/instantiated types
-# the revert needs). So this rule keeps 103's original predecessor gate: it
-# fires only when the reference directly follows a pointwise map / filter /
-# peek, which is exactly the neighbour 401 fuses it into. A peek reference with
+# the revert needs). So this rule carries its own `𝜏-predecessor` gate (103
+# has none): it fires only when the reference directly follows a pointwise map
+# / filter / peek, which is exactly the neighbour 401 fuses it into. A peek
+# reference with
 # no fusable predecessor is left native — no wrapper, no pessimisation, the
 # same "do not pessimise a lone operator" stance as the 441/442 reverts.
 #

--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-distinct-frame.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-distinct-frame.phr
@@ -40,9 +40,11 @@
 # predicate names the survivor.
 #
 # Ordering: 503 claims EVERY frame-item in a stateful distill-lambda, so these
-# three have to reach the retyped ones first. No integer is free between 502 and
-# 503, so they share 503's number and rely on alphabetical filename order being
-# the schedule: `503-distill-distinct-frame` < `503-distill-dropwhile-frame` <
+# seven have to reach the retyped ones first. No integer is free between 502
+# and 503, so they share 503's number and rely on alphabetical filename order
+# being the schedule: `503-distill-distinct-frame-peeked` <
+# `503-distill-distinct-frame` < `503-distill-dropwhile-frame` <
+# `503-distill-predicate-frame` < `503-distill-skip-frame-peeked` <
 # `503-distill-skip-frame` < `503-distill-state-frame`. It runs before 512 wraps
 # the lambda into a method (503 < 512), so the marker never reaches jeo. Scoped
 # to a distill-lambda WITH `captured`, like 503 itself, so stateless filter

--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-state-frame.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-state-frame.phr
@@ -26,9 +26,10 @@
 # ahead of the guard in the fused body preserves the element type. When a
 # type-CHANGING map is fused ahead, bridge-input is the head map's INPUT
 # while the value at the keep-label is its OUTPUT, and the frame written
-# here fails JVM verification (#798). The three rules that sort in front
-# of this one — `503-distill-distinct-frame`,
-# `503-distill-dropwhile-frame`, `503-distill-skip-frame` — claim those
+# here fails JVM verification (#798). The six rules that sort in front of
+# this one — `503-distill-distinct-frame-peeked`, `503-distill-distinct-frame`,
+# `503-distill-dropwhile-frame`, `503-distill-predicate-frame`,
+# `503-distill-skip-frame-peeked`, `503-distill-skip-frame` — claim those
 # markers first and derive the stack item from the survivor, leaving this
 # rule the guards with a type-preserving neighbour or nothing fused ahead
 # of them at all, where bridge-input is right. The LOCAL at slot 1 is


### PR DESCRIPTION
Fixes #870.

## Problem

Two header comments in the `503-distill-*` family claimed the ordering involved "three" rules, but the family has seven members now (#805 added `predicate-frame`, `distinct-frame-peeked`, `skip-frame-peeked`). Separately, `103` claimed to fire "only when the method-ref directly follows a pointwise object operator", but its pattern has no predecessor gate, and `105` referred to "103's original predecessor gate" that does not exist.

## Solution

- `503-distill-distinct-frame.phr` and `503-distill-state-frame.phr`: enumerate all seven (resp. six) `503-*` rules in the actual alphabetical sort order.
- `103-methodref-to-lambda.phr`: state that there is no predecessor gate and that unfused wrappers are protected by the 711/712 reverts.
- `105-methodref-peek-to-lambda.phr`: attribute the `𝜏-predecessor` gate to 105 itself, not to 103.

## Changes

| File | Change |
|------|--------|
| `5xx/503-distill-distinct-frame.phr` | ordering comment: three -> seven, full list |
| `5xx/503-distill-state-frame.phr` | ordering comment: three -> six, full list |
| `1xx/103-methodref-to-lambda.phr` | drop the false predecessor-gate claim; note 711/712 protection |
| `1xx/105-methodref-peek-to-lambda.phr` | gate is 105's own, not "103's original" |

## Tests

- `mvn -Dtest=RulesTest test` — 9 tests pass (rule structure intact)
- Comment-only change; no logic touched