### PR TITLE
fix(#868): guard Docker mounts against Windows drives and rewrite backslash prefixes

### DIFF
--- a/src/main/java/org/eolang/hone/OptimizeMojo.java
+++ b/src/main/java/org/eolang/hone/OptimizeMojo.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -358,6 +359,46 @@ public final class OptimizeMojo extends AbstractMojo {
     }
 
     /**
+     * Build a {@code host:container} bind mount for Docker, rejecting paths
+     * that Docker would misparse (Windows drive letters contain a colon).
+     * @param host The host path
+     * @param container The container path
+     * @return The bind-mount string
+     */
+    static String mount(final File host, final String container) {
+        final String path = host.toString();
+        if (path.indexOf(':') >= 0) {
+            throw new IllegalStateException(
+                String.format(
+                    "Docker bind mounts are not supported for paths containing ':' (Windows drives): %s",
+                    path
+                )
+            );
+        }
+        return String.format("%s:%s", path, container);
+    }
+
+    /**
+     * Rewrite the {@code /target} (or {@code \target}) prefixes to the real
+     * local path, tolerating backslash separators.
+     * @param target The local target directory
+     * @param paths The includes/excludes patterns
+     * @return The joined, rewritten patterns
+     */
+    static String localPaths(final String target, final String... paths) {
+        return String.join(
+            ",",
+            new Mapped<>(
+                p -> p.replaceAll(
+                    "^[/\\\\]target",
+                    Matcher.quoteReplacement(target)
+                ),
+                paths
+            )
+        );
+    }
+
+    /**
      * Check if the classes directory is absent or doesn't have classes.
      * @return True if there are no class files, false otherwise
      */
@@ -418,8 +459,8 @@ public final class OptimizeMojo extends AbstractMojo {
             Arrays.asList(
                 "run",
                 "--rm",
-                "--volume", String.format("%s:%s", this.target, tdir),
-                "--volume", String.format("%s:%s", this.cache, cdir),
+                "--volume", OptimizeMojo.mount(this.target, tdir),
+                "--volume", OptimizeMojo.mount(this.cache, cdir),
                 "--env", String.format("TARGET=%s", tdir),
                 "--env", String.format("EO_CACHE=%s", cdir),
                 "--env", "WORKDIR=/hone"
@@ -668,10 +709,16 @@ public final class OptimizeMojo extends AbstractMojo {
                 jaxec = jaxec.withEnv("EXTRA", temp.path().resolve("hone-extra").toString());
             }
             if (this.includes != null && this.includes.length > 0) {
-                jaxec = jaxec.withEnv("INCLUDES", this.localPaths(this.includes));
+                jaxec = jaxec.withEnv(
+                    "INCLUDES",
+                    OptimizeMojo.localPaths(this.target.toString(), this.includes)
+                );
             }
             if (this.excludes != null && this.excludes.length > 0) {
-                jaxec = jaxec.withEnv("EXCLUDES", this.localPaths(this.excludes));
+                jaxec = jaxec.withEnv(
+                    "EXCLUDES",
+                    OptimizeMojo.localPaths(this.target.toString(), this.excludes)
+                );
             }
             if (this.cache != null) {
                 jaxec = jaxec.withEnv("EO_CACHE", this.cache.getAbsolutePath());
@@ -684,16 +731,6 @@ public final class OptimizeMojo extends AbstractMojo {
             jaxec = jaxec.withEnv("JEO_VERSION", this.jeo());
             jaxec.exec();
         }
-    }
-
-    private String localPaths(final String... paths) {
-        return String.join(
-            ",",
-            new Mapped<>(
-                p -> p.replaceAll("^/target", this.target.toString()),
-                paths
-            )
-        );
     }
 
     /**

--- a/src/test/java/org/eolang/hone/OptimizeMojoTest.java
+++ b/src/test/java/org/eolang/hone/OptimizeMojoTest.java
@@ -9,11 +9,13 @@ import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
 import com.yegor256.farea.Farea;
 import com.yegor256.farea.RequisiteMatcher;
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -141,6 +143,36 @@ final class OptimizeMojoTest {
     void optimizesSimpleApp(@Mktmp final Path home,
         @RandomImage final String image) throws Exception {
         new Farea(home).together(f -> OptimizeMojoTest.runSimpleApp(f, image));
+    }
+
+    @Test
+    void mountsUnixHostPath() {
+        MatcherAssert.assertThat(
+            "a plain Unix host path mounts as host:container (see #868)",
+            OptimizeMojo.mount(new File("/repo/target"), "/target"),
+            Matchers.equalTo("/repo/target:/target")
+        );
+    }
+
+    @Test
+    void rejectsWindowsDrivePathInMount() {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> OptimizeMojo.mount(new File("C:\\repo\\target"), "/target"),
+            "a Windows drive path must be rejected for a Docker bind mount (see #868)"
+        );
+    }
+
+    @Test
+    void rewritesBothPrefixFormsInLocalPaths() {
+        MatcherAssert.assertThat(
+            "both /target and \\target prefixes must be rewritten (see #868)",
+            OptimizeMojo.localPaths(
+                "C:\\repo\\target",
+                "\\target\\a", "/target/b"
+            ),
+            Matchers.equalTo("C:\\repo\\target\\a,C:\\repo\\target/b")
+        );
     }
 
     /**


### PR DESCRIPTION
Fixes #868.

## Problem

Two spots in `OptimizeMojo` assumed Unix path syntax:

1. The Docker bind mounts were built as `String.format("%s:%s", host, container)` (`OptimizeMojo.java:421-422`). On Windows `this.target`/`this.cache` are `C:\...`, Docker misparses the first `:` as the host/container separator, and the `docker run` fails or mounts the wrong thing.
2. `localPaths()` rewrote only the Unix prefix with `p.replaceAll("^/target", ...)`. A backslash form (`\target\...`) or a Windows target path (containing `\` — also a regex-replacement hazard) was passed through unchanged or produced an `IllegalArgumentException` (unquoted replacement).

## Solution

- New `OptimizeMojo.mount(File, String)` builds the `host:container` string and throws a clear `IllegalStateException` when the host path contains a `:` (Windows drive), instead of handing Docker a broken mount.
- `localPaths` now accepts both prefix forms (`^[/\\]target`) and quotes the replacement with `Matcher.quoteReplacement` so a Windows-style target path cannot corrupt the substitution.

## Changes

| File | Change |
|------|--------|
| `src/main/java/org/eolang/hone/OptimizeMojo.java` | `mount()` guard + `localPaths()` backslash/quoteReplacement; both package-private static for testability |
| `src/test/java/org/eolang/hone/OptimizeMojoTest.java` | 3 tests: unix mount, Windows-drive rejection, both prefix forms |

## Tests

- `mvn -Dtest=OptimizeMojoTest#mountsUnixHostPath+rejectsWindowsDrivePathInMount+rewritesBothPrefixFormsInLocalPaths test` — 3 pass
- `mvn clean install -Pqulice` — 0 offenses