### PR TITLE
fix(#863): let the watchdog finish its KILL escalation and expose the kill grace

### DIFF
--- a/src/main/java/org/eolang/hone/OptimizeMojo.java
+++ b/src/main/java/org/eolang/hone/OptimizeMojo.java
@@ -261,6 +261,20 @@ public final class OptimizeMojo extends AbstractMojo {
     private int timeout;
 
     /**
+     * How many seconds to wait after the TERM signal before force-killing a
+     * timed-out phino process tree.
+     *
+     * <p>The watchdog of {@code rewrite.sh} sends TERM to the whole process
+     * group once the {@code hone.timeout} deadline passes, then gives the tree
+     * this grace window to clean up, and finally force-kills whatever survived,
+     * so no orphan phino is left burning CPU (see #863).</p>
+     *
+     * @since 0.38.0
+     */
+    @Parameter(property = "hone.kill-grace", defaultValue = "10")
+    private int killgrace;
+
+    /**
      * How many threads to use for rewriting?
      *
      * <p>By default, it is set to zero, which means the number of threads
@@ -508,7 +522,8 @@ public final class OptimizeMojo extends AbstractMojo {
         );
         command.addAll(
             Arrays.asList(
-                "--env", String.format("TIMEOUT=%d", this.timeout)
+                "--env", String.format("TIMEOUT=%d", this.timeout),
+                "--env", String.format("KILL_GRACE=%d", this.killgrace)
             )
         );
         if (this.includes != null && this.includes.length > 0) {
@@ -662,6 +677,7 @@ public final class OptimizeMojo extends AbstractMojo {
                 .withEnv("MAX_CYCLES", Integer.toString(this.maxCycles))
                 .withEnv("THREADS", Integer.toString(this.threads))
                 .withEnv("TIMEOUT", Integer.toString(this.timeout))
+                .withEnv("KILL_GRACE", Integer.toString(this.killgrace))
                 .withEnv("RULES", this.rulesAsString());
             if (this.extra != null && !this.extra.isEmpty()) {
                 this.copyExtras(temp.path().resolve("hone-extra"));

--- a/src/main/resources/org/eolang/hone/scaffolding/entry.sh
+++ b/src/main/resources/org/eolang/hone/scaffolding/entry.sh
@@ -231,6 +231,7 @@ if [ "${SKIP_PHINO}" != 'true' ]; then
   export HONE_MAX_CYCLES="${MAX_CYCLES}"
   export HONE_THREADS="${THREADS}"
   export HONE_TIMEOUT="${TIMEOUT}"
+  export HONE_KILL_GRACE="${KILL_GRACE}"
   export HONE_STATISTICS
   start=$(date '+%s.%N')
   (

--- a/src/main/resources/org/eolang/hone/scaffolding/rewrite.sh
+++ b/src/main/resources/org/eolang/hone/scaffolding/rewrite.sh
@@ -219,7 +219,13 @@ function rewrite_with_timeout {
   ) &
   watchdog=$!
   wait "${sid}" || code=$?
-  kill "${watchdog}" 2>/dev/null || true
+  # If the deadline fired, the watchdog is mid-escalation (TERM → grace →
+  # KILL) and killing it here would orphan phino again (#727, #863) — so only
+  # stop it when it is still in its initial sleep, i.e. the worker finished
+  # before the deadline.
+  if [ ! -f "${flag}" ]; then
+    kill "${watchdog}" 2>/dev/null || true
+  fi
   wait "${watchdog}" 2>/dev/null || true
   if [ -f "${flag}" ]; then
     rm -f "${flag}"


### PR DESCRIPTION
Fixes #863.

## Problem

`rewrite_with_timeout` in `rewrite.sh` runs every phino rewrite under a watchdog that escalates TERM → grace → KILL so a timed-out phino never survives as an orphan (the #727 fix). The escalation was cut short:

- `wait "${sid}"` returns as soon as the **bash worker** (the direct setsid child) exits on TERM — which happens before phino (a grandchild) dies.
- The main flow then immediately killed the watchdog with `kill "${watchdog}"` (`rewrite.sh:222`), while the watchdog was still in its `sleep "${HONE_KILL_GRACE:-10}"`. The KILL phase never ran, and phino was orphaned again on every timeout.
- Separately, `HONE_KILL_GRACE` was never exported (`entry.sh` exports `HONE_TIMEOUT` but not `HONE_KILL_GRACE`; `OptimizeMojo` passes `TIMEOUT` but no `KILL_GRACE`), so the knob was permanently dead at its `:-10` default.

## Solution

- **`rewrite.sh`**: only stop the watchdog when the deadline did NOT fire (no flag file) — i.e. it is still in its initial sleep. When the timeout flag is present, the watchdog is mid-escalation, so the main flow waits for it to complete the TERM → grace → KILL sequence, guaranteeing phino is dead before the task returns.
- **`OptimizeMojo`**: new `hone.kill-grace` parameter (default `10`), forwarded as `KILL_GRACE` in both the Docker and no-Docker paths.
- **`entry.sh`**: export `HONE_KILL_GRACE` from `KILL_GRACE`, so `rewrite.sh:199` reads a real value.

## Changes

| File | Change |
|------|--------|
| `src/main/java/org/eolang/hone/OptimizeMojo.java` | add `hone.kill-grace`; pass `KILL_GRACE` env in both paths |
| `src/main/resources/org/eolang/hone/scaffolding/entry.sh` | export `HONE_KILL_GRACE` |
| `src/main/resources/org/eolang/hone/scaffolding/rewrite.sh` | don't kill the watchdog when the timeout fired; wait for the KILL escalation |

## Tests

- `bash -n` + `shellcheck` — clean on both scripts
- `mvn clean install -Pqulice` — 0 offenses
- Simulated escalation (grace 10s, process ignoring TERM): with the fix the watchdog survives to the KILL phase and phino dies; the old always-kill code orphans it (`FAIL: phino ALIVE`)