### PR TITLE
#905: Report temporary cleanup failures

### DIFF
--- a/src/main/java/org/eolang/hone/Mktemp.java
+++ b/src/main/java/org/eolang/hone/Mktemp.java
@@ -5,11 +5,12 @@
 package org.eolang.hone;
 
 import java.io.Closeable;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -40,11 +41,13 @@ final class Mktemp implements Closeable {
 
     @Override
     public void close() throws IOException {
+        final List<Path> files;
         try (Stream<Path> stream = Files.walk(this.dir)) {
-            stream
-                .map(Path::toFile)
-                .sorted(Comparator.reverseOrder())
-                .forEach(File::delete);
+            files = stream.sorted(Comparator.reverseOrder())
+                .collect(Collectors.toList());
+        }
+        for (final Path file : files) {
+            Files.delete(file);
         }
     }
 


### PR DESCRIPTION
Closes #905.

`Mktemp.close()` used `File.delete()` inside a stream and discarded its boolean result, so cleanup failures were silently treated as success.

This change materializes the reverse-ordered walk, closes the walk stream, and then deletes every path with `Files.delete()`. A failed deletion now propagates its `IOException` (including the failing path) through the existing `Closeable.close()` contract instead of disappearing. Closing the walk before deletion also avoids keeping traversal handles open while directories are removed.

Validation on the Java 8 production target:
- `javac --release 8` compiles `Mktemp.java`.
- A same-package probe created `a/b/file.txt` under `Mktemp`, called `close()`, and verified the root directory no longer exists.

The change is limited to cleanup semantics; temporary-directory creation and callers are unchanged.
