### PR TITLE
#892: compare the chain with the XMIR it is made from

### DIFF
--- a/src/main/resources/org/eolang/hone/scaffolding/rewrite.sh
+++ b/src/main/resources/org/eolang/hone/scaffolding/rewrite.sh
@@ -112,8 +112,8 @@ function rewrite {
   mkdir -p "$(dirname "${phi}")"
   mkdir -p "$(dirname "${pho}")"
   mkdir -p "$(dirname "${xo}")"
-  if [ -f "${pho}" ] && [ "${pho}" -nt "${phi}" ] && [ -f "${xo}" ] && [ "${xo}" -nt "${pho}" ]; then
-    echo "Target $(basename "${pho}") is newer than source $(basename "${phi}") and output $(basename "${xo}") is present; skipping transformation for ${idx}"
+  if [ -f "${phi}" ] && [ "${phi}" -nt "${xi}" ] && [ -f "${pho}" ] && [ "${pho}" -nt "${phi}" ] && [ -f "${xo}" ] && [ "${xo}" -nt "${pho}" ]; then
+    echo "Output $(basename "${xo}") is newer than input $(basename "${xi}") all the way through the chain; skipping transformation for ${idx}"
     return
   fi
   verbose "Next ${idx} XMIR is ${xi} ($(du -sh "${xi}" | cut -f1))"


### PR DESCRIPTION
The skip check compared the intermediates with each other and never with the
XMIR the whole chain is derived from, so on the second build of a project where
one class changed the leftovers of the first build were still consistent with
each other, the file was skipped, and `jeo:assemble` read the optimization of
the previous version of that class. Nothing said so.

The input is now the first link of the comparison.

Draft: it touches `rewrite.sh`, which #912 also changes.

Closes #892
