### PR TITLE
#902: warn instead of failing when the image is not removed

### DIFF
--- a/src/main/java/org/eolang/hone/RmiMojo.java
+++ b/src/main/java/org/eolang/hone/RmiMojo.java
@@ -37,12 +37,20 @@ public final class RmiMojo extends AbstractMojo {
                 this.image
             );
         } else {
-            new Docker(this.sudo).exec(
-                "rmi",
-                "--no-prune",
-                this.image
-            );
-            Logger.info(this, "Docker image '%s' was removed", this.image);
+            try {
+                new Docker(this.sudo).exec(
+                    "rmi",
+                    "--no-prune",
+                    this.image
+                );
+                Logger.info(this, "Docker image '%s' was removed", this.image);
+            } catch (final IOException ex) {
+                Logger.warn(
+                    this,
+                    "Docker image '%s' was not removed, the build is not affected by it: %s",
+                    this.image, ex.getMessage()
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
`docker rmi` exits non-zero for reasons that have nothing to do with the build:
the image is held by a container, another build removed it first, or it was
never pulled. `Docker.exec` turned that into a `MojoExecutionException`, so a
build whose bytecode was already optimized failed at the last step, on a goal
whose only purpose is to free disk space.

The failure is a warning now.

Closes #902
