### PR TITLE
#882: find every rule and hand them all over

### DIFF
--- a/src/main/resources/org/eolang/hone/scaffolding/entry.sh
+++ b/src/main/resources/org/eolang/hone/scaffolding/entry.sh
@@ -135,7 +135,11 @@ fi
 echo "Using JEO version ${JEO_VERSION}"
 
 if [ -z "${RULES}" ]; then
-  RULES=$(find "${SELF}/rules" -name '*.yml' -exec "${RP}" {} \;)
+  # Both extensions, the way Rules.discover() reads them on the Java side, and
+  # separated by spaces, because rewrite.sh splits this list with "read -a",
+  # which would stop at the first newline:
+  RULES=$(find "${SELF}/rules" \( -name '*.yml' -o -name '*.phr' \) -exec "${RP}" {} \; | sort | tr '\n' ' ')
+  RULES="${RULES% }"
 fi
 for rule in ${RULES}; do
   if [ ! -e "${rule}" ]; then


### PR DESCRIPTION
The fallback list was wrong twice over.

It looked for `*.yml` only, while the rules directory holds 107 `.phr` files and 2 `.yml` ones, and
`Rules.discover()` on the Java side accepts both:

```java
if (!path.endsWith(".phr") && !path.endsWith(".yml")) {
```

And `find` prints one path per line, while `rewrite.sh` splits the list with `read`, which stops at
the first newline, so `phino rewrite` was handed a single `--rule=` whatever the list held:

```
$ RULES=$(find rules \( -name '*.yml' -o -name '*.phr' \) -exec realpath {} \; | sort | tr '\n' ' ')
$ IFS=' ' read -r -a rules <<< "${RULES}"; echo "count=${#rules[@]}"
count=4          # one before this change
```

Both extensions are found now, and the list is separated by spaces the way the `EXTRA` branch a few
lines below already does it with `| sort | tr '\n' ' '`. The trailing space goes, so the count the
script prints stays right.

Closes #882
