### PR TITLE
Upgrade qulice to 0.35.2 and fix all warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -404,7 +404,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.30.13</version>
+            <version>0.35.2</version>
             <configuration>
               <excludes>
                 <!--

--- a/src/main/java/org/eolang/hone/AbstractMojo.java
+++ b/src/main/java/org/eolang/hone/AbstractMojo.java
@@ -7,6 +7,7 @@ package org.eolang.hone;
 import com.jcabi.log.Logger;
 import java.io.File;
 import java.io.IOException;
+import java.util.Locale;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.cactoos.io.ResourceOf;
@@ -30,6 +31,7 @@ abstract class AbstractMojo extends org.apache.maven.plugin.AbstractMojo {
 
     /**
      * The "target/" directory of Maven project.
+     *
      * @since 0.1.0
      */
     @Parameter(
@@ -40,6 +42,7 @@ abstract class AbstractMojo extends org.apache.maven.plugin.AbstractMojo {
 
     /**
      * The base directory of the Maven project.
+     *
      * @since 0.1.0
      */
     @Parameter(
@@ -51,12 +54,14 @@ abstract class AbstractMojo extends org.apache.maven.plugin.AbstractMojo {
 
     /**
      * Timings tracker for performance measurements.
+     *
      * @since 0.1.0
      */
     protected Timings timings;
 
     /**
      * Docker image to use.
+     *
      * @since 0.1.0
      */
     @Parameter(property = "hone.image", defaultValue = "yegor256/hone:latest")
@@ -64,6 +69,7 @@ abstract class AbstractMojo extends org.apache.maven.plugin.AbstractMojo {
 
     /**
      * Whether to use "sudo" when executing Docker commands.
+     *
      * @since 0.1.0
      */
     @Parameter(property = "hone.sudo", defaultValue = "false")
@@ -84,6 +90,7 @@ abstract class AbstractMojo extends org.apache.maven.plugin.AbstractMojo {
 
     /**
      * Phino version to use.
+     *
      * @since 0.21.0
      * @checkstyle MemberNameCheck (6 lines)
      */
@@ -92,6 +99,7 @@ abstract class AbstractMojo extends org.apache.maven.plugin.AbstractMojo {
 
     /**
      * Skip the execution, if set to TRUE.
+     *
      * @since 0.1.0
      */
     @Parameter(property = "hone.skip", defaultValue = "false")
@@ -99,6 +107,7 @@ abstract class AbstractMojo extends org.apache.maven.plugin.AbstractMojo {
 
     /**
      * Skip the execution, if there is no way to run: no Docker and no local phino.
+     *
      * @since 0.22.0
      * @checkstyle MemberNameCheck (6 lines)
      */
@@ -107,6 +116,7 @@ abstract class AbstractMojo extends org.apache.maven.plugin.AbstractMojo {
 
     /**
      * Skip the execution, if it's Windows.
+     *
      * @since 0.23.0
      * @checkstyle MemberNameCheck (6 lines)
      */
@@ -134,6 +144,7 @@ abstract class AbstractMojo extends org.apache.maven.plugin.AbstractMojo {
 
     /**
      * Returns the phino version to use.
+     *
      * @return The phino version
      * @throws IOException If reading the default version fails
      */
@@ -161,19 +172,16 @@ abstract class AbstractMojo extends org.apache.maven.plugin.AbstractMojo {
 
     /**
      * Execute the specific goal implementation.
+     *
      * @throws IOException If execution fails
      */
     abstract void exec() throws IOException;
 
-    /**
+    /*
      * There is nothing to run with: no Docker, and no local phino either.
-     *
-     * <p>Every goal here takes the local {@code phino} when Docker is absent
-     * and the executable is of the version we expect, so the lack of Docker
-     * alone is not a reason to skip anymore.</p>
-     *
-     * @return TRUE if neither way of running is available
-     * @throws MojoExecutionException If the phino version cannot be read
+     * Every goal here takes the local phino when Docker is absent and the
+     * executable is of the version we expect, so the lack of Docker alone
+     * is not a reason to skip anymore.
      */
     private boolean helpless() throws MojoExecutionException {
         boolean nothing = !new Docker(this.sudo).available();
@@ -187,13 +195,9 @@ abstract class AbstractMojo extends org.apache.maven.plugin.AbstractMojo {
         return nothing;
     }
 
-    /**
-     * Check if the current operating system is Windows.
-     * @return True if running on Windows
-     */
     private static boolean windows() {
         return System.getProperty("os.name")
-            .toLowerCase(java.util.Locale.ENGLISH)
+            .toLowerCase(Locale.ENGLISH)
             .startsWith("win");
     }
 }

--- a/src/main/java/org/eolang/hone/BuildMojo.java
+++ b/src/main/java/org/eolang/hone/BuildMojo.java
@@ -40,6 +40,7 @@ public final class BuildMojo extends AbstractMojo {
 
     /**
      * Shall we use buildx?
+     *
      * @since 0.8.0
      * @checkstyle MemberNameCheck (6 lines)
      */
@@ -48,6 +49,7 @@ public final class BuildMojo extends AbstractMojo {
 
     /**
      * JEO version to use.
+     *
      * @since 0.20.0
      * @checkstyle MemberNameCheck (6 lines)
      */
@@ -118,12 +120,6 @@ public final class BuildMojo extends AbstractMojo {
         }
     }
 
-    /**
-     * Get the JEO version to use.
-     * If not set, read it from the default resource file.
-     * @return JEO version
-     * @throws IOException If reading the version fails
-     */
     private String jeo() throws IOException {
         String ver = this.jeoVersion;
         if (ver == null) {

--- a/src/main/java/org/eolang/hone/CSV.java
+++ b/src/main/java/org/eolang/hone/CSV.java
@@ -28,6 +28,7 @@ import org.cactoos.list.ListOf;
 
 /**
  * CSV summary .
+ *
  * @since 0.1.0
  * @checkstyle AbbreviationAsWordInNameCheck (3 lines)
  */
@@ -45,6 +46,7 @@ public final class CSV {
 
     /**
      * Constructor.
+     *
      * @param root CSV file path
      */
     CSV(final Path root) {
@@ -53,6 +55,7 @@ public final class CSV {
 
     /**
      * Constructor.
+     *
      * @param other The CSV to copy fields from
      */
     private CSV(final CSV other) {
@@ -61,6 +64,7 @@ public final class CSV {
 
     /**
      * Constructor.
+     *
      * @param headers CSV headers
      * @param records CSV records
      */
@@ -74,6 +78,7 @@ public final class CSV {
 
     /**
      * Combines this CSV with another CSV, concatenating their records.
+     *
      * @param other The other CSV to combine with this one
      * @return A new CSV instance containing the combined records of both CSVs
      */
@@ -98,6 +103,7 @@ public final class CSV {
 
     /**
      * Number of records in the CSV.
+     *
      * @return The number of records in the CSV
      */
     int size() {
@@ -106,6 +112,7 @@ public final class CSV {
 
     /**
      * Counts rows where a column value matches the given condition.
+     *
      * @param header The column name to check
      * @param condition Predicate applied to the column value
      * @return Number of matching rows
@@ -134,6 +141,7 @@ public final class CSV {
 
     /**
      * Flushes the CSV content to the specified file path.
+     *
      * @param res The path to the file where the CSV content should be written
      */
     void flush(final Path res) {
@@ -158,6 +166,7 @@ public final class CSV {
 
     /**
      * Whether a cell, parsed as a positive integer, is greater than zero.
+     *
      * @param value The cell content
      * @return TRUE when the integer value is greater than zero
      */
@@ -201,13 +210,6 @@ public final class CSV {
         }
     }
 
-    /**
-     * Whether a row matches under the condition, tolerating a missing cell.
-     * @param row The CSV record
-     * @param header The column name
-     * @param condition The predicate on the cell value
-     * @return TRUE when the cell is present and the condition holds
-     */
     private static boolean test(
         final Map<String, String> row,
         final String header,

--- a/src/main/java/org/eolang/hone/Collector.java
+++ b/src/main/java/org/eolang/hone/Collector.java
@@ -1,0 +1,80 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.hone;
+
+import com.jcabi.log.Logger;
+import java.io.IOException;
+import java.nio.file.FileSystemLoopException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.List;
+
+/**
+ * A file visitor that gathers statistics files, following symlinks.
+ *
+ * @since 0.1.0
+ */
+final class Collector extends SimpleFileVisitor<Path> {
+
+    /**
+     * Where to put the found CSVs.
+     */
+    private final List<CSV> found;
+
+    /**
+     * The statistics file name to look for.
+     */
+    private final String stats;
+
+    /**
+     * The summary output, excluded from the walk.
+     */
+    private final Path output;
+
+    /**
+     * Ctor.
+     *
+     * @param found Where to put the found CSVs
+     * @param stats The statistics file name to look for
+     * @param output The summary output to exclude
+     */
+    Collector(final List<CSV> found, final String stats, final Path output) {
+        this.found = found;
+        this.stats = stats;
+        this.output = output;
+    }
+
+    @Override
+    public FileVisitResult visitFile(
+        final Path file, final BasicFileAttributes attrs
+    ) {
+        if (this.stats.equals(file.getFileName().toString())
+            && !Collector.same(this.output, file)) {
+            this.found.add(new CSV(file));
+        }
+        return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public FileVisitResult visitFileFailed(
+        final Path file, final IOException exc
+    ) {
+        if (exc instanceof FileSystemLoopException) {
+            Logger.warn(
+                this,
+                "Symlink cycle detected at %s, skipping",
+                file
+            );
+        }
+        return FileVisitResult.CONTINUE;
+    }
+
+    private static boolean same(final Path first, final Path second) {
+        return first.toAbsolutePath().normalize()
+            .equals(second.toAbsolutePath().normalize());
+    }
+}

--- a/src/main/java/org/eolang/hone/Docker.java
+++ b/src/main/java/org/eolang/hone/Docker.java
@@ -47,6 +47,7 @@ final class Docker {
 
     /**
      * Creates a Docker executor with optional sudo.
+     *
      * @param root Whether to run Docker commands with sudo
      */
     Docker(final boolean root) {
@@ -55,6 +56,7 @@ final class Docker {
 
     /**
      * Execute a Docker command with the given arguments.
+     *
      * @param args Docker command arguments
      * @return Exit code (always 0 on success)
      * @throws IOException If the command fails or returns non-zero exit code
@@ -65,6 +67,7 @@ final class Docker {
 
     /**
      * Docker executable is available?
+     *
      * @return TRUE if Docker is here
      */
     boolean available() {
@@ -80,6 +83,7 @@ final class Docker {
 
     /**
      * Execute a Docker command with the given arguments.
+     *
      * @param args Docker command arguments as a collection
      * @return Exit code (always 0 on success)
      * @throws IOException If the command fails or returns non-zero exit code
@@ -94,12 +98,6 @@ final class Docker {
         return this.fire(command);
     }
 
-    /**
-     * Execute the assembled command and handle the process.
-     * @param command Complete command with all arguments
-     * @return Exit code (always 0 on success)
-     * @throws IOException If the command fails or returns non-zero exit code
-     */
     private int fire(final List<String> command) throws IOException {
         final long start = System.currentTimeMillis();
         Logger.info(this, "+ %s ...", String.join(" ", command));

--- a/src/main/java/org/eolang/hone/Greppable.java
+++ b/src/main/java/org/eolang/hone/Greppable.java
@@ -33,6 +33,7 @@ final class Greppable {
 
     /**
      * Ctor.
+     *
      * @param names Method names to match
      */
     Greppable(final String... names) {
@@ -48,12 +49,10 @@ final class Greppable {
         return String.format(">(%s)<", String.join("|", hexes));
     }
 
-    /**
-     * Convert a string to a dash-separated sequence of upper-case hex byte
-     * values, matching the way jeo encodes a string literal inside a
-     * {@code .xmir} file (for example, {@code "map"} becomes {@code "6D-61-70"}).
-     * @param text The string to convert
-     * @return Hex-byte representation, dash-separated
+    /*
+     * A dash-separated sequence of upper-case hex byte values, matching the
+     * way jeo encodes a string literal inside a .xmir file: "map" becomes
+     * "6D-61-70".
      */
     private static String hex(final String text) {
         final byte[] bytes = text.getBytes(StandardCharsets.UTF_8);

--- a/src/main/java/org/eolang/hone/Mktemp.java
+++ b/src/main/java/org/eolang/hone/Mktemp.java
@@ -30,6 +30,7 @@ final class Mktemp implements Closeable {
 
     /**
      * Creates a new temporary directory.
+     *
      * @throws IOException If directory creation fails
      * @checkstyle ConstructorsCodeFreeCheck (3 lines)
      */
@@ -49,6 +50,7 @@ final class Mktemp implements Closeable {
 
     /**
      * Get the path to the temporary directory.
+     *
      * @return Path of the temporary directory
      */
     Path path() {

--- a/src/main/java/org/eolang/hone/OptimizeMojo.java
+++ b/src/main/java/org/eolang/hone/OptimizeMojo.java
@@ -114,6 +114,7 @@ public final class OptimizeMojo extends AbstractMojo {
     /**
      * Location of {@code .class} files to optimize inside
      * the {@code target} directory.
+     *
      * @since 0.8.0
      */
     @Parameter(property = "hone.classes", defaultValue = "classes")
@@ -142,6 +143,7 @@ public final class OptimizeMojo extends AbstractMojo {
     /**
      * List of extra rules to use for optimization, provided as
      * YAML files.
+     *
      * @since 0.1.0
      */
     @Parameter(property = "hone.extra")
@@ -149,6 +151,7 @@ public final class OptimizeMojo extends AbstractMojo {
 
     /**
      * EO version to use.
+     *
      * @since 0.1.0
      * @checkstyle MemberNameCheck (6 lines)
      */
@@ -191,6 +194,7 @@ public final class OptimizeMojo extends AbstractMojo {
 
     /**
      * Skip if no .class files found.
+     *
      * @since 0.16.0
      * @checkstyle MemberNameCheck (6 lines)
      */
@@ -291,6 +295,7 @@ public final class OptimizeMojo extends AbstractMojo {
 
     /**
      * The list of all file extensions for the extra rules.
+     *
      * @since 0.5.0
      * @checkstyle MemberNameCheck (6 lines)
      */
@@ -325,6 +330,7 @@ public final class OptimizeMojo extends AbstractMojo {
 
     /**
      * JEO version to use.
+     *
      * @since 0.1.0
      * @checkstyle MemberNameCheck (6 lines)
      */
@@ -333,6 +339,7 @@ public final class OptimizeMojo extends AbstractMojo {
 
     /**
      * EO cache directory.
+     *
      * @since 0.1.0
      */
     @Parameter(property = "hone.cache", defaultValue = "${user.home}/.eo")
@@ -361,6 +368,7 @@ public final class OptimizeMojo extends AbstractMojo {
 
     /**
      * Return the user and group IDs of the current user, using the given C library.
+     *
      * @param lib The C library to query for the IDs
      * @return A string in the format "uid:gid"
      */
@@ -375,6 +383,7 @@ public final class OptimizeMojo extends AbstractMojo {
     /**
      * Build a {@code host:container} bind mount for Docker, rejecting paths
      * that Docker would misparse (Windows drive letters contain a colon).
+     *
      * @param host The host path
      * @param container The container path
      * @return The bind-mount string
@@ -395,6 +404,7 @@ public final class OptimizeMojo extends AbstractMojo {
     /**
      * Rewrite the {@code /target} (or {@code \target}) prefixes to the real
      * local path, tolerating backslash separators.
+     *
      * @param target The local target directory
      * @param paths The includes/excludes patterns
      * @return The joined, rewritten patterns
@@ -412,10 +422,6 @@ public final class OptimizeMojo extends AbstractMojo {
         );
     }
 
-    /**
-     * Check if the classes directory is absent or doesn't have classes.
-     * @return True if there are no class files, false otherwise
-     */
     private boolean withoutClasses() {
         final Path dir = this.target.toPath().resolve(this.classes);
         final boolean exists = dir.toFile().exists();
@@ -663,10 +669,6 @@ public final class OptimizeMojo extends AbstractMojo {
         }
     }
 
-    /**
-     * Return the user and group IDs of the current user.
-     * @return A string in the format "uid:gid"
-     */
     private static String whoami() {
         return OptimizeMojo.whoami(OptimizeMojo.CLibrary.INSTANCE);
     }
@@ -749,12 +751,6 @@ public final class OptimizeMojo extends AbstractMojo {
         }
     }
 
-    /**
-     * Get the JEO version to use.
-     * If not set, read it from the default resource file.
-     * @return JEO version
-     * @throws IOException If reading the version fails
-     */
     private String jeo() throws IOException {
         String ver = this.jeoVersion;
         if (ver == null) {
@@ -789,18 +785,21 @@ public final class OptimizeMojo extends AbstractMojo {
 
         /**
          * Get the user ID of the calling process.
+         *
          * @return The user ID
          */
         int getuid();
 
         /**
          * Get the effective user ID of the calling process.
+         *
          * @return The effective user ID
          */
         int geteuid();
 
         /**
          * Get the group ID of the calling process.
+         *
          * @return The group ID
          */
         int getgid();

--- a/src/main/java/org/eolang/hone/Phino.java
+++ b/src/main/java/org/eolang/hone/Phino.java
@@ -13,6 +13,7 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * An abstraction of Phino in command line.
+ *
  * @since 0.17.0
  */
 final class Phino {
@@ -31,6 +32,7 @@ final class Phino {
 
     /**
      * Ctor.
+     *
      * @param executable The executable to run, instead of "phino"
      */
     Phino(final String executable) {
@@ -39,6 +41,7 @@ final class Phino {
 
     /**
      * Is it available?
+     *
      * @param expected This is the expected version
      * @return TRUE if available
      */
@@ -76,11 +79,6 @@ final class Phino {
         return available;
     }
 
-    /**
-     * Drain a process stdout into a buffer, byte by byte.
-     * @param stdout Where to collect the output
-     * @param input The input stream to drain
-     */
     private static void pump(final ByteArrayOutputStream stdout, final InputStream input) {
         try {
             final byte[] buffer = new byte[1024];
@@ -96,14 +94,6 @@ final class Phino {
         }
     }
 
-    /**
-     * Decide whether the probed phino is the expected one.
-     * @param proc The probed process
-     * @param stdout Collected version output
-     * @param expected The version we need
-     * @param self Logger target
-     * @return TRUE if the versions match
-     */
     private static boolean version(
         final Process proc, final ByteArrayOutputStream stdout,
         final String expected, final Phino self

--- a/src/main/java/org/eolang/hone/Rules.java
+++ b/src/main/java/org/eolang/hone/Rules.java
@@ -64,6 +64,7 @@ final class Rules {
 
     /**
      * Creates a rule manager with specific patterns.
+     *
      * @param ptns Comma-separated patterns (e.g., "simple,b*,!abc")
      * @checkstyle ConstructorsCodeFreeCheck (3 lines)
      */
@@ -115,6 +116,7 @@ final class Rules {
 
     /**
      * Copy all matching rule files to the specified directory.
+     *
      * @param dir Destination directory where rule files will be copied
      * @throws IOException If copying files fails
      */
@@ -140,11 +142,6 @@ final class Rules {
         }
     }
 
-    /**
-     * Check if a rule name matches the configured patterns.
-     * @param name The name of the rule, e.g. "thirty-three"
-     * @return TRUE if the rule matches and should be included
-     */
     private boolean matches(final CharSequence name) {
         boolean matches = false;
         for (final Map.Entry<Pattern, Boolean> ent : this.patterns.entrySet()) {
@@ -160,11 +157,6 @@ final class Rules {
         return matches;
     }
 
-    /**
-     * Convert pattern strings to compiled regular expressions.
-     * @param ptns Comma-separated pattern strings with optional negation
-     * @return Map of compiled patterns to inclusion flags
-     */
     private static Map<Pattern, Boolean> regexs(final String ptns) {
         final Map<Pattern, Boolean> list = new HashMap<>(0);
         Rules.SEPARATOR.splitAsStream(ptns).filter(ptn -> !ptn.isEmpty()).forEach(
@@ -190,10 +182,6 @@ final class Rules {
         return list;
     }
 
-    /**
-     * Discover all available rules from the classpath.
-     * @return Array of rule names discovered from classpath resources
-     */
     private static String[] discover() {
         final List<String> names = new ArrayList<>(0);
         try (

--- a/src/main/java/org/eolang/hone/Summary.java
+++ b/src/main/java/org/eolang/hone/Summary.java
@@ -4,15 +4,10 @@
  */
 package org.eolang.hone;
 
-import com.jcabi.log.Logger;
 import java.io.IOException;
-import java.nio.file.FileSystemLoopException;
 import java.nio.file.FileVisitOption;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
@@ -20,6 +15,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Build summary statistics.
+ *
  * @since 0.1.0
  */
 public final class Summary {
@@ -36,6 +32,7 @@ public final class Summary {
 
     /**
      * Constructor.
+     *
      * @param root Root directory to search for statistics
      */
     Summary(final Path root) {
@@ -44,6 +41,7 @@ public final class Summary {
 
     /**
      * Constructor.
+     *
      * @param root Root directory to search for statistics
      * @param target Directory to save the summary report
      */
@@ -54,6 +52,7 @@ public final class Summary {
 
     /**
      * Collects summary statistics from all child modules.
+     *
      * @return The path to the generated summary report
      */
     Path collect() {
@@ -65,7 +64,7 @@ public final class Summary {
                 this.root,
                 EnumSet.of(FileVisitOption.FOLLOW_LINKS),
                 Integer.MAX_VALUE,
-                new Summary.Collector(found, stats, destination)
+                new Collector(found, stats, destination)
             );
         } catch (final IOException exception) {
             throw new IllegalStateException(
@@ -90,79 +89,5 @@ public final class Summary {
             "ID",
             ignore -> String.format("%d/%d", index.getAndIncrement(), res.size())
         );
-    }
-
-    /**
-     * Whether two paths point to the same file.
-     * @param first First path
-     * @param second Second path
-     * @return TRUE when both resolve to the same normalized absolute path
-     */
-    private static boolean same(final Path first, final Path second) {
-        return first.toAbsolutePath().normalize()
-            .equals(second.toAbsolutePath().normalize());
-    }
-
-    /**
-     * A file visitor that gathers statistics files, following symlinks.
-     * @since 0.1.0
-     */
-    private static final class Collector extends SimpleFileVisitor<Path> {
-
-        /**
-         * Where to put the found CSVs.
-         */
-        private final List<CSV> found;
-
-        /**
-         * The statistics file name to look for.
-         */
-        private final String stats;
-
-        /**
-         * The summary output, excluded from the walk.
-         */
-        private final Path output;
-
-        /**
-         * Ctor.
-         * @param found Where to put the found CSVs
-         * @param stats The statistics file name to look for
-         * @param output The summary output to exclude
-         */
-        Collector(
-            final List<CSV> found,
-            final String stats,
-            final Path output
-        ) {
-            this.found = found;
-            this.stats = stats;
-            this.output = output;
-        }
-
-        @Override
-        public FileVisitResult visitFile(
-            final Path file, final BasicFileAttributes attrs
-        ) {
-            if (this.stats.equals(file.getFileName().toString())
-                && !Summary.same(this.output, file)) {
-                this.found.add(new CSV(file));
-            }
-            return FileVisitResult.CONTINUE;
-        }
-
-        @Override
-        public FileVisitResult visitFileFailed(
-            final Path file, final IOException exc
-        ) {
-            if (exc instanceof FileSystemLoopException) {
-                Logger.warn(
-                    this,
-                    "Symlink cycle detected at %s, skipping",
-                    file
-                );
-            }
-            return FileVisitResult.CONTINUE;
-        }
     }
 }

--- a/src/main/java/org/eolang/hone/Timings.java
+++ b/src/main/java/org/eolang/hone/Timings.java
@@ -31,6 +31,7 @@ final class Timings {
 
     /**
      * Creates a new timings recorder.
+     *
      * @param file Path to the CSV file where timings will be recorded
      */
     Timings(final Path file) {
@@ -39,6 +40,7 @@ final class Timings {
 
     /**
      * Executes an action and records its execution time.
+     *
      * @param name Name of the action being timed
      * @param action The action to execute and measure
      * @throws IOException If recording the timing fails
@@ -64,6 +66,7 @@ final class Timings {
 
     /**
      * Functional interface for actions that can be timed.
+     *
      * @since 0.1.0
      */
     @FunctionalInterface
@@ -71,6 +74,7 @@ final class Timings {
 
         /**
          * Execute the action.
+         *
          * @throws IOException If execution fails
          */
         void exec() throws IOException;

--- a/src/main/java/org/eolang/hone/package-info.java
+++ b/src/main/java/org/eolang/hone/package-info.java
@@ -4,6 +4,7 @@
  */
 /**
  * The main classes of the hone-maven-plugin.
+ *
  * @since 0.1.0
  */
 package org.eolang.hone;

--- a/src/test/java/org/eolang/hone/AbstractMojoTest.java
+++ b/src/test/java/org/eolang/hone/AbstractMojoTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link AbstractMojo}.
+ *
  * @since 0.1.0
  */
 final class AbstractMojoTest {
@@ -36,6 +37,7 @@ final class AbstractMojoTest {
 
     /**
      * Fake implementation of AbstractMojo for testing.
+     *
      * @since 0.1.0
      */
     private static final class FakeAbstractMojo extends AbstractMojo {

--- a/src/test/java/org/eolang/hone/BuildMojoTest.java
+++ b/src/test/java/org/eolang/hone/BuildMojoTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 
 /**
  * Test case for {@link BuildMojo}.
+ *
  * @since 0.1.0
  */
 @Execution(ExecutionMode.SAME_THREAD)

--- a/src/test/java/org/eolang/hone/CSVTest.java
+++ b/src/test/java/org/eolang/hone/CSVTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for {@link CSV}.
+ *
  * @since 0.1.0
  * @checkstyle AbbreviationAsWordInNameCheck (3 lines)
  */

--- a/src/test/java/org/eolang/hone/ClassOpcodes.java
+++ b/src/test/java/org/eolang/hone/ClassOpcodes.java
@@ -41,6 +41,7 @@ final class ClassOpcodes {
 
     /**
      * Ctor.
+     *
      * @param src Path to the {@code .class} file to inspect
      */
     ClassOpcodes(final Path src) {
@@ -49,6 +50,7 @@ final class ClassOpcodes {
 
     /**
      * Count opcodes used inside the class.
+     *
      * @return Map from lowercase JVM mnemonic to its number of occurrences
      * @throws IOException If the file cannot be read
      */

--- a/src/test/java/org/eolang/hone/DisabledWithoutDocker.java
+++ b/src/test/java/org/eolang/hone/DisabledWithoutDocker.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 /**
  * This annotation disables JUnit tests when Docker is
  * not runnable in command line.
+ *
  * @since 0.1.0
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })

--- a/src/test/java/org/eolang/hone/DisabledWithoutDockerCondition.java
+++ b/src/test/java/org/eolang/hone/DisabledWithoutDockerCondition.java
@@ -12,9 +12,17 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 /**
  * This annotation disables JUnit tests when Docker is
  * not runnable in command line.
+ *
  * @since 0.1.0
  */
 public final class DisabledWithoutDockerCondition implements ExecutionCondition {
+
+    /**
+     * Public ctor, for JUnit to call reflectively.
+     */
+    public DisabledWithoutDockerCondition() {
+        // nothing to initialize
+    }
 
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(final ExtensionContext ctx) {

--- a/src/test/java/org/eolang/hone/DisabledWithoutPhino.java
+++ b/src/test/java/org/eolang/hone/DisabledWithoutPhino.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 /**
  * This annotation disables JUnit tests when phino is
  * not runnable in command line.
+ *
  * @since 0.1.0
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })

--- a/src/test/java/org/eolang/hone/DisabledWithoutPhinoCondition.java
+++ b/src/test/java/org/eolang/hone/DisabledWithoutPhinoCondition.java
@@ -15,9 +15,17 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 /**
  * This annotation disables JUnit tests when phino is
  * not runnable in command line.
+ *
  * @since 0.1.0
  */
 public final class DisabledWithoutPhinoCondition implements ExecutionCondition {
+
+    /**
+     * Public ctor, for JUnit to call reflectively.
+     */
+    public DisabledWithoutPhinoCondition() {
+        // nothing to initialize
+    }
 
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(final ExtensionContext ctx) {

--- a/src/test/java/org/eolang/hone/DockerTest.java
+++ b/src/test/java/org/eolang/hone/DockerTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for {@link Docker}.
+ *
  * @since 0.1.0
  */
 @ExtendWith(RandomImageResolver.class)

--- a/src/test/java/org/eolang/hone/Grammar.java
+++ b/src/test/java/org/eolang/hone/Grammar.java
@@ -432,6 +432,7 @@ final class Grammar {
 
     /**
      * Ctor.
+     *
      * @param table The productions, indexed by domain and role
      */
     private Grammar(final Map<String, List<String>> table) {
@@ -440,6 +441,7 @@ final class Grammar {
 
     /**
      * One domain to start a pipeline in.
+     *
      * @param rnd The source of randomness
      * @return The domain, as the grammar names it
      */
@@ -449,6 +451,7 @@ final class Grammar {
 
     /**
      * Every fragment the grammar can reach, whatever domain it belongs to.
+     *
      * @return The fragments, as they are written in the grammar
      */
     List<String> fragments() {
@@ -461,6 +464,7 @@ final class Grammar {
 
     /**
      * One fragment of the given domain and role.
+     *
      * @param domain The element domain the pipeline is in
      * @param role What the fragment must be: a source, a stage, a turn, a peek
      * @param rnd The source of randomness
@@ -502,6 +506,7 @@ final class Grammar {
 
     /**
      * The Java code of one line of a walk.
+     *
      * @param line The line, as {@code domain|role|fragment}
      * @return What the pipeline appends for it
      */
@@ -511,6 +516,7 @@ final class Grammar {
 
     /**
      * The Java code of a fragment, without the marks the grammar wraps it in.
+     *
      * @param production The fragment, as it is written in the grammar
      * @return What the walk appends to a pipeline when it picks this fragment
      */
@@ -526,10 +532,6 @@ final class Grammar {
         return code;
     }
 
-    /**
-     * The productions, indexed by domain and role.
-     * @return Map from {@code domain|role} to the fragments it allows
-     */
     private static Map<String, List<String>> indexed() {
         final Map<String, List<String>> table = new HashMap<>();
         for (final String line : Grammar.LINES) {

--- a/src/test/java/org/eolang/hone/GreppableTest.java
+++ b/src/test/java/org/eolang/hone/GreppableTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Greppable}.
+ *
  * @since 0.27.2
  */
 final class GreppableTest {

--- a/src/test/java/org/eolang/hone/MktempTest.java
+++ b/src/test/java/org/eolang/hone/MktempTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Mktemp}.
+ *
  * @since 0.1.0
  */
 final class MktempTest {

--- a/src/test/java/org/eolang/hone/OptimizeMojoDefaultGrepInTest.java
+++ b/src/test/java/org/eolang/hone/OptimizeMojoDefaultGrepInTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 /**
  * Test case for {@link OptimizeMojo}, against its default {@code grep-in}
  * pre-filter pattern and the {@code rewrite.sh} scaffolding script.
+ *
  * @since 0.1.0
  */
 @Execution(ExecutionMode.SAME_THREAD)
@@ -218,15 +219,11 @@ final class OptimizeMojoDefaultGrepInTest {
         );
     }
 
-    /**
-     * Runs the default {@code grep-in} pattern through the very tool that
-     * consumes it in {@code rewrite.sh} ({@code grep -E}), so the pattern's
-     * dialect is validated against its real consumer rather than against
-     * {@link java.util.regex.Pattern} (see #671).
-     * @param dir Temporary directory to hold the sample file
-     * @param content The line of XMIR to grep through
-     * @return TRUE if {@code grep -E} finds a match
-     * @throws IOException If the sample file cannot be written
+    /*
+     * Runs the default grep-in pattern through the very tool that consumes it
+     * in rewrite.sh (grep -E), so the pattern's dialect is validated against
+     * its real consumer rather than against java.util.regex.Pattern
+     * (see #671).
      */
     private static boolean grepInMatches(final Path dir, final String content)
         throws IOException {
@@ -237,14 +234,10 @@ final class OptimizeMojoDefaultGrepInTest {
         ).withCheck(false).execUnsafe().code() == 0;
     }
 
-    /**
-     * Run the {@code grep_in_check} sub-command of the real
-     * {@code rewrite.sh} against a sample XMIR and return its exit code.
-     * @param dir Temporary directory for the script and the sample file
-     * @param pattern The pattern to verify
-     * @return The exit code of {@code grep_in_check}: 0 = match,
-     *  1 = no match, 2 = invalid pattern
-     * @throws IOException If the script or the sample file cannot be written
+    /*
+     * Runs the grep_in_check sub-command of the real rewrite.sh against a
+     * sample XMIR and returns its exit code: 0 = match, 1 = no match,
+     * 2 = invalid pattern.
      */
     private static int grepInCode(final Path dir, final String pattern)
         throws IOException {

--- a/src/test/java/org/eolang/hone/OptimizeMojoRulesTest.java
+++ b/src/test/java/org/eolang/hone/OptimizeMojoRulesTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 /**
  * Test case for {@link OptimizeMojo}, against extra optimization rules,
  * includes/excludes, and small-steps modes.
+ *
  * @since 0.1.0
  */
 @Execution(ExecutionMode.SAME_THREAD)
@@ -100,14 +101,6 @@ final class OptimizeMojoRulesTest {
         );
     }
 
-    /**
-     * Body of {@link #optimizesJustOneLargeJnaClass}.
-     * @param fea Fake Maven project
-     * @param path Path of the .class resource, relative to the project
-     * @param bin Path of the .class resource on disk
-     * @param image Docker image tag
-     * @throws IOException If the build fails to run
-     */
     private static void runOneLargeJnaClass(final Farea fea, final String path,
         final Path bin, final String image) throws IOException {
         fea.clean();
@@ -189,12 +182,6 @@ final class OptimizeMojoRulesTest {
         );
     }
 
-    /**
-     * Body of {@link #optimizesWithIncludesAndExcludes}.
-     * @param fea Fake Maven project
-     * @param image Docker image tag
-     * @throws IOException If the build fails to run
-     */
     private static void runIncludesAndExcludes(final Farea fea, final String image)
         throws IOException {
         fea.clean();
@@ -260,12 +247,6 @@ final class OptimizeMojoRulesTest {
         );
     }
 
-    /**
-     * Body of {@link #optimizesWithExtraRules}.
-     * @param fea Fake Maven project
-     * @param image Docker image tag
-     * @throws IOException If the build fails to run
-     */
     private static void runExtraRules(final Farea fea, final String image) throws IOException {
         fea.clean();
         fea.files()
@@ -359,12 +340,6 @@ final class OptimizeMojoRulesTest {
         );
     }
 
-    /**
-     * Body of {@link #optimizesWithSmallSteps}.
-     * @param fea Fake Maven project
-     * @param image Docker image tag
-     * @throws IOException If the build fails to run
-     */
     private static void runSmallSteps(final Farea fea, final String image) throws IOException {
         fea.clean();
         fea.files()
@@ -457,12 +432,6 @@ final class OptimizeMojoRulesTest {
         );
     }
 
-    /**
-     * Body of {@link #optimizesWithSmallConsecutiveSteps}.
-     * @param fea Fake Maven project
-     * @param image Docker image tag
-     * @throws IOException If the build fails to run
-     */
     private static void runSmallConsecutiveSteps(final Farea fea, final String image)
         throws IOException {
         fea.clean();

--- a/src/test/java/org/eolang/hone/OptimizeMojoStatisticsTest.java
+++ b/src/test/java/org/eolang/hone/OptimizeMojoStatisticsTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 
 /**
  * Test case for {@link OptimizeMojo}, against the statistics CSV it writes.
+ *
  * @since 0.1.0
  */
 @Execution(ExecutionMode.SAME_THREAD)
@@ -53,11 +54,6 @@ final class OptimizeMojoStatisticsTest {
         new Farea(home).together(f -> OptimizeMojoStatisticsTest.runWithDocker(f, image));
     }
 
-    /**
-     * Body of {@link #generatesStatisticsWithoutDocker}.
-     * @param fea Fake Maven project
-     * @throws IOException If the build fails to run
-     */
     private static void runWithoutDocker(final Farea fea) throws IOException {
         fea.clean();
         fea.files()
@@ -128,12 +124,6 @@ final class OptimizeMojoStatisticsTest {
         );
     }
 
-    /**
-     * Body of {@link #generatesStatisticsWithDocker}.
-     * @param fea Fake Maven project
-     * @param image Docker image tag
-     * @throws IOException If the build fails to run
-     */
     private static void runWithDocker(final Farea fea, final String image) throws IOException {
         fea.clean();
         fea.files()

--- a/src/test/java/org/eolang/hone/OptimizeMojoTest.java
+++ b/src/test/java/org/eolang/hone/OptimizeMojoTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 
 /**
  * Test case for {@link OptimizeMojo}.
+ *
  * @since 0.1.0
  */
 @Execution(ExecutionMode.SAME_THREAD)
@@ -165,11 +166,6 @@ final class OptimizeMojoTest {
         );
     }
 
-    /**
-     * Body of {@link #doesNothingWhenNoClasses}.
-     * @param fea Fake Maven project
-     * @throws IOException If the build fails to run
-     */
     private static void runWithoutClasses(final Farea fea) throws IOException {
         fea.clean();
         fea.build()
@@ -194,12 +190,6 @@ final class OptimizeMojoTest {
         );
     }
 
-    /**
-     * Body of {@link #transformsSimpleAppWithoutPhino}.
-     * @param fea Fake Maven project
-     * @param image Docker image tag
-     * @throws IOException If the build fails to run
-     */
     private static void runWithoutPhino(final Farea fea, final String image) throws IOException {
         fea.clean();
         fea.files()
@@ -249,12 +239,6 @@ final class OptimizeMojoTest {
         );
     }
 
-    /**
-     * Body of {@link #optimizesExecutableJavaApp}.
-     * @param fea Fake Maven project
-     * @param image Docker image tag
-     * @throws IOException If the build fails to run
-     */
     private static void runExecutableApp(final Farea fea, final String image) throws IOException {
         fea.clean();
         fea.files()
@@ -293,12 +277,6 @@ final class OptimizeMojoTest {
         );
     }
 
-    /**
-     * Body of {@link #optimizesTwice}.
-     * @param fea Fake Maven project
-     * @param image Docker image tag
-     * @throws IOException If the build fails to run
-     */
     private static void runTwice(final Farea fea, final String image) throws IOException {
         fea.clean();
         fea.files()
@@ -345,11 +323,6 @@ final class OptimizeMojoTest {
         );
     }
 
-    /**
-     * Body of {@link #optimizesSimpleAppWithoutDocker}.
-     * @param fea Fake Maven project
-     * @throws IOException If the build fails to run
-     */
     private static void runSimpleAppWithoutDocker(final Farea fea) throws IOException {
         fea.clean();
         fea.files()
@@ -398,12 +371,6 @@ final class OptimizeMojoTest {
         );
     }
 
-    /**
-     * Body of {@link #optimizesSimpleApp}.
-     * @param fea Fake Maven project
-     * @param image Docker image tag
-     * @throws IOException If the build fails to run
-     */
     private static void runSimpleApp(final Farea fea, final String image) throws IOException {
         fea.clean();
         fea.files()

--- a/src/test/java/org/eolang/hone/OptimizeMojoWhoamiTest.java
+++ b/src/test/java/org/eolang/hone/OptimizeMojoWhoamiTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link OptimizeMojo#whoami}.
+ *
  * @since 0.6.0
  */
 @SuppressWarnings("JTCOP.RuleEveryTestHasProductionClass")
@@ -30,6 +31,7 @@ final class OptimizeMojoWhoamiTest {
      * Fixed-value stub of {@link OptimizeMojo.CLibrary} that returns
      * distinct values for uid, euid, and gid so callers can be checked
      * for picking up the right one.
+     *
      * @since 0.6.0
      */
     private static final class FakeCLibrary implements OptimizeMojo.CLibrary {
@@ -51,6 +53,7 @@ final class OptimizeMojoWhoamiTest {
 
         /**
          * Ctor.
+         *
          * @param ruid Real user ID
          * @param reuid Effective user ID
          * @param rgid Group ID

--- a/src/test/java/org/eolang/hone/OptimizeMojoYamlPackTest.java
+++ b/src/test/java/org/eolang/hone/OptimizeMojoYamlPackTest.java
@@ -38,6 +38,7 @@ import org.yaml.snakeyaml.Yaml;
 /**
  * Test case for {@link OptimizeMojo}, against YAML packs of
  * {@code before}/{@code after} bytecode expectations.
+ *
  * @since 0.1.0
  */
 @Execution(ExecutionMode.SAME_THREAD)
@@ -168,6 +169,7 @@ final class OptimizeMojoYamlPackTest {
     /**
      * Source method for {@link #appliesPhinoRulesAsSpecifiedInYamlPack}.
      * Walks {@code src/test/phino/} and yields every {@code .yml} pack.
+     *
      * @return Stream of YAML pack paths in alphabetical order
      * @throws IOException If the directory cannot be listed
      */
@@ -187,18 +189,6 @@ final class OptimizeMojoYamlPackTest {
         return packs.stream();
     }
 
-    /**
-     * Body of {@link #optimizesAsSpecifiedInYamlPack}.
-     * @param fea Fake Maven project
-     * @param path Path of the Java source file to write, relative to the project
-     * @param code Java source of the class under test
-     * @param pack The full YAML pack, for its optional and expectation fields
-     * @param image Docker image tag
-     * @param slashed The pack's package name, with dots replaced by slashes
-     * @param klass The pack's class name
-     * @param pkgname The pack's package name
-     * @throws IOException If the build fails to run
-     */
     @SuppressWarnings("unchecked")
     private static void runYamlPack(final Farea fea, final String path, final String code,
         final Map<String, Object> pack, final String image, final String slashed,
@@ -258,13 +248,9 @@ final class OptimizeMojoYamlPackTest {
         );
     }
 
-    /**
-     * Assert that opcode counts in a compiled class match the YAML
+    /*
+     * Asserts that opcode counts in a compiled class match the YAML
      * expectations. A zero value asserts the opcode is absent.
-     * @param klass Path to the .class file
-     * @param expected Expected map of opcode to count, or null to skip
-     * @param stage Either "before" or "after" — used in the failure message
-     * @throws IOException If the class file cannot be read
      */
     private static void assertOpcodes(final Path klass,
         final Map<String, Integer> expected, final String stage) throws IOException {
@@ -287,12 +273,9 @@ final class OptimizeMojoYamlPackTest {
         );
     }
 
-    /**
-     * Build a single opcode matcher: presence with an exact count when
-     * the expected value is positive, absence when it is zero.
-     * @param opcode Opcode mnemonic
-     * @param count Expected occurrences (zero asserts absence)
-     * @return A Hamcrest matcher over the opcode tally
+    /*
+     * One opcode matcher: presence with an exact count when the expected
+     * value is positive, absence when it is zero.
      */
     private static org.hamcrest.Matcher<? super Map<String, Integer>> opcodeMatcher(
         final String opcode, final Integer count) {

--- a/src/test/java/org/eolang/hone/PhinoTest.java
+++ b/src/test/java/org/eolang/hone/PhinoTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Test case for {@link Phino}.
+ *
  * @since 0.17.0
  */
 final class PhinoTest {
@@ -60,13 +61,6 @@ final class PhinoTest {
         );
     }
 
-    /**
-     * Create a fake executable script in the given directory.
-     * @param dir The directory to create the script in
-     * @param body The body of the script, after the shebang line
-     * @return The path to the script
-     * @throws Exception If something goes wrong
-     */
     private static Path fake(final Path dir, final String body) throws Exception {
         final Path script = dir.resolve("phino");
         Files.write(

--- a/src/test/java/org/eolang/hone/PullMojoTest.java
+++ b/src/test/java/org/eolang/hone/PullMojoTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for {@link PullMojo}.
+ *
  * @since 0.1.0
  */
 @ExtendWith(MktmpResolver.class)

--- a/src/test/java/org/eolang/hone/RandomImage.java
+++ b/src/test/java/org/eolang/hone/RandomImage.java
@@ -13,6 +13,7 @@ import java.lang.annotation.Target;
  * This annotation is used in unit tests in order to signal
  * to JUnit that a certain method argument must be generated
  * through the {@link RandomImageResolver}.
+ *
  * @since 0.1.0
  */
 @Target(ElementType.PARAMETER)

--- a/src/test/java/org/eolang/hone/RandomImageResolver.java
+++ b/src/test/java/org/eolang/hone/RandomImageResolver.java
@@ -12,9 +12,17 @@ import org.junit.jupiter.api.extension.ParameterResolver;
  * This class is instantiated and then called by JUnit when
  * an argument of a test method is marked with the {@link RandomImage}
  * annotation.
+ *
  * @since 0.1.0
  */
 public final class RandomImageResolver implements ParameterResolver {
+
+    /**
+     * Public ctor, for JUnit to call reflectively.
+     */
+    public RandomImageResolver() {
+        // nothing to initialize
+    }
 
     @Override
     public boolean supportsParameter(final ParameterContext context,

--- a/src/test/java/org/eolang/hone/RandomPipeline.java
+++ b/src/test/java/org/eolang/hone/RandomPipeline.java
@@ -269,22 +269,13 @@ final class RandomPipeline {
     );
 
     /**
-     * The largest number of intermediate operations in one pipeline.
-     */
-    private static final int STAGES = 7;
-
-    /**
-     * One walk in this many goes parallel, when it is allowed to.
-     */
-    private static final int RACES = 5;
-
-    /**
      * The seed of the walk.
      */
     private final long seed;
 
     /**
      * Ctor.
+     *
      * @param sed The seed, which fully determines the class produced
      */
     RandomPipeline(final long sed) {
@@ -293,6 +284,7 @@ final class RandomPipeline {
 
     /**
      * Print the Java source of the class.
+     *
      * @param pkg The package to put the class in
      * @param name The name of the class, also the label of its printed value
      * @return Java source code, ready for {@code javac}
@@ -319,31 +311,22 @@ final class RandomPipeline {
         );
     }
 
-    /**
-     * The walk this seed settles on.
-     * @param grammar The grammar to walk
-     * @return The grammar lines the class is printed from, the frame first
-     */
     private List<String> rolled(final Grammar grammar) {
         return RandomPipeline.walk(
             grammar, new Random(RandomPipeline.scrambled(this.seed * 31L))
         );
     }
 
-    /**
+    /*
      * The seed, mixed.
-     *
-     * <p>{@link Random} scrambles a seed by exclusive-or alone, which moves the
-     * state of two neighbouring seeds by so little that the first few bits they
-     * draw are the same bits — the first {@code nextInt(2)} of seeds 0 to 200
-     * answers the same way almost every time. The walk draws the frame it sits
-     * in first of all, so without a mix of its own three quarters of the seeds
-     * would land in one frame and the axis would be an axis in name only. This
-     * is SplitMix64's finalizer, which spreads one increment across all sixty
-     * four bits.</p>
-     *
-     * @param seed The seed, as the caller counted it
-     * @return A seed whose neighbours are nowhere near it
+     * Random scrambles a seed by exclusive-or alone, which moves the state of
+     * two neighbouring seeds by so little that the first few bits they draw
+     * are the same bits — the first nextInt(2) of seeds 0 to 200 answers the
+     * same way almost every time. The walk draws the frame it sits in first
+     * of all, so without a mix of its own three quarters of the seeds would
+     * land in one frame and the axis would be an axis in name only. This is
+     * SplitMix64's finalizer, which spreads one increment across all sixty
+     * four bits.
      */
     private static long scrambled(final long seed) {
         long mixed = seed + 0x9E37_79B9_7F4A_7C15L;
@@ -352,16 +335,13 @@ final class RandomPipeline {
         return mixed ^ mixed >>> 31;
     }
 
-    /**
+    /*
      * One walk through the grammar, as the lines of it that were picked.
-     *
-     * <p>The first line is not a step but the frame the pipeline sits in, as
-     * {@code frame|holder|guard}. The frame is picked before anything else
-     * because it decides which roles the walk may draw from.</p>
-     *
-     * @param grammar The grammar to walk
-     * @param rnd The source of randomness
-     * @return The grammar lines, a frame first, a source second, a terminal last
+     * The first line is not a step but the frame the pipeline sits in, as
+     * frame|holder|guard. The frame is picked before anything else because it
+     * decides which roles the walk may draw from.
+     * Seven is the largest number of intermediate operations one pipeline
+     * gets, and one walk in five goes parallel, when it is allowed to.
      */
     private static List<String> walk(final Grammar grammar, final Random rnd) {
         final String holder =
@@ -381,7 +361,7 @@ final class RandomPipeline {
         steps.add(
             String.join("|", domain, "source", grammar.pick(domain, "source", rnd))
         );
-        final int total = 1 + rnd.nextInt(RandomPipeline.STAGES);
+        final int total = 1 + rnd.nextInt(7);
         boolean observed = false;
         for (int stage = 0; stage < total; ++stage) {
             final String role = roles.get(rnd.nextInt(roles.size()));
@@ -394,30 +374,23 @@ final class RandomPipeline {
         }
         final String end = grammar.terminal(domain, observed, rnd);
         if (RandomPipeline.raceable(end, observed, domain)
-            && rnd.nextInt(RandomPipeline.RACES) == 0) {
+            && rnd.nextInt(5) == 0) {
             steps.add(String.join("|", domain, "race", "parallel()"));
         }
         steps.add(end);
         return steps;
     }
 
-    /**
+    /*
      * Whether this pipeline may go parallel.
-     *
-     * <p>Two things forbid it. A traversal that is counted, by a {@code peek}
-     * or by a {@code forEach} that accumulates, is counted by several ForkJoin
-     * workers at once into one unsynchronized slot, and what they lose is not
-     * the same on every run. And a terminal that reduces floating point adds in
+     * Two things forbid it. A traversal that is counted, by a peek or by a
+     * forEach that accumulates, is counted by several ForkJoin workers at
+     * once into one unsynchronized slot, and what they lose is not the same
+     * on every run. And a terminal that reduces floating point adds in
      * whatever order the splits happened to combine in. Everything else the
-     * grammar can build is ordered, so a parallel run prints what a sequential
-     * one prints — which is the very contract {@code 222}-{@code 225} keep by
-     * refusing to fuse a {@code skip} or a {@code distinct} into a parallel
-     * pipeline.</p>
-     *
-     * @param end The terminal line the walk picked
-     * @param observed TRUE if something counts the traversal
-     * @param domain The element domain the pipeline ended in
-     * @return TRUE if {@code parallel()} may be appended
+     * grammar can build is ordered, so a parallel run prints what a
+     * sequential one prints — which is the very contract 222-225 keep by
+     * refusing to fuse a skip or a distinct into a parallel pipeline.
      */
     private static boolean raceable(final String end, final boolean observed,
         final String domain) {
@@ -426,12 +399,6 @@ final class RandomPipeline {
             && !RandomPipeline.FLOATS.contains(domain);
     }
 
-    /**
-     * The template of the body of the method that holds the pipeline.
-     * @param guard Either {@code plain} or {@code guarded}
-     * @param role The role of the terminal, either {@code end} or {@code void}
-     * @return A template with one {@code %s} where the pipeline goes
-     */
     private static String shape(final String guard, final String role) {
         final String body;
         if ("void".equals(role)) {
@@ -448,17 +415,12 @@ final class RandomPipeline {
         return shape;
     }
 
-    /**
+    /*
      * The body of the method, with the pipeline in it.
-     *
-     * <p>The pipeline arrives with one step per line and no indentation at all,
-     * and every line but the first is pushed out to where the {@code %s} of the
-     * shape stands, so that the shapes carry their own layout and nothing has
-     * to be told twice how deep a body is nested.</p>
-     *
-     * @param shape The template of the body
-     * @param pipe The pipeline, one step per line
-     * @return The Java statements of the body
+     * The pipeline arrives with one step per line and no indentation at all,
+     * and every line but the first is pushed out to where the %s of the shape
+     * stands, so that the shapes carry their own layout and nothing has to be
+     * told twice how deep a body is nested.
      */
     private static String body(final String shape, final String pipe) {
         final int mark = shape.indexOf("%s");
@@ -473,22 +435,12 @@ final class RandomPipeline {
         );
     }
 
-    /**
-     * The same block, one level deeper.
-     * @param block The Java statements
-     * @return The very same statements, indented by four more spaces
-     */
     private static String deeper(final String block) {
         return "    ".concat(
             block.replace(RandomPipeline.EOL, RandomPipeline.EOL.concat("    "))
         );
     }
 
-    /**
-     * The modifiers of the method that holds the pipeline.
-     * @param holder Either {@code static} or {@code instance}
-     * @return What stands in front of the return type
-     */
     private static String modifier(final String holder) {
         final String modifier;
         if ("instance".equals(holder)) {
@@ -499,12 +451,6 @@ final class RandomPipeline {
         return modifier;
     }
 
-    /**
-     * The expression {@code main} reaches the pipeline by.
-     * @param holder Either {@code static} or {@code instance}
-     * @param name The name of the class
-     * @return The Java expression that runs the pipeline once
-     */
     private static String call(final String holder, final String name) {
         final String call;
         if ("instance".equals(holder)) {

--- a/src/test/java/org/eolang/hone/RandomPipelineOptimizationTest.java
+++ b/src/test/java/org/eolang/hone/RandomPipelineOptimizationTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 /**
  * Test case for {@link OptimizeMojo}, fuzzing it with randomly generated
  * stream pipelines from {@link RandomPipeline}.
+ *
  * @since 0.1.0
  */
 @Execution(ExecutionMode.SAME_THREAD)
@@ -265,14 +266,6 @@ final class RandomPipelineOptimizationTest {
         );
     }
 
-    /**
-     * Body of {@link #preservesWhatRandomPipelinesPrint}.
-     * @param fea Fake Maven project
-     * @param home The root of the fake Maven project
-     * @param pipelines How many random pipelines to generate
-     * @param image Docker image tag
-     * @throws IOException If the build fails to run
-     */
     private static void runRandomPipelines(final Farea fea, final Path home,
         final int pipelines, final String image) throws IOException {
         fea.clean();
@@ -345,14 +338,6 @@ final class RandomPipelineOptimizationTest {
         );
     }
 
-    /**
-     * What the two runs of one pipeline disagree about.
-     * @param before The run of the class as the Java compiler left it
-     * @param after The run of the same class after optimization
-     * @param java The source of the class, printed when there is a complaint
-     * @param name The name of the class
-     * @return The complaint, or an empty string when the two runs agree
-     */
     private static String differs(final Result before, final Result after,
         final String java, final String name) {
         final String complaint;
@@ -377,14 +362,6 @@ final class RandomPipelineOptimizationTest {
         return complaint;
     }
 
-    /**
-     * Run one class of the fake project, in the JVM that runs this test.
-     * @param home The root of the fake Maven project
-     * @param dir The directory with compiled classes, relative to the root
-     * @param name The name of the class in the {@code random} package
-     * @return What the JVM printed and the code it exited with
-     * @throws IOException If the JVM cannot be started
-     */
     private static Result runs(final Path home, final String dir, final String name)
         throws IOException {
         return new Jaxec(

--- a/src/test/java/org/eolang/hone/RmiMojoTest.java
+++ b/src/test/java/org/eolang/hone/RmiMojoTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for {@link RmiMojo}.
+ *
  * @since 0.1.0
  */
 @ExtendWith(MktmpResolver.class)

--- a/src/test/java/org/eolang/hone/RulesTest.java
+++ b/src/test/java/org/eolang/hone/RulesTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for {@link Rules}.
+ *
  * @since 0.1.0
  */
 @ExtendWith(MktmpResolver.class)

--- a/src/test/java/org/eolang/hone/SummaryTest.java
+++ b/src/test/java/org/eolang/hone/SummaryTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for {@link Rules}.
+ *
  * @since 0.1.0
  */
 @ExtendWith(MktmpResolver.class)

--- a/src/test/java/org/eolang/hone/TimingsTest.java
+++ b/src/test/java/org/eolang/hone/TimingsTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Timings}.
+ *
  * @since 0.1.0
  */
 final class TimingsTest {

--- a/src/test/java/org/eolang/hone/package-info.java
+++ b/src/test/java/org/eolang/hone/package-info.java
@@ -4,6 +4,7 @@
  */
 /**
  * Test cases.
+ *
  * @since 0.1.0
  */
 package org.eolang.hone;


### PR DESCRIPTION
Bumps `qulice-maven-plugin` from `0.30.13` to `0.35.2`.

The new version brings several checks this codebase did not satisfy — 194 violations in total. All of them are fixed here, and no suppression or exclusion was added to the `qulice` profile.

| Check | Count | What was done |
| --- | --- | --- |
| `JavadocEmptyLineBeforeTagCheck` | 140 | Inserted the missing empty Javadoc line between a description and the block of at-clauses below it. |
| `NoJavadocForPrivateMethodsCheck` | 47 | Removed Javadoc from private methods. |
| `ImplicitConstructorCheck` | 3 | Declared the constructor explicitly in the three JUnit extension classes. |
| `SingleUseConstantCheck` | 2 | Inlined `STAGES` and `RACES` in `RandomPipeline`. |
| `ProhibitStaticNestedClassesCheck` | 1 | Moved `Summary.Collector` into its own file. |
| `FullyQualifiedTypeCheck` | 1 | Imported `Locale` in `AbstractMojo`. |

A few of these deserve more than a line.

**Javadoc on private methods.** Most of the 47 blocks only restated the signature in prose (`@param dir The directory`, `@return TRUE if ...`), and those are simply gone — which is what the check exists for. Nine of them carried an explanation that the method's name and body do not give away: why `scrambled()` mixes the seed by SplitMix64's finalizer rather than leaving it to `Random`, why `raceable()` refuses `parallel()` to a counted traversal or a floating-point reduction, why `grepInMatches()` validates the pattern through `grep -E` rather than `java.util.regex.Pattern` (#671). Those explanations stay, as a plain block comment above the method with the at-clauses dropped, so nothing that was worth reading was deleted.

**Single-use constants.** `STAGES` and `RACES` are inlined into their only usage in `RandomPipeline.walk()`. What their Javadoc documented — seven is the largest number of intermediate operations one pipeline gets, one walk in five goes parallel — moves into the comment above `walk()`, because `MethodBodyCommentsCheck` prohibits a comment inside a method body and that is where the two literals now sit.

**`Summary.Collector`.** It becomes `Collector`, package-private, in `src/main/java/org/eolang/hone/Collector.java`. The private `Summary.same()` helper went with it, since `Collector.visitFile()` was its only caller, and `Summary` shed the five imports that only the nested class needed.

## Verification

Locally:

- `mvn clean install -DskipTests -Dinvoker.skip -Pqulice` — `BUILD SUCCESS`, zero violations (was 194 before the fixes, on the same 0.35.2).
- `mvn test` — 72 tests, 0 failures.
- `mvn -Pdeep test` — 92 tests, 0 failures, 21 skipped. The skips are the end-to-end optimize fixtures and the single-rule packs, which need Docker and a local `phino`; neither was available where this ran.
- `mvn javadoc:javadoc` — no warnings, which is what `ImplicitConstructorCheck` is guarding against in the first place.

On this PR, all 19 checks pass, `qulice` and both `mvn` matrix legs among them.

Worth flagging about the 21 local skips: `-Pdeep` is used only by `deep.yml` and `codecov.yml`, and both of those trigger on push to `master` alone, so the `@Tag("deep")` fixtures do not run on this pull request either — they will run once it is merged. What does exercise the pipeline end-to-end here is `smoke` (the plugin against `apache/commons-cli` with a real `phino`) and `make` (the `streams` rule tests), and both are green. Since no `.phr` rule, shell script, or pinned tool version was touched, the risk to the deep fixtures is a Java-side one, and the only behavioural change on that side is `Summary.Collector` moving out into `Collector`, which `SummaryTest` covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxobLW5wZwyeMCWc71FGSm
