### PR TITLE
fix(#865): merge CSV headers on add instead of corrupting the summary silently

### DIFF
--- a/src/main/java/org/eolang/hone/CSV.java
+++ b/src/main/java/org/eolang/hone/CSV.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.hone;
 
+import com.jcabi.log.Logger;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
@@ -13,6 +14,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -76,9 +78,22 @@ public final class CSV {
      * @return A new CSV instance containing the combined records of both CSVs
      */
     CSV add(final CSV other) {
+        final List<String> merged = new ArrayList<>(this.headers);
+        for (final String header : other.headers) {
+            if (!merged.contains(header)) {
+                merged.add(header);
+            }
+        }
+        if (!new HashSet<>(this.headers).equals(new HashSet<>(other.headers))) {
+            Logger.warn(
+                this,
+                "CSV headers differ (%s vs %s); merged to %s, missing cells will be empty",
+                this.headers, other.headers, merged
+            );
+        }
         final List<Map<String, String>> combined = new ArrayList<>(this.records);
         combined.addAll(other.records);
-        return new CSV(this.headers, combined);
+        return new CSV(merged, combined);
     }
 
     /**

--- a/src/test/java/org/eolang/hone/CSVTest.java
+++ b/src/test/java/org/eolang/hone/CSVTest.java
@@ -120,4 +120,40 @@ final class CSVTest {
             Matchers.is(0)
         );
     }
+
+    @Test
+    void mergesHeadersWhenAddingCsvsWithDifferentColumns(@Mktmp final Path temp)
+        throws Exception {
+        final Path left = temp.resolve("left.csv");
+        final Path right = temp.resolve("right.csv");
+        final Path merged = temp.resolve("merged.csv");
+        Files.write(
+            left,
+            String.join(
+                System.lineSeparator(),
+                "ID,Changed",
+                "1,3",
+                ""
+            ).getBytes(StandardCharsets.UTF_8)
+        );
+        Files.write(
+            right,
+            String.join(
+                System.lineSeparator(),
+                "ID,Before",
+                "2,5",
+                ""
+            ).getBytes(StandardCharsets.UTF_8)
+        );
+        new CSV(left).add(new CSV(right)).flush(merged);
+        MatcherAssert.assertThat(
+            "the merged CSV keeps the union of both headers (see #865)",
+            new String(Files.readAllBytes(merged), StandardCharsets.UTF_8),
+            Matchers.allOf(
+                Matchers.containsString("ID,Changed,Before"),
+                Matchers.containsString("1,3,"),
+                Matchers.containsString("2,,5")
+            )
+        );
+    }
 }


### PR DESCRIPTION
Fixes #865.

## Problem

`CSV.add()` (`CSV.java:78`) concatenated records while keeping only the left CSV's headers. Records are `Map<String, String>` keyed by each file's own headers, so a record from a CSV with different columns produced `null` cells at `flush()` for every header it lacked — the merged summary silently gained empty cells (e.g. empty `Changed`, empty opcode counts) with no warning.

## Solution

`add()` now computes the **union** of both header lists (left order preserved, foreign columns appended) and logs a warning when the two header sets differ. Missing cells remain empty, but the corruption is no longer silent and the columns are preserved.

## Changes

| File | Change |
|------|--------|
| `src/main/java/org/eolang/hone/CSV.java` | `add()` merges headers (union) and warns on mismatch |
| `src/test/java/org/eolang/hone/CSVTest.java` | test: two CSVs with different columns merge to a union header |

## Tests

- `mvn -Dtest=CSVTest,SummaryTest test` — 10 tests pass
- `mvn clean install -Pqulice` — 0 offenses