### PR TITLE
#901: leave no reading thread behind when the probe times out

### DIFF
--- a/src/main/java/org/eolang/hone/Phino.java
+++ b/src/main/java/org/eolang/hone/Phino.java
@@ -62,6 +62,8 @@ final class Phino {
                 available = Phino.version(proc, stdout, expected, this);
             } else {
                 proc.destroyForcibly();
+                pump.interrupt();
+                pump.join(TimeUnit.SECONDS.toMillis(1L));
                 Logger.info(
                     this,
                     "The 'phino --version' probe timed out, we must use Docker"


### PR DESCRIPTION
On the timeout branch the process was killed and the thread reading its output
was left running. `available()` is called by `helpless()` and again by each
goal, so a multi-module build with a hanging phino accumulated one stuck thread
per goal per module for the life of the Maven JVM.

The reader is now interrupted and joined there as well.

Draft: it touches `Phino.java`, which #916 also changes.

Closes #901
