### PR TITLE
#896: Discover phr extra rules

### DIFF
--- a/src/main/resources/org/eolang/hone/scaffolding/entry.sh
+++ b/src/main/resources/org/eolang/hone/scaffolding/entry.sh
@@ -152,7 +152,7 @@ for rule in ${RULES}; do
   fi
 done
 if [ -n "${EXTRA}" ]; then
-  e=$(find "${EXTRA}" -name '*.yml' -exec "${RP}" {} \; | sort | tr '\n' ' ')
+  e=$(find "${EXTRA}" \( -name '*.yml' -o -name '*.phr' \) -exec "${RP}" {} \; | sort | tr '\n' ' ')
   if [ -n "${e}" ]; then
     echo "Extra rules found in ${EXTRA}: ${e}"
     RULES="${RULES} ${e}"


### PR DESCRIPTION
Closes #896.

The main fallback rule scan already accepts both `.yml` and `.phr` on current `master` (via #882), but the `EXTRA` scan still filters only `*.yml`. This makes directly-mounted extra `.phr` rules invisible to the standalone scaffolding path.

This change makes the `EXTRA` scan use the same extension set as the main rule discovery: `.yml` or `.phr`.

Validation:
- `bash -n src/main/resources/org/eolang/hone/scaffolding/entry.sh`
- exercised the exact `find` expression against a directory containing one `.yml`, one nested `.phr`, and one unrelated `.txt`; only the two rule files were selected.

No other rule ordering or formatting behavior is changed.
