### PR TITLE
fix(#866): follow symlinks when collecting module statistics

### DIFF
--- a/src/main/java/org/eolang/hone/Summary.java
+++ b/src/main/java/org/eolang/hone/Summary.java
@@ -4,13 +4,19 @@
  */
 package org.eolang.hone;
 
+import com.jcabi.log.Logger;
 import java.io.IOException;
+import java.nio.file.FileSystemLoopException;
+import java.nio.file.FileVisitOption;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Stream;
 
 /**
  * Build summary statistics.
@@ -54,13 +60,13 @@ public final class Summary {
         final List<CSV> found = new ArrayList<>(0);
         final String stats = "hone-statistics.csv";
         final Path destination = this.target.resolve(stats);
-        final Path output = destination.toAbsolutePath().normalize();
-        try (Stream<Path> paths = Files.walk(this.root)) {
-            paths.filter(Files::isRegularFile)
-                .filter(path -> stats.equals(path.getFileName().toString()))
-                .filter(path -> !output.equals(path.toAbsolutePath().normalize()))
-                .map(CSV::new)
-                .forEach(found::add);
+        try {
+            Files.walkFileTree(
+                this.root,
+                EnumSet.of(FileVisitOption.FOLLOW_LINKS),
+                Integer.MAX_VALUE,
+                new Summary.Collector(found, stats, destination)
+            );
         } catch (final IOException exception) {
             throw new IllegalStateException(
                 "Failed to collect summary statistics",
@@ -84,5 +90,79 @@ public final class Summary {
             "ID",
             ignore -> String.format("%d/%d", index.getAndIncrement(), res.size())
         );
+    }
+
+    /**
+     * Whether two paths point to the same file.
+     * @param first First path
+     * @param second Second path
+     * @return TRUE when both resolve to the same normalized absolute path
+     */
+    private static boolean same(final Path first, final Path second) {
+        return first.toAbsolutePath().normalize()
+            .equals(second.toAbsolutePath().normalize());
+    }
+
+    /**
+     * A file visitor that gathers statistics files, following symlinks.
+     * @since 0.1.0
+     */
+    private static final class Collector extends SimpleFileVisitor<Path> {
+
+        /**
+         * Where to put the found CSVs.
+         */
+        private final List<CSV> found;
+
+        /**
+         * The statistics file name to look for.
+         */
+        private final String stats;
+
+        /**
+         * The summary output, excluded from the walk.
+         */
+        private final Path output;
+
+        /**
+         * Ctor.
+         * @param found Where to put the found CSVs
+         * @param stats The statistics file name to look for
+         * @param output The summary output to exclude
+         */
+        Collector(
+            final List<CSV> found,
+            final String stats,
+            final Path output
+        ) {
+            this.found = found;
+            this.stats = stats;
+            this.output = output;
+        }
+
+        @Override
+        public FileVisitResult visitFile(
+            final Path file, final BasicFileAttributes attrs
+        ) {
+            if (this.stats.equals(file.getFileName().toString())
+                && !Summary.same(this.output, file)) {
+                this.found.add(new CSV(file));
+            }
+            return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult visitFileFailed(
+            final Path file, final IOException exc
+        ) {
+            if (exc instanceof FileSystemLoopException) {
+                Logger.warn(
+                    this,
+                    "Symlink cycle detected at %s, skipping",
+                    file
+                );
+            }
+            return FileVisitResult.CONTINUE;
+        }
     }
 }

--- a/src/test/java/org/eolang/hone/SummaryTest.java
+++ b/src/test/java/org/eolang/hone/SummaryTest.java
@@ -68,6 +68,22 @@ final class SummaryTest {
         );
     }
 
+    @Test
+    void includesSymlinkedModuleStatistics(@Mktmp final Path temp) throws Exception {
+        Files.write(
+            Files.createSymbolicLink(
+                temp.resolve("linked"),
+                Files.createDirectories(temp.resolve("real"))
+            ).resolve("hone-statistics.csv"),
+            new BytesOf(new ResourceOf("csv/hone-statistics-server.csv")).asBytes()
+        );
+        MatcherAssert.assertThat(
+            "report must include statistics reached through a symlinked module (see #866)",
+            new TextOf(new Summary(temp).collect()).asString(),
+            Matchers.containsString("Server.phi")
+        );
+    }
+
     private static Path modular(final Path root) throws Exception {
         Files.createDirectories(root.resolve("server"));
         Files.createDirectories(root.resolve("client"));


### PR DESCRIPTION
Fixes #866.

## Problem

`Summary.collect()` used `Files.walk(this.root)`, which does not descend into directories reached via a symlink. In a monorepo where module directories are symlinks, the `hone-statistics.csv` of those modules was never found and the modules silently disappeared from the `hone:summary` report.

## Solution

Replace the stream-based walk with `Files.walkFileTree(..., FileVisitOption.FOLLOW_LINKS, ...)` using a dedicated `Summary.Collector` visitor. Symlinked directories are now traversed; symlink cycles are detected and skipped with a warning (`visitFileFailed` + `FileSystemLoopException`) instead of aborting the walk.

## Changes

| File | Change |
|------|--------|
| `src/main/java/org/eolang/hone/Summary.java` | `collect()` walks with `FOLLOW_LINKS` via `Summary.Collector`; cycle-safe |
| `src/test/java/org/eolang/hone/SummaryTest.java` | test: a module reached only through a symlink appears in the report |

## Tests

- `mvn -Dtest=SummaryTest test` — 4 tests pass (incl. the new symlink test)
- `mvn clean install -Pqulice` — 0 offenses