### PR TITLE
#906: say which file the summary could not read

### DIFF
--- a/src/main/java/org/eolang/hone/Collector.java
+++ b/src/main/java/org/eolang/hone/Collector.java
@@ -69,6 +69,12 @@ final class Collector extends SimpleFileVisitor<Path> {
                 "Symlink cycle detected at %s, skipping",
                 file
             );
+        } else {
+            Logger.warn(
+                this,
+                "Can't read %s, its statistics are missing from the summary: %s",
+                file, exc.getMessage()
+            );
         }
         return FileVisitResult.CONTINUE;
     }


### PR DESCRIPTION
The walk logged a symlink cycle and dropped every other failure, so a module
whose statistics file could not be read was simply missing from the summary and
`Optimized X/Y files` was counted over whatever happened to be readable.

Any other failure is now logged with the path and the reason.

Closes #906
