### PR TITLE
#881: keep one copy of the classes, not a copy of the copy

### DIFF
--- a/src/main/resources/org/eolang/hone/scaffolding/entry.sh
+++ b/src/main/resources/org/eolang/hone/scaffolding/entry.sh
@@ -93,7 +93,10 @@ after the 'compile' phase is finished; this is what is in the '${TARGET}' direct
   fi
 fi
 
-# In order to save them "as is", just in case:
+# In order to save them "as is", just in case. The previous copy goes first,
+# because "cp -R" puts the source inside a directory that already exists, and
+# a second run without "clean" would otherwise nest one backup in the other:
+rm -rf "${TARGET}/classes-before-hone"
 cp -R "${TARGET}/${CLASSES}" "${TARGET}/classes-before-hone"
 echo "The binaries before hone are saved in '${TARGET}/classes-before-hone' ($(find "${TARGET}/classes-before-hone" -print | wc -l | xargs) files)"
 

--- a/src/test/java/org/eolang/hone/OptimizeMojoTest.java
+++ b/src/test/java/org/eolang/hone/OptimizeMojoTest.java
@@ -338,6 +338,11 @@ final class OptimizeMojoTest {
             fea.files().file("target/hone/phi-optimized/Hello.phi").exists(),
             Matchers.is(true)
         );
+        MatcherAssert.assertThat(
+            "the backup must hold the classes, not an earlier backup of them (see #881)",
+            fea.files().file("target/classes-before-hone/classes").exists(),
+            Matchers.is(false)
+        );
     }
 
     /**


### PR DESCRIPTION
`cp -R src dst` puts the source inside `dst` when `dst` is already a directory, and nothing removed
the previous backup, so a second `mvn install` without `clean` left
`target/classes-before-hone/classes/...` next to the real one. By then the classes it copied were
the ones hone had already rewritten, so the nested copy was not the "before" state at all, and the
file count the line below prints grew with it.

The previous copy is removed first, so the backup holds the classes and nothing else.

`optimizesTwice` already runs `optimize` twice against the same `target`, which is the case that
produced this, so the check goes there.

Closes #881
