### PR TITLE
#904: start the timings file fresh, with a header

### DIFF
--- a/src/main/java/org/eolang/hone/Timings.java
+++ b/src/main/java/org/eolang/hone/Timings.java
@@ -66,16 +66,10 @@ final class Timings {
         }
     }
 
-    /**
-     * Start the file when it does not belong to this build yet.
-     *
-     * <p>The rows of a build that ran before this JVM are of no use here and
-     * "target" survives between runs unless "clean" is used, so a file older
-     * than the JVM is replaced by a fresh one with a header. The goals of this
-     * build write after that moment and append to each other.</p>
-     *
-     * @throws IOException If the file cannot be written
-     */
+    // The rows of a build that ran before this JVM are of no use here and
+    // "target" survives between runs unless "clean" is used, so a file older
+    // than the JVM is replaced by a fresh one with a header. The goals of this
+    // build write after that moment and append to each other.
     private void started() throws IOException {
         final boolean stale;
         if (Files.exists(this.path)) {

--- a/src/main/java/org/eolang/hone/Timings.java
+++ b/src/main/java/org/eolang/hone/Timings.java
@@ -7,6 +7,7 @@ package org.eolang.hone;
 import com.jcabi.log.Logger;
 import java.io.File;
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -54,12 +55,40 @@ final class Timings {
             if (dir.mkdirs()) {
                 Logger.debug(this, "Directory created: %[file]s", dir);
             }
+            this.started();
             Files.write(
                 this.path,
                 String.format(
-                    "%s,%d%n", name, System.currentTimeMillis() - start
+                    "\"%s\";%d%n", name, System.currentTimeMillis() - start
                 ).getBytes(StandardCharsets.UTF_8),
                 StandardOpenOption.APPEND, StandardOpenOption.CREATE
+            );
+        }
+    }
+
+    /**
+     * Start the file when it does not belong to this build yet.
+     *
+     * <p>The rows of a build that ran before this JVM are of no use here and
+     * "target" survives between runs unless "clean" is used, so a file older
+     * than the JVM is replaced by a fresh one with a header. The goals of this
+     * build write after that moment and append to each other.</p>
+     *
+     * @throws IOException If the file cannot be written
+     */
+    private void started() throws IOException {
+        final boolean stale;
+        if (Files.exists(this.path)) {
+            stale = Files.getLastModifiedTime(this.path).toMillis()
+                < ManagementFactory.getRuntimeMXBean().getStartTime();
+        } else {
+            stale = true;
+        }
+        if (stale) {
+            Files.write(
+                this.path,
+                String.format("\"Mojo\";\"Time\"%n").getBytes(StandardCharsets.UTF_8),
+                StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING
             );
         }
     }

--- a/src/test/java/org/eolang/hone/TimingsTest.java
+++ b/src/test/java/org/eolang/hone/TimingsTest.java
@@ -23,7 +23,10 @@ final class TimingsTest {
     void dropsTheRowsOfAPreviousBuild() throws Exception {
         try (Mktemp temp = new Mktemp()) {
             final Path file = temp.path().resolve("bar.csv");
-            Files.write(file, "\"old\";1\n".getBytes(StandardCharsets.UTF_8));
+            Files.write(
+                file,
+                String.format("\"old\";1%n").getBytes(StandardCharsets.UTF_8)
+            );
             Files.setLastModifiedTime(file, FileTime.fromMillis(0L));
             new Timings(file).through("foo", () -> { });
             MatcherAssert.assertThat(

--- a/src/test/java/org/eolang/hone/TimingsTest.java
+++ b/src/test/java/org/eolang/hone/TimingsTest.java
@@ -7,6 +7,7 @@ package org.eolang.hone;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -17,6 +18,21 @@ import org.junit.jupiter.api.Test;
  * @since 0.1.0
  */
 final class TimingsTest {
+
+    @Test
+    void dropsTheRowsOfAPreviousBuild() throws Exception {
+        try (Mktemp temp = new Mktemp()) {
+            final Path file = temp.path().resolve("bar.csv");
+            Files.write(file, "\"old\";1\n".getBytes(StandardCharsets.UTF_8));
+            Files.setLastModifiedTime(file, FileTime.fromMillis(0L));
+            new Timings(file).through("foo", () -> { });
+            MatcherAssert.assertThat(
+                "the rows of a build that ran before this one must go, but they stayed",
+                new String(Files.readAllBytes(file), StandardCharsets.UTF_8),
+                Matchers.not(Matchers.containsString("old"))
+            );
+        }
+    }
 
     @Test
     @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
@@ -35,8 +51,9 @@ final class TimingsTest {
                 "file must have two lines",
                 new String(Files.readAllBytes(file), StandardCharsets.UTF_8),
                 Matchers.allOf(
-                    Matchers.containsString("foo,"),
-                    Matchers.containsString(String.format("%nbar,"))
+                    Matchers.containsString("\"Mojo\";\"Time\""),
+                    Matchers.containsString("\"foo\";"),
+                    Matchers.containsString(String.format("%n\"bar\";"))
                 )
             );
         }


### PR DESCRIPTION
`hone-timings.csv` was appended to and never started, so it had no header and a
second `mvn hone:optimize` without `clean` mixed its rows with the previous
run's. The other timings file in the same directory has a header and uses
quotes and semicolons.

The file is now replaced with a header when it is older than the JVM, which is
once per build, and the rows take the same quoting and separator as the sibling
file. The goals of one build still append to each other.

Closes #904
