### PR TITLE
#906: Warn about failed summary visits

### DIFF
--- a/src/main/java/org/eolang/hone/Collector.java
+++ b/src/main/java/org/eolang/hone/Collector.java
@@ -69,6 +69,13 @@ final class Collector extends SimpleFileVisitor<Path> {
                 "Symlink cycle detected at %s, skipping",
                 file
             );
+        } else {
+            Logger.warn(
+                this,
+                "Failed to visit %s, skipping: %s",
+                file,
+                exc.getMessage()
+            );
         }
         return FileVisitResult.CONTINUE;
     }


### PR DESCRIPTION
Closes #906.

`Collector.visitFileFailed()` now reports every filesystem walk failure instead of silently continuing for everything except symlink cycles.

Symlink loops keep their existing dedicated warning. Other `IOException`s now log both the path that could not be visited and the exception message, while still returning `CONTINUE`, so the aggregator remains best-effort but no longer presents a partial summary as if it were complete.

`git diff --check` is clean. Maven is not installed in this Termux environment, so repository CI will run the Java quality/test matrix.
