### PR TITLE
fix(#869): give every rule a unique name and enforce it in RulesTest

### DIFF
--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/121-nonstatic-lambda-to-static.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/121-nonstatic-lambda-to-static.phr
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-name: nonstatic-invokedynamic-to-lambda
+name: 121-nonstatic-lambda-to-static
 pattern: |
   ⟦
     φ ↦ Φ.hone.lambda,

--- a/src/main/resources/org/eolang/hone/rules/streams/1xx/131-remove-this-before-nonstatic-lambda.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/1xx/131-remove-this-before-nonstatic-lambda.phr
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-name: nonstatic-invokedynamic-to-lambda
+name: 131-remove-this-before-nonstatic-lambda
 pattern: |
   ⟦
     𝐵-before,

--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/501-distill-to-mapMulti.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/501-distill-to-mapMulti.phr
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-name: distill-to-mapMulti
+name: 501-distill-to-mapMulti
 pattern: |
   ⟦
     φ ↦ Φ.jeo.class,

--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-predicate-frame.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/503-distill-predicate-frame.phr
@@ -39,7 +39,7 @@
 # alphabetically, so the fallback is left only the markers nobody could name.
 # Scoped to a distill-lambda WITH `captured`, so stateless filter keep-labels
 # stay with 506/507.
-name: distill-predicate-frame
+name: 503-distill-predicate-frame
 pattern: |
   ⟦
     φ ↦ Φ.hone.distill-lambda,

--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/506-distill-predicate-frame.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/506-distill-predicate-frame.phr
@@ -41,7 +41,7 @@
 # `507-distill-filter-frame-fallback`. A same-locals-1 frame is enough — a
 # stateless wrapper owns no per-call counter. Scoped to a distill-lambda WITHOUT
 # `captured`, so stateful keep-labels stay with 503/504.
-name: distill-predicate-frame
+name: 506-distill-predicate-frame
 pattern: |
   ⟦
     φ ↦ Φ.hone.distill-lambda,

--- a/src/main/resources/org/eolang/hone/rules/streams/5xx/511-distill-lambda-to-method.phr
+++ b/src/main/resources/org/eolang/hone/rules/streams/5xx/511-distill-lambda-to-method.phr
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-name: distill-to-mapMulti
+name: 511-distill-lambda-to-method
 pattern: |
   ⟦
     φ ↦ Φ.hone.distill-lambda,

--- a/src/test/java/org/eolang/hone/RulesTest.java
+++ b/src/test/java/org/eolang/hone/RulesTest.java
@@ -145,6 +145,34 @@ final class RulesTest {
     }
 
     @Test
+    void keepsRuleNamesUnique(@Mktmp final Path temp) throws IOException {
+        new Rules("*").copyTo(temp);
+        final Pattern key = Pattern.compile("^name:\\s*(.+)$", Pattern.MULTILINE);
+        final Map<String, Collection<String>> names = new HashMap<>(0);
+        final List<Path> files;
+        try (Stream<Path> walk = Files.walk(temp)) {
+            files = walk.filter(Files::isRegularFile).collect(Collectors.toList());
+        }
+        for (final Path file : files) {
+            final Matcher found = key.matcher(
+                Files.readString(file, StandardCharsets.UTF_8)
+            );
+            if (found.find()) {
+                names.computeIfAbsent(found.group(1).trim(), name -> new HashSet<>(0))
+                    .add(temp.relativize(file).toString());
+            }
+        }
+        MatcherAssert.assertThat(
+            "no two rules can share one name: field, since it is the rule's identity in phino logs and any future tooling (see #869)",
+            names.entrySet().stream()
+                .filter(entry -> entry.getValue().size() > 1)
+                .map(Map.Entry::toString)
+                .collect(Collectors.toList()),
+            Matchers.empty()
+        );
+    }
+
+    @Test
     void yamlsReturnsSortedList() {
         final Iterable<String> yamls = new Rules("*").yamls();
         String previous = null;


### PR DESCRIPTION
Fixes #869.

## Problem

Three pairs of `.phr` rules shared one `name:` field (copy-paste artifacts):

| `name:` | Rules that carried it |
|---------|----------------------|
| `distill-predicate-frame` | `503-distill-predicate-frame.phr` and `506-distill-predicate-frame.phr` |
| `distill-to-mapMulti` | `501-distill-to-mapMulti.phr` and `511-distill-lambda-to-method.phr` |
| `nonstatic-invokedynamic-to-lambda` | `121-nonstatic-lambda-to-static.phr` and `131-remove-this-before-nonstatic-lambda.phr` |

The `name:` field is the rule's identity in phino logs and any future tooling, and the duplicates could silently diverge (same name, different behavior).

## Solution

- Rename each `name:` to match its file (e.g. `503-distill-predicate-frame`, `506-distill-predicate-frame`, ...).
- Add `RulesTest.keepsRuleNamesUnique` — mirroring the existing `mintsSyntheticNamesInDisjointNamespaces` (#777) test — that collects every `name:` across `streams/` and asserts uniqueness, so this class of bug cannot recur.

## Changes

| File | Change |
|------|--------|
| `5xx/503-distill-predicate-frame.phr` | `name:` → `503-distill-predicate-frame` |
| `5xx/506-distill-predicate-frame.phr` | `name:` → `506-distill-predicate-frame` |
| `5xx/501-distill-to-mapMulti.phr` | `name:` → `501-distill-to-mapMulti` |
| `5xx/511-distill-lambda-to-method.phr` | `name:` → `511-distill-lambda-to-method` |
| `1xx/121-nonstatic-lambda-to-static.phr` | `name:` → `121-nonstatic-lambda-to-static` |
| `1xx/131-remove-this-before-nonstatic-lambda.phr` | `name:` → `131-remove-this-before-nonstatic-lambda` |
| `src/test/java/org/eolang/hone/RulesTest.java` | new uniqueness test for `name:` |

## Tests

- `mvn -Dtest=RulesTest test` — 10 tests pass (incl. the new one)
- `mvn clean install -Pqulice` — 0 offenses
- `grep "^name:" streams/ | uniq -d` — empty