### PR TITLE
#903: Record rmi goal timing

### DIFF
--- a/src/main/java/org/eolang/hone/RmiMojo.java
+++ b/src/main/java/org/eolang/hone/RmiMojo.java
@@ -30,19 +30,24 @@ public final class RmiMojo extends AbstractMojo {
 
     @Override
     public void exec() throws IOException {
-        if (!this.alwaysWithDocker && new Phino().available(this.phino())) {
-            Logger.info(
-                this,
-                "Docker image '%s' was probably NOT built, that's why not removed either",
-                this.image
-            );
-        } else {
-            new Docker(this.sudo).exec(
-                "rmi",
-                "--no-prune",
-                this.image
-            );
-            Logger.info(this, "Docker image '%s' was removed", this.image);
-        }
+        this.timings.through(
+            "rmi",
+            () -> {
+                if (!this.alwaysWithDocker && new Phino().available(this.phino())) {
+                    Logger.info(
+                        this,
+                        "Docker image '%s' was probably NOT built, that's why not removed either",
+                        this.image
+                    );
+                } else {
+                    new Docker(this.sudo).exec(
+                        "rmi",
+                        "--no-prune",
+                        this.image
+                    );
+                    Logger.info(this, "Docker image '%s' was removed", this.image);
+                }
+            }
+        );
     }
 }

--- a/src/test/java/org/eolang/hone/RmiMojoTest.java
+++ b/src/test/java/org/eolang/hone/RmiMojoTest.java
@@ -9,8 +9,11 @@ import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
 import com.yegor256.farea.Farea;
 import com.yegor256.farea.RequisiteMatcher;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.regex.Pattern;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,6 +47,13 @@ final class RmiMojoTest {
                     "the build must be successful",
                     f.log(),
                     RequisiteMatcher.SUCCESS
+                );
+                MatcherAssert.assertThat(
+                    "the rmi goal must be present in hone-timings.csv",
+                    Files.readString(dir.resolve("target/hone-timings.csv")),
+                    Matchers.matchesPattern(
+                        Pattern.compile("(?s).*^rmi,[0-9]+$.*", Pattern.MULTILINE)
+                    )
                 );
             }
         );

--- a/src/test/java/org/eolang/hone/RmiMojoTest.java
+++ b/src/test/java/org/eolang/hone/RmiMojoTest.java
@@ -48,14 +48,14 @@ final class RmiMojoTest {
                     f.log(),
                     RequisiteMatcher.SUCCESS
                 );
-                MatcherAssert.assertThat(
-                    "the rmi goal must be present in hone-timings.csv",
-                    Files.readString(dir.resolve("target/hone-timings.csv")),
-                    Matchers.matchesPattern(
-                        Pattern.compile("(?s).*^rmi,[0-9]+$.*", Pattern.MULTILINE)
-                    )
-                );
             }
+        );
+        MatcherAssert.assertThat(
+            "the rmi goal must be present in hone-timings.csv",
+            Files.readString(dir.resolve("target/hone-timings.csv")),
+            Matchers.matchesPattern(
+                Pattern.compile("(?s).*^rmi,[0-9]+$.*", Pattern.MULTILINE)
+            )
         );
     }
 }


### PR DESCRIPTION
Closes #903.

`rmi` was the only regular Hone goal that bypassed `Timings.through`, so a normal `pull/build/optimize/rmi` run could not account for image-removal time in `hone-timings.csv`.

This wraps the full `RmiMojo.exec()` operation in `timings.through("rmi", ...)`, matching the existing pattern in `PullMojo`, `BuildMojo`, and `OptimizeMojo`. Both the Docker-removal branch and the branch that decides no image was built are therefore represented as execution time of the `rmi` goal.

The existing Docker integration test now also verifies that the generated timings file contains an `rmi,<milliseconds>` row.

Local Maven execution is unavailable in this Android/Termux environment; `git diff --check` passes and repository CI provides Maven/Docker validation.
