### PR TITLE
#893: let the exit code of the worker decide

### DIFF
--- a/src/main/resources/org/eolang/hone/scaffolding/rewrite.sh
+++ b/src/main/resources/org/eolang/hone/scaffolding/rewrite.sh
@@ -238,18 +238,22 @@ function rewrite_with_timeout {
     kill "${watchdog}" 2>/dev/null || true
   fi
   wait "${watchdog}" 2>/dev/null || true
-  if [ -f "${flag}" ]; then
+  # The worker finishing and the deadline passing are independent events, so
+  # both can be true for a file that finished just as the watchdog fired. The
+  # exit code decides: a worker that exited normally wrote its output, and
+  # copying the input over it would ship the class unoptimized (#893).
+  if [ "${code}" -eq 0 ]; then
+    rm -f "${flag}"
+  elif [ -f "${flag}" ]; then
     rm -f "${flag}"
     sec=$(perl -E "say int($(now) - ${start})")
     echo "Timeout in ${idx} $(basename "${xi}") ($(du -sh "${xi}" | cut -f1)) after ${sec} seconds"
     cp "${xi}" "${xo}"
-  elif [ "${code}" -ne 0 ]; then
+  else
     rm -f "${flag}"
     sec=$(perl -E "say int($(now) - ${start})")
     echo "Failure (exit code ${code}) in ${idx} $(basename "${xi}") ($(du -sh "${xi}" | cut -f1)) after ${sec} seconds; refusing to copy it through unoptimized" >&2
     exit "${code}"
-  else
-    rm -f "${flag}"
   fi
 }
 


### PR DESCRIPTION
The flag file the watchdog creates was read before the exit code, so a file
that finished just as the deadline passed took the timeout branch and had its
optimized XMIR overwritten with the unoptimized input. The build stayed green
and the log said the file timed out.

The exit code decides now: a worker that exited normally keeps its output, and
the copy runs only when it was actually killed.

Draft: it touches `rewrite.sh`, which #912 and #918 also change.

Closes #893
