### PR TITLE
#891: unquote the glob that clears the small-step files

### DIFF
--- a/src/main/resources/org/eolang/hone/scaffolding/rewrite.sh
+++ b/src/main/resources/org/eolang/hone/scaffolding/rewrite.sh
@@ -132,7 +132,7 @@ function rewrite {
   fi
   atomic_write "${phi}" phino rewrite "${phinopts[@]}" --input=xmir --sweet "${xi}"
   verbose "Converted ${idx} XMIR ($(du -sh "${xi}" | cut -f1)) to $(basename "${phi}") ($(du -sh "${phi}" | cut -f1))"
-  rm -f "${pho}.*"
+  rm -f "${pho}".*
   pos=0
   start=$(now)
   if [ "${HONE_SMALL_STEPS}" == "true" ]; then


### PR DESCRIPTION
`rm -f "${pho}.*"` keeps the glob inside the quotes, so the shell looks for a
file literally named `out.phi.*` and removes nothing. The `.01`, `.02`, ...
files of a previous `smallSteps` run stayed on disk next to the new ones.

The glob is now outside the quotes, so the path is still quoted and the
intermediates are actually removed.

Closes #891
