### PR TITLE
#885: skip only when there is nothing to run with

### DIFF
--- a/src/main/java/org/eolang/hone/AbstractMojo.java
+++ b/src/main/java/org/eolang/hone/AbstractMojo.java
@@ -98,7 +98,7 @@ abstract class AbstractMojo extends org.apache.maven.plugin.AbstractMojo {
     private boolean skip;
 
     /**
-     * Skip the execution, if Docker is not available.
+     * Skip the execution, if there is no way to run: no Docker and no local phino.
      * @since 0.22.0
      * @checkstyle MemberNameCheck (6 lines)
      */
@@ -118,7 +118,7 @@ abstract class AbstractMojo extends org.apache.maven.plugin.AbstractMojo {
         StaticLoggerBinder.getSingleton().setMavenLog(this.getLog());
         if (this.skip) {
             Logger.info(this, "Execution skipped due to hone.skip=true");
-        } else if (this.skipWithoutDocker && !new Docker(this.sudo).available()) {
+        } else if (this.skipWithoutDocker && this.helpless()) {
             Logger.info(this, "Execution skipped due to hone.skipWithoutDocker=true");
         } else if (this.skipOnWindows && AbstractMojo.windows()) {
             Logger.info(this, "Execution skipped due to hone.skipOnWindows=true");
@@ -164,6 +164,28 @@ abstract class AbstractMojo extends org.apache.maven.plugin.AbstractMojo {
      * @throws IOException If execution fails
      */
     abstract void exec() throws IOException;
+
+    /**
+     * There is nothing to run with: no Docker, and no local phino either.
+     *
+     * <p>Every goal here takes the local {@code phino} when Docker is absent
+     * and the executable is of the version we expect, so the lack of Docker
+     * alone is not a reason to skip anymore.</p>
+     *
+     * @return TRUE if neither way of running is available
+     * @throws MojoExecutionException If the phino version cannot be read
+     */
+    private boolean helpless() throws MojoExecutionException {
+        boolean nothing = !new Docker(this.sudo).available();
+        if (nothing && !this.alwaysWithDocker) {
+            try {
+                nothing = !new Phino().available(this.phino());
+            } catch (final IOException ex) {
+                throw new MojoExecutionException(ex);
+            }
+        }
+        return nothing;
+    }
 
     /**
      * Check if the current operating system is Windows.


### PR DESCRIPTION
`hone.skipWithoutDocker` skipped on the absence of Docker alone, and Docker stopped being the only
way to run. All four goals here take the local `phino` when it is installed and of the expected
version:

```java
BuildMojo:    if (!this.alwaysWithDocker && new Phino().available(this.phino()))
PullMojo:     if (this.alwaysWithDocker || !new Phino().available(this.phino()))
RmiMojo:      if (!this.alwaysWithDocker && new Phino().available(this.phino()))
OptimizeMojo: if (this.alwaysWithDocker || !new Phino().available(this.phino()))
```

So on a machine with `phino` and no Docker the optimization that would have run was skipped, and
the build quietly produced unoptimized bytecode.

The flag now skips only when neither way is there: no Docker, and no usable local `phino`. When
`alwaysWithDocker` is set, `phino` is not consulted, because it would not be used anyway.

About the test. What changed only shows on a machine that has no Docker, and both the CI here and
my own machine have it, so any test I could add would take the same branch it takes today and
prove nothing. The `@DisabledWithoutPhino` tests already cover the path that does the running.
Making this deterministic would mean handing `Docker` and `Phino` to the mojo instead of building
them inside it, which is a larger change than this bug asks for. I would rather say so than write a
test that passes either way.

Closes #885
