### PR TITLE
#898: ask the daemon whether Docker is available

### DIFF
--- a/src/main/java/org/eolang/hone/Docker.java
+++ b/src/main/java/org/eolang/hone/Docker.java
@@ -66,14 +66,19 @@ final class Docker {
     }
 
     /**
-     * Docker executable is available?
+     * Docker is available?
+     *
+     * <p>The daemon is asked, not the client: {@code docker --version} prints
+     * the version of the binary and exits with zero without ever reaching the
+     * socket, so a machine with a stopped daemon answered that Docker was
+     * usable and the build failed later inside {@code docker run}.</p>
      *
      * @return TRUE if Docker is here
      */
     boolean available() {
         boolean yes = true;
         try {
-            this.exec("--version");
+            this.exec("info", "--format", "{{.ServerVersion}}");
         } catch (final IOException | IllegalStateException ex) {
             Logger.warn(this, "Docker is not available: %s", ex.getMessage());
             yes = false;


### PR DESCRIPTION
`available()` ran `docker --version`, which prints the version of the client
binary and exits with zero without contacting the daemon. On a machine with
Docker installed but the daemon down, `helpless()` concluded there was
something to run with, `skipWithoutDocker` did not skip, the local `phino` was
never considered, and the build failed later inside `docker run`.

It now runs `docker info`, which fails when the daemon is not there.

Draft: it touches `Docker.java`, which #914 also changes.

Closes #898
