### PR TITLE
#897: quit before listing the target directory

### DIFF
--- a/src/main/resources/org/eolang/hone/scaffolding/entry.sh
+++ b/src/main/resources/org/eolang/hone/scaffolding/entry.sh
@@ -82,15 +82,19 @@ fi
 if [ ! -e "${TARGET}/${CLASSES}" ]; then
   echo "There is no '${TARGET}/${CLASSES}' directory, which most probably means \
 that the project has not been compiled yet; make sure you use 'hone-maven-plugin' \
-after the 'compile' phase is finished; this is what is in the '${TARGET}' directory:"
-  tree "${TARGET}"
+after the 'compile' phase is finished"
   if [ "${SKIP_IF_NO_CLASSES}" == 'true' ]; then
     echo "We don't fail but quit quietly, because of skipIfNoClasses=true"
     exit
-  else
-    echo "We can't continue and must fail here. Set skipIfNoClasses to 'true' if you need a quiet pass."
-    exit 1
   fi
+  echo "This is what is in the '${TARGET}' directory:"
+  if command -v tree > /dev/null; then
+    tree "${TARGET}"
+  else
+    ls -R "${TARGET}"
+  fi
+  echo "We can't continue and must fail here. Set skipIfNoClasses to 'true' if you need a quiet pass."
+  exit 1
 fi
 
 # In order to save them "as is", just in case. The previous copy goes first,


### PR DESCRIPTION
The script listed the target directory with `tree` before it looked at
`skipIfNoClasses`, so a host without `tree` failed under `set -e` on the path
that was meant to quit quietly. The non-Docker run uses the host's utilities,
where `tree` is not guaranteed.

The quiet exit now comes first, and the listing falls back to `ls -R` when
`tree` is not installed.

Closes #897
