### PR TITLE
#884: stop passing jeo options that do not exist

### DIFF
--- a/src/main/resources/org/eolang/hone/scaffolding/entry.sh
+++ b/src/main/resources/org/eolang/hone/scaffolding/entry.sh
@@ -185,13 +185,13 @@ declare -a assemble_opts=(
   "-Djeo.assemble.xmir.verification=false"
   "-Djeo.assemble.skip.verification=true"
 )
+# Only the disassembly is filtered. The assemble goal has no such parameters,
+# and it does not need them: it takes back what the disassembly left behind.
 if [ -n "${INCLUDES}" ]; then
   disassemble_opts+=("-Djeo.disassemble.includes=${INCLUDES}")
-  assemble_opts+=("-Djeo.assemble.includes=${INCLUDES}")
 fi
 if [ -n "${EXCLUDES}" ]; then
   disassemble_opts+=("-Djeo.disassemble.excludes=${EXCLUDES}")
-  assemble_opts+=("-Djeo.assemble.excludes=${EXCLUDES}")
 fi
 if [ "${SKIP_PHINO}" == 'true' ]; then
   echo "Skipping the phino step as requested"


### PR DESCRIPTION
`jeo.assemble.includes` and `jeo.assemble.excludes` are not parameters of anything. `AssembleMojo`
declares six, and none of them filters:

```
jeo.assemble.sourcesDir
jeo.assemble.outputDir
jeo.assemble.skip.verification
jeo.assemble.xmir.verification
jeo.assemble.disabled
jeo.assemble.debug
```

Maven ignores an unknown `-D` without a word, so the two lines did nothing at all, while reading as
though the assembly were filtered the way the disassembly is.

The filtering happens once, at disassembly, and the assembly takes back whatever that left in the
sources directory. `OptimizeMojoRulesTest` already covers it: with `includes` and `excludes` set,
only the included class comes out optimized.

Closes #884
