### PR TITLE
fix(#867): make rewrite.sh portable to macOS (nproc, @Q, date %N)

### DIFF
--- a/src/main/resources/org/eolang/hone/scaffolding/entry.sh
+++ b/src/main/resources/org/eolang/hone/scaffolding/entry.sh
@@ -41,6 +41,12 @@ fi
 
 SELF=$(dirname "$0")
 
+function now {
+  # Current time in seconds with sub-second precision. macOS's BSD date has
+  # no %N, so use perl's high-resolution clock when available (see #867).
+  perl -MTime::HiRes=time -e 'printf "%.6f\n", time' 2>/dev/null || date '+%s'
+}
+
 if [ "${LANG}" != 'en_US.UTF-8' ]; then
   echo "Setting locale to en_US.UTF-8 from '${LANG}'"
   LANG=en_US.UTF-8
@@ -205,10 +211,10 @@ function record_timing {
 }
 
 function elapsed {
-  awk -v start="${1}" -v end="$(date '+%s.%N')" 'BEGIN { printf "%.3f\n", end - start }'
+  awk -v start="${1}" -v end="$(now)" 'BEGIN { printf "%.3f\n", end - start }'
 }
 
-start=$(date '+%s.%N')
+start=$(now)
 (
   set -x
   mvn "${disassemble_opts[@]}" "org.eolang:jeo-maven-plugin:${JEO_VERSION}:disassemble"
@@ -232,7 +238,7 @@ if [ "${SKIP_PHINO}" != 'true' ]; then
   export HONE_THREADS="${THREADS}"
   export HONE_TIMEOUT="${TIMEOUT}"
   export HONE_STATISTICS
-  start=$(date '+%s.%N')
+  start=$(now)
   (
     set -x
     "${SELF}/rewrite.sh"
@@ -240,7 +246,7 @@ if [ "${SKIP_PHINO}" != 'true' ]; then
   record_timing "phino:rewrite (default-cli)" "$(elapsed "${start}")"
 fi
 
-start=$(date '+%s.%N')
+start=$(now)
 (
   set -x
   mvn "${assemble_opts[@]}" "org.eolang:jeo-maven-plugin:${JEO_VERSION}:assemble"

--- a/src/main/resources/org/eolang/hone/scaffolding/rewrite.sh
+++ b/src/main/resources/org/eolang/hone/scaffolding/rewrite.sh
@@ -72,6 +72,17 @@ function atomic_write {
   fi
 }
 
+function now {
+  # Current time in seconds with sub-second precision. macOS's BSD date has
+  # no %N, so use perl's high-resolution clock when available (see #867).
+  perl -MTime::HiRes=time -e 'printf "%.6f\n", time' 2>/dev/null || date '+%s'
+}
+
+function q {
+  # Bash-compatible quoting of a single argument (portable printf %q).
+  printf '%q' "${1}"
+}
+
 if [ "${HONE_DEBUG}" == 'true' ]; then
   set -x
 fi
@@ -123,7 +134,7 @@ function rewrite {
   verbose "Converted ${idx} XMIR ($(du -sh "${xi}" | cut -f1)) to $(basename "${phi}") ($(du -sh "${phi}" | cut -f1))"
   rm -f "${pho}.*"
   pos=0
-  start=$(date '+%s.%N')
+  start=$(now)
   if [ "${HONE_SMALL_STEPS}" == "true" ]; then
     verbose "Applying ${#rules[@]} rule(s) one by one to ${idx} $(basename "${phi}")..."
     cp "${phi}" "${pho}"
@@ -148,7 +159,7 @@ function rewrite {
   fi
   s_size=$(du -sh "${xi}" | cut -f1)
   s_lines=$(wc -l < "${pho}" | xargs)
-  per=$(perl -E "say int(${s_lines} / ($(date '+%s.%N') - ${start}))")
+  per=$(perl -E "say int(${s_lines} / ($(now) - ${start}))")
   changed=0
   if cmp -s "${phi}" "${pho}"; then
     echo "No changes in ${idx} $(basename "${pho}"): ${s_size}, ${s_lines} lines, ${per} lps"
@@ -186,7 +197,7 @@ function rewrite_with_timeout {
   pho=${3}
   xi=${4}
   xo=${5}
-  start=$(date '+%s.%N')
+  start=$(now)
   code=0
   # GNU "timeout" sends its signal only to its direct child (the bash
   # re-invocation of this script), not to the phino process that the "rewrite"
@@ -223,12 +234,12 @@ function rewrite_with_timeout {
   wait "${watchdog}" 2>/dev/null || true
   if [ -f "${flag}" ]; then
     rm -f "${flag}"
-    sec=$(perl -E "say int($(date '+%s.%N') - ${start})")
+    sec=$(perl -E "say int($(now) - ${start})")
     echo "Timeout in ${idx} $(basename "${xi}") ($(du -sh "${xi}" | cut -f1)) after ${sec} seconds"
     cp "${xi}" "${xo}"
   elif [ "${code}" -ne 0 ]; then
     rm -f "${flag}"
-    sec=$(perl -E "say int($(date '+%s.%N') - ${start})")
+    sec=$(perl -E "say int($(now) - ${start})")
     echo "Failure (exit code ${code}) in ${idx} $(basename "${xi}") ($(du -sh "${xi}" | cut -f1)) after ${sec} seconds; refusing to copy it through unoptimized" >&2
     exit "${code}"
   else
@@ -325,16 +336,16 @@ while IFS= read -r f; do
   xi="${HONE_XMIR_IN}/${f}.xmir"
   xo="${HONE_XMIR_OUT}/${f}.xmir"
   i="${idx}/${total}"
-  printf "%s rewrite_with_timeout %s %s %s %s %s\n" "${0@Q}" "${i@Q}" "${phi@Q}" "${pho@Q}" "${xi@Q}" "${xo@Q}" >> "${tasks}"
+  printf "%s rewrite_with_timeout %s %s %s %s %s\n" "$(q "${0}")" "$(q "${i}")" "$(q "${phi}")" "$(q "${pho}")" "$(q "${xi}")" "$(q "${xo}")" >> "${tasks}"
 done <<< "${files}"
 
 threads=${HONE_THREADS}
 if [ -z "${threads}" ] || [ "${threads}" == '0' ]; then
-  threads=$(nproc)
+  threads=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)
   echo "Using ${threads} threads, by the number of CPU cores"
 fi
 
-start=$(date '+%s.%N')
+start=$(now)
 if [ "${threads}" -eq 1 ]; then
   echo "Starting to rewrite ${total} file(s)..."
   while IFS= read -r cmd; do
@@ -354,4 +365,4 @@ else
     --env _ \
     --halt-on-error=now,fail=1 --halt=now,fail=1 < "${tasks}"
 fi
-echo "Finished rewriting ${total} file(s) in $(perl -E "say int($(date '+%s.%N') - ${start})") seconds"
+echo "Finished rewriting ${total} file(s) in $(perl -E "say int($(now) - ${start})") seconds"


### PR DESCRIPTION
Fixes #867.

## Problem

`rewrite.sh` is run on the host whenever phino is installed locally (the `withoutDocker()` path), and on macOS it broke in three independent places:

1. `nproc` does not exist on macOS — `threads=$(nproc)` produced an empty value, then `[ "${threads}" -eq 1 ]` died with `integer expression expected` under `set -e`.
2. `${0@Q}` and friends require bash >= 4.4; macOS ships bash 3.2, where the operator is a syntax error.
3. `date '+%s.%N'` is GNU-only — BSD `date` prints a literal `%N`, corrupting all timing arithmetic.

## Solution

- **threads**: `threads=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)` — falls back to the macOS CPU count, then to 1.
- **quoting**: new `q()` helper using `printf '%q'` (supported by bash 3.2), replacing every `@Q` use when writing the tasks file.
- **clock**: new `now()` helper using `perl -MTime::HiRes=time` (present on both macOS and Linux, core module), falling back to `date '+%s'`. All `date '+%s.%N'` occurrences in `rewrite.sh` and `entry.sh` now go through `now()`.

## Changes

| File | Change |
|------|--------|
| `src/main/resources/org/eolang/hone/scaffolding/rewrite.sh` | add `now()`/`q()`, use them; `nproc` fallback chain |
| `src/main/resources/org/eolang/hone/scaffolding/entry.sh` | add `now()`, replace `date '+%s.%N'` |

## Tests

- `bash -n` + `shellcheck` — clean on both scripts
- `now()` returns a float second value on macOS (verified); `q()` escapes paths with spaces
- Timing arithmetic verified: `int(end - start)` works with the float values